### PR TITLE
Should only check path for consistency with what is visible from Glob…

### DIFF
--- a/core/database/api/authz_router.js
+++ b/core/database/api/authz_router.js
@@ -66,7 +66,7 @@ router.get('/gridftp', function (req, res) {
         if ( !alloc )
             throw g_lib.ERR_PERM_DENIED;
 
-        if ( alloc.path + data_key != path ){
+        if ( ! path.endsWith(alloc.path + data_key) ){
             // This may be due to an alloc/owner change
             // Allow IF new path matches
             //console.log("authz loc info:", loc );
@@ -78,7 +78,7 @@ router.get('/gridftp', function (req, res) {
 
             //console.log("path:", path, "alloc path:", alloc.path + data_key );
 
-            if ( !alloc || ( alloc.path + data_key != path ))
+            if ( !alloc || ! path.endsWith(alloc.path + data_key) )
                 throw g_lib.ERR_PERM_DENIED;
         }
 

--- a/core/database/api/authz_router.js
+++ b/core/database/api/authz_router.js
@@ -57,7 +57,6 @@ router.get('/gridftp', function (req, res) {
 
         // Verify repo and path are correct for record
         // Note: only managed records have an allocations and this gridftp auth call is only made for managed records
-        var path = req.queryParams.file.substr( req.queryParams.file.indexOf("/",8));
         var loc = g_db.loc.firstExample({_from: data_id});
         if ( !loc )
             throw g_lib.ERR_PERM_DENIED;
@@ -66,7 +65,7 @@ router.get('/gridftp', function (req, res) {
         if ( !alloc )
             throw g_lib.ERR_PERM_DENIED;
 
-        if ( ! path.endsWith(alloc.path + data_key) ){
+        if ( ! req.queryParams.file.endsWith(alloc.path + data_key) ){
             // This may be due to an alloc/owner change
             // Allow IF new path matches
             //console.log("authz loc info:", loc );
@@ -78,7 +77,7 @@ router.get('/gridftp', function (req, res) {
 
             //console.log("path:", path, "alloc path:", alloc.path + data_key );
 
-            if ( !alloc || ! path.endsWith(alloc.path + data_key) )
+            if ( !alloc || ! req.queryParams.file.endsWith(alloc.path + data_key) )
                 throw g_lib.ERR_PERM_DENIED;
         }
 


### PR DESCRIPTION
…us collection root

As an example this is the content of path: file ftp://datafed-gcs-test/home/cades/collections/mapped/datafed-home/user/brownjs/1M.dat

Whereas in the "devel" branch this is the content of alloc.path + data_key: /datafed-home/user/brownjs/68722984

In "devel" the decision was made that the core server should not have insight into the full path of the POSIX filesystem, it only needs to know the directory structure of the collection root which it has control of. The Repo and Authz modules that exist on the same machine as the collection can check the actual POSIX path.

This fix also removes the use of the magick number 8 which appears to be dependent on how the repository directory hierarchy was set up and is brittle.