### PR TITLE
Centos7 Dockerfiles for building initial DataFed container

### DIFF
--- a/dockerfiles/Dockerfile.datafed-centos7
+++ b/dockerfiles/Dockerfile.datafed-centos7
@@ -1,9 +1,17 @@
-FROM datafed/datafed-kickstart:centos7
+FROM datafed/kickstart:centos7
 
 ARG DATAFED_WORKDIR="/apps/datafed"
 
 RUN mkdir -p ${DATAFED_WORKDIR}
 ADD . ${DATAFED_WORKDIR}
 WORKDIR ${DATAFED_WORKDIR}
+
+# Setup the GNU comipler to devtoolset-7 and compile project
+RUN echo "source scl_source enable devtoolset-7" >> /etc/bashrc \
+    && source /etc/bashrc \
+    && mkdir build \
+    && cd build \
+    && cmake3 -GNinja ../ \
+    && ninja-build
 
 

--- a/dockerfiles/Dockerfile.kickstart-centos7
+++ b/dockerfiles/Dockerfile.kickstart-centos7
@@ -1,13 +1,6 @@
 FROM centos:centos7
 
-# CMake - Build-time only variables
-ARG CMAKE_MAJOR_MINOR_VERSION="3.16"
-ARG CMAKE_PATCH_LEVEL="3"
-ARG CMAKE_VERSION="${CMAKE_MAJOR_MINOR_VERSION}.${CMAKE_PATCH_LEVEL}"
-ARG CMAKE_DIR="cmake-${CMAKE_VERSION}"
-ARG CMAKE_ARCHIVE="${CMAKE_DIR}.tar.gz"
-ARG CMAKE_DOWNLOAD_LINK="https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_ARCHIVE}"
-
+# Protobuf - Build-time only variables
 ARG PBUF_MAJOR_MINOR_VERSION="3.11"
 ARG PBUF_PATCH_LEVEL="2"
 ARG PBUF_VERSION="${PBUF_MAJOR_MINOR_VERSION}.${PBUF_PATCH_LEVEL}"
@@ -25,26 +18,19 @@ ENV PBUF_LIB_DIR="/usr/local/lib"
 # Change to working directory for installing "extra" software
 WORKDIR /opt
 
-# Install OS dependencies (to just get CMake installed)
-#  - CMake and Protobuf install layers take forever,
+# Install OS dependencies and make devtoolset-7 the set GNU compilers
+#  - Protobuf install layer take forever,
 #    so moving install of other dependencies to a post-layer, 
 #    since they can change (for initial development)
 #
 #  - TODO: If supporting multiple versions of python, switch to pyenv
 #          This would be very helpful for running tox to test the Python CLI
 RUN yum update -y \
-    && yum install epel-release -y \
     && yum group install "Development Tools" -y \
-    && yum install wget openssl-devel python36 -y
-
-# Install CMake from source
-#  - needed to get v3.x.x)
-RUN wget ${CMAKE_DOWNLOAD_LINK} \
-    && tar xvzf ${CMAKE_ARCHIVE} \
-    && cd ${CMAKE_DIR} \
-    && ./bootstrap --prefix=/usr/local \
-    && make \
-    && make install
+    && yum install -y epel-release centos-release-scl -y \
+    && yum install wget devtoolset-7 openssl-devel python36 cmake3 -y \
+    && echo "source scl_source enable devtoolset-7" >> /etc/bashrc \
+    && source /etc/bashrc
 
 # Install Protobuf (compiler and python package)
 #  - needed to get v3.x.x)
@@ -68,12 +54,13 @@ RUN mkdir globus-connect-server \
     && curl -LOs https://downloads.globus.org/toolkit/globus-connect-server/globus-connect-server-repo-latest.noarch.rpm \
     && rpm --import https://downloads.globus.org/toolkit/gt6/stable/repo/rpm/RPM-GPG-KEY-Globus \
     && yum install globus-connect-server-repo-latest.noarch.rpm yum-plugin-priorities -y \
-    && yum install globus-connect-server -y \
+    && yum install globus-connect-server globus-common-devel -y \
     && cd ..
 
 # Install extra dependencies:
 RUN yum install -y \
         boost-devel \
+        fuse-devel \
         libcurl-devel \
         ninja-build \
         rapidjson-devel \

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -25,7 +25,7 @@ So, a way to build the SDE for different OS.
 
 | OS       | Dockerfile                               | Tag                               |
 |----------|------------------------------------------|-----------------------------------|
-| Centos 7 | dockerfiles/Dockerfile.kickstart-centos7 | datafed/datafed-kickstart:centos7 |
+| Centos 7 | dockerfiles/Dockerfile.kickstart-centos7 | datafed/kickstart:centos7         |
 
 ## Application Containers
 These are to build DataFed using one of the respective kickstarts with paired OS.
@@ -34,3 +34,16 @@ These are to build DataFed using one of the respective kickstarts with paired OS
 |----------|------------------------------------------|-----------------------------------|
 | Centos 7 | dockerfiles/Dockerfile.datafed-centos7   | datafed/datafed:centos7           |
 
+
+## Example for entire build for Centos7
+
+Run following to:
+  - Build Kickstart image from Centos7 image
+  - Build DataFed image from Kickstart image
+  - Drop into interactive session with built DataFed container
+
+```
+docker build -f dockerfiles/Dockerfile.kickstart-centos7 -t datafed/kickstart:centos7 . \
+&& docker build -f dockerfiles/Dockerfile.datafed-centos7 -t datafed/datafed:centos7 . \
+&& docker run -it datafed/datafed:centos7
+```


### PR DESCRIPTION
Fixes #270  (for now, will open new tickets for future work)

**Work included**:
 - New `dockerfiles` directory for all current and future Dockerfiles.
 - A Centos7 "kickstart" Dockerfile (ie ` dockerfiles/Dockerfile.kickstart-centos7`) for building a "development-ready" image
 - A partner DataFed Dockerfile (ie  `dockerfiles/Dockerfile.datafed-centos7`) that uses the Centos7 kickstart to copy over the DataFed source and build it. The finished build is in `/apps/datafed/build`.
 - `dockerfiles/README.md` to explain how to use the Dockerfiles.

**To test**:
Run the command below (pulled from the README).
*NOTE*: runs for ~15-30 minutes first time through.
 - kickstart: 15-30 minutes to build initially; will be cached after 1st build unless the file is modified.
 - datafed: ~1 minute to build
```
docker build -f dockerfiles/Dockerfile.kickstart-centos7 -t datafed/kickstart:centos7 . \
&& docker build -f dockerfiles/Dockerfile.datafed-centos7 -t datafed/datafed:centos7 . \
&& docker run -it datafed/datafed:centos7
cd build # ... and inspect for the built project
```

**Future work / improvements**:
 - Install the python datafed client package on the system
 - Figure out how to start up the services / executables:
    - `/apps/datafed/build/core/server/sdms-core` gives: `Exception: Could not open public key file: datafed-core-key.pub`
	- `/apps/datafed/build/repository/server/sdms-repo` gives: `Exception: Could not open public key file: datafed-core-key.pub`
    - `/apps/datafed/build/repository/filesys/sdms-fs` gives: `Exception: Mount-dir must be specified` (probably just need to give an arbitrary mount directory?)
 - Dive deeper on how to setup a data repository (ie Globus endpoint setup automatically, credentials needed to setup an endpoint, file system accessible, etc.)