### PR TITLE
Joshua s brown fix docker build expose ports

### DIFF
--- a/dockerfiles/Dockerfile.core.ubuntu
+++ b/dockerfiles/Dockerfile.core.ubuntu
@@ -24,4 +24,11 @@ RUN ${BUILD_DIR}/scripts/generate_core_config.sh &&\
  cmake --build build
 RUN cmake --build build --target install
 
+# For communicating with repo server
+EXPOSE 7512
+# For listening to web server
+EXPOSE 7513
+# ArangoDB port
+EXPOSE 8529
+
 CMD ["bash","-c","$(cat datafed-core.service | grep ExecStart | cut -d '=' -f2)"]

--- a/dockerfiles/Dockerfile.repo.ubuntu
+++ b/dockerfiles/Dockerfile.repo.ubuntu
@@ -25,4 +25,10 @@ RUN ${BUILD_DIR}/scripts/generate_repo_config.sh &&\
  cmake --build build
 RUN cmake --build build --target install
 
+# This port is needed to communicate with the DataFed core server
+EXPOSE 7512
+# Not quite sure what 9000 is doing that 7512 isn't, difference between egress
+# and ingress?
+EXPOSE 9000
+
 CMD ["bash","-c","$(cat datafed-repo.service | grep ExecStart | cut -d '=' -f2)"]

--- a/dockerfiles/Dockerfile.web
+++ b/dockerfiles/Dockerfile.web
@@ -34,4 +34,7 @@ RUN npm install client-oauth2
 
 ENV DATAFED_CONFIG_DIR ${DATAFED_CONFIG_DIR}
 
+EXPOSE 443
+EXPOSE 7513
+
 CMD ./datafed-ws.js ${DATAFED_CONFIG_DIR}/datafed-ws.ini


### PR DESCRIPTION
Docker files were not exposing ports, making it impossible to communicate between containers.