### PR TITLE
Devel g5 fix

### DIFF
--- a/common/proto/SDMS.proto
+++ b/common/proto/SDMS.proto
@@ -304,10 +304,9 @@ message RepoData
     optional string             pub_key     = 5;
     optional string             address     = 6;
     optional string             endpoint    = 7;
-    optional string             path        = 8;
-    optional string             domain      = 9;
-    optional string             exp_path    = 10;
-    repeated string             admin       = 11;
+    optional string             base_path   = 8;
+    optional string             repo_path   = 9;
+    repeated string             admin       = 10;
 }
 
 

--- a/common/proto/SDMS_Auth.proto
+++ b/common/proto/SDMS_Auth.proto
@@ -907,14 +907,13 @@ message RepoCreateRequest
     required string             id          = 1; // ID of repo
     required string             title       = 2; // Title
     optional string             desc        = 3; // Description
-    optional string             domain      = 5; // RESERVED
-    required string             path        = 6; // Path to storage directories
-    optional string             exp_path    = 7; // RESERVED
-    required string             address     = 8; // Repo server address
-    required string             endpoint    = 9; // Globus endpoint UUID or legacy name
-    required string             pub_key     = 10; // Public encryption key
-    required uint64             capacity    = 11; // Total data capacity
-    repeated string             admin       = 12; // Repo admin(s)
+    required string             base_path   = 4; // Path to base data collection (/path/to/data)
+    required string             repo_path   = 5; // Path to repo directory relative to base (/repo1/)
+    required string             address     = 6; // Repo server address
+    required string             endpoint    = 7; // Globus endpoint UUID or legacy name
+    required string             pub_key     = 8; // Public encryption key
+    required uint64             capacity    = 9; // Total data capacity
+    repeated string             admin       = 10; // Repo admin(s)
 }
 
 // Request to update an existing repository. Only system or repos admins may
@@ -924,16 +923,15 @@ message RepoCreateRequest
 message RepoUpdateRequest
 {
     required string             id          = 1; // ID of repo
-    optional string             title       = 2; // Title
+    required string             title       = 2; // Title
     optional string             desc        = 3; // Description
-    optional string             domain      = 5; // RESERVED
-    optional string             path        = 6; // Path to storage directories
-    optional string             exp_path    = 7; // RESERVED
-    optional string             address     = 8; // Repo server address
-    optional string             endpoint    = 9; // Globus endpoint UUID or legacy name
-    optional string             pub_key     = 10; // Public encryption key
-    optional uint64             capacity    = 11; // Total data capacity
-    repeated string             admin       = 12; // Repo admin(s)
+    required string             base_path   = 4; // Path to base data collection (/path/to/data)
+    required string             repo_path   = 5; // Path to repo directory relative to base (/repo1/)
+    required string             address     = 6; // Repo server address
+    required string             endpoint    = 7; // Globus endpoint UUID or legacy name
+    required string             pub_key     = 8; // Public encryption key
+    required uint64             capacity    = 9; // Total data capacity
+    repeated string             admin       = 10; // Repo admin(s)
 }
 
 // Request to delete a repository. Only system or repos admins may send this

--- a/common/proto/Version.proto
+++ b/common/proto/Version.proto
@@ -14,7 +14,7 @@ enum Version
     option allow_alias = true; // Must be commented out if there are no duplicate values
 
     VER_MAJOR = 1;          // System MAJOR version, no backward compatibility
-    VER_MAPI_MAJOR = 4;     // Message API MAJOR version, no backward compatibility
+    VER_MAPI_MAJOR = 5;     // Message API MAJOR version, no backward compatibility
     VER_MAPI_MINOR = 1;     // Message API MINOR version, backward compatible
     VER_CORE = 0;           // Core server MINOR version, information only
     VER_WEB = 0;            // Web server MINOR version, info/notification purposes

--- a/core/database/api/support.js
+++ b/core/database/api/support.js
@@ -256,7 +256,7 @@ module.exports = ( function() {
                 }
             }else if ( spec.required )
                 throw [obj.ERR_MISSING_REQ_PARAM,"Missing required field '" + spec.label + "'."];
-            }
+        }
     };
 
     obj.isInteger = function( x ) {

--- a/core/database/api/tasks.js
+++ b/core/database/api/tasks.js
@@ -38,7 +38,7 @@ var tasks_func = function() {
         }
 
         var repo = g_db.repo.document( a_repo_id );
-        var path = repo.path + (a_subject_id.charAt(0) == "p"?"project/":"user/") + a_subject_id.substr(2) + "/";
+        var path = repo.base_path + repo.repo_path + (a_subject_id.charAt(0) == "p"?"project/":"user/") + a_subject_id.substr(2) + "/";
         var state = { repo_id: a_repo_id, subject: a_subject_id, data_limit: a_data_limit, rec_limit: a_rec_limit, repo_path: path };
         var task = obj._createTask( a_client._id, g_lib.TT_ALLOC_CREATE, 2, state );
 
@@ -106,7 +106,7 @@ var tasks_func = function() {
             throw [g_lib.ERR_IN_USE, "A duplicate allocation delete task was found." ];
         }
 
-        var path = repo.path + (a_subject_id.charAt(0) == "p"?"project/":"user/") + a_subject_id.substr(2) + "/";
+        var path = repo.base_path + repo.repo_path + (a_subject_id.charAt(0) == "p"?"project/":"user/") + a_subject_id.substr(2) + "/";
         var state = { repo_id: a_repo_id, subject: a_subject_id, repo_path: path };
         var task = obj._createTask( a_client._id, g_lib.TT_ALLOC_DEL, 2, state );
 
@@ -358,10 +358,12 @@ var tasks_func = function() {
                 }
             }
 
+            var repo = g_db.repo.document( xfr.dst_repo_id );
+
             // Request data size update
             params = {
                 repo_id: xfr.dst_repo_id,
-                repo_path: xfr.dst_repo_path,
+                repo_path: repo.base_path + xfr.dst_repo_path,
                 ids: [xfr.files[0].id]
             };
             reply = { cmd: g_lib.TC_RAW_DATA_UPDATE_SIZE, params: params, step: a_task.step };
@@ -1201,7 +1203,7 @@ var tasks_func = function() {
 
             var repo = g_db.repo.document( a_remote );
             rem_ep = repo.endpoint;
-            rem_path = repo.path + (a_dst_owner.charAt(0)=="u"?"user/":"project/") + a_dst_owner.substr(2) + "/";
+            rem_path = repo.repo_path + (a_dst_owner.charAt(0)=="u"?"user/":"project/") + a_dst_owner.substr(2) + "/";
         }
 
         if ( a_mode  == g_lib.TT_DATA_GET){
@@ -1209,7 +1211,7 @@ var tasks_func = function() {
         }
 
         if ( a_data.length ){
-            var loc, locs = g_db._query("for i in @data for v,e in 1..1 outbound i loc return { d_id: i._id, d_sz: i.size, d_ext: i.ext, d_src: i.source, r_id: v._id, r_ep: v.endpoint, r_path: v.path, uid: e.uid }", { data: a_data });
+            var loc, locs = g_db._query("for i in @data for v,e in 1..1 outbound i loc return { d_id: i._id, d_sz: i.size, d_ext: i.ext, d_src: i.source, r_id: v._id, r_ep: v.endpoint, r_path: v.repo_path, uid: e.uid }", { data: a_data });
 
             //console.log("locs hasNext",locs.hasNext());
 
@@ -1427,7 +1429,7 @@ var tasks_func = function() {
     obj._buildDeleteDoc = function( a_data ){
         var loc, locs, doc = [], repo_map = {};
 
-        locs = g_db._query("for i in @data for v,e in 1..1 outbound i loc return { d_id: i._id, r_id: v._id, r_path: v.path, uid: e.uid }", { data: a_data });
+        locs = g_db._query("for i in @data for v,e in 1..1 outbound i loc return { d_id: i._id, r_id: v._id, r_path: v.repo_path, uid: e.uid }", { data: a_data });
 
         //console.log("locs hasNext",locs.hasNext());
 

--- a/core/server/ClientWorker.hpp
+++ b/core/server/ClientWorker.hpp
@@ -86,7 +86,7 @@ private:
 
     void schemaLoader( const nlohmann::json_uri & a_uri, nlohmann::json & a_value );
 
-    void error( const nlohmann::json_pointer<nlohmann::basic_json<>> & a_ptr, const nlohmann::json & a_inst, const std::string & a_err_msg ) override
+    void error( const nlohmann::json::json_pointer & a_ptr, const nlohmann::json & a_inst, const std::string & a_err_msg ) override
     {
         (void) a_ptr;
         (void) a_inst;

--- a/core/server/Config.cpp
+++ b/core/server/Config.cpp
@@ -20,30 +20,6 @@ namespace SDMS {
 
       for ( RepoData & r : temp_repos ) {
         {
-          // Validate repo settings (in case an admin manually edits repo config)
-          if ( r.pub_key().size() != 40 ){
-            DL_ERROR("Ignoring " << r.id() << " - invalid public key: " << r.pub_key() );
-            continue;
-          }
-
-          if ( r.address().compare(0,6,"tcp://") ){
-            DL_ERROR("Ignoring " << r.id() << " - invalid server address: " << r.address() );
-            continue;
-          }
-
-          if ( r.endpoint().size() != 36 ){
-            DL_ERROR("Ignoring " << r.id() << " - invalid endpoint UUID: " << r.endpoint() );
-            continue;
-          }
-
-          if ( r.path().size() == 0 || r.path()[0] != '/' ){
-            DL_ERROR("Ignoring " << r.id() << " - invalid path: " << r.path() );
-            continue;
-          }
-
-          DL_DEBUG("Repo " << r.id() << " OK");
-          DL_DEBUG("UUID: " << r.endpoint() );
-
           // Cache pub key for ZAP handler
           m_auth_clients_mtx.lock();
           m_auth_clients[r.pub_key()] = r.id();
@@ -53,8 +29,6 @@ namespace SDMS {
           m_repos_mtx.lock();
           m_repos[r.id()] = r;
           m_repos_mtx.unlock();
-
-
         }
       }
     }

--- a/core/server/DatabaseAPI.cpp
+++ b/core/server/DatabaseAPI.cpp
@@ -2228,7 +2228,8 @@ DatabaseAPI::repoCreate( const Auth::RepoCreateRequest & a_request, Auth::RepoDa
 
     string body = "{\"id\":\"" + a_request.id() + "\"";
     body += ",\"title\":\"" + escapeJSON( a_request.title() ) + "\"";
-    body += ",\"path\":\"" + escapeJSON( a_request.path() ) + "\"";
+    body += ",\"base_path\":\"" + escapeJSON( a_request.base_path() ) + "\"";
+    body += ",\"repo_path\":\"" + escapeJSON( a_request.repo_path() ) + "\"";
     body += ",\"pub_key\":\"" + escapeJSON( a_request.pub_key() ) + "\"";
     body += ",\"address\":\"" + a_request.address() + "\"";
     body += ",\"endpoint\":\"" + a_request.endpoint() + "\"";
@@ -2236,10 +2237,6 @@ DatabaseAPI::repoCreate( const Auth::RepoCreateRequest & a_request, Auth::RepoDa
 
     if ( a_request.has_desc() )
         body += ",\"desc\":\"" + escapeJSON( a_request.desc() ) + "\"";
-    if ( a_request.has_domain() )
-        body += ",\"domain\":\"" + a_request.domain() + "\"";
-    if ( a_request.has_exp_path() )
-        body += ",\"exp_path\":\"" + escapeJSON( a_request.exp_path() ) + "\"";
 
     if ( a_request.admin_size() > 0 )
     {
@@ -2266,24 +2263,16 @@ DatabaseAPI::repoUpdate( const Auth::RepoUpdateRequest & a_request, Auth::RepoDa
     Value result;
 
     string body = "{\"id\":\"" + a_request.id() + "\"";
-    if ( a_request.has_title() )
-        body += ",\"title\":\"" + escapeJSON( a_request.title() ) + "\"";
+    body += ",\"title\":\"" + escapeJSON( a_request.title() ) + "\"";
+    body += ",\"base_path\":\"" + escapeJSON( a_request.base_path() ) + "\"";
+    body += ",\"repo_path\":\"" + escapeJSON( a_request.repo_path() ) + "\"";
+    body += ",\"pub_key\":\"" + escapeJSON( a_request.pub_key() ) + "\"";
+    body += ",\"address\":\"" + a_request.address() + "\"";
+    body += ",\"endpoint\":\"" + a_request.endpoint() + "\"";
+    body += ",\"capacity\":\"" + to_string( a_request.capacity() )+ "\"";
+
     if ( a_request.has_desc() )
         body += ",\"desc\":\"" + escapeJSON( a_request.desc() ) + "\"";
-    if ( a_request.has_path() )
-        body += ",\"path\":\"" + escapeJSON( a_request.path() ) + "\"";
-    if ( a_request.has_exp_path() )
-        body += ",\"exp_path\":\"" + escapeJSON( a_request.exp_path() ) + "\"";
-    if ( a_request.has_domain() )
-        body += ",\"domain\":\"" + a_request.domain() + "\"";
-    if ( a_request.has_pub_key() )
-        body += ",\"pub_key\":\"" + escapeJSON( a_request.pub_key() ) + "\"";
-    if ( a_request.has_address() )
-        body += ",\"address\":\"" + a_request.address() + "\"";
-    if ( a_request.has_endpoint() )
-        body += ",\"endpoint\":\"" + a_request.endpoint() + "\"";
-    if ( a_request.has_capacity() )
-        body += ",\"capacity\":\"" + to_string( a_request.capacity() )+ "\"";
 
     if ( a_request.admin_size() > 0 )
     {
@@ -2387,16 +2376,12 @@ DatabaseAPI::setRepoData( Auth::RepoDataReply * a_reply, std::vector<RepoData> &
             a_repos.back().set_pub_key( obj.asString() );
         }
 
-        if ( obj.has( "path" )) {
-            a_repos.back().set_path( obj.asString() );
+        if ( obj.has( "base_path" )) {
+            a_repos.back().set_base_path( obj.asString() );
         }
 
-        if ( obj.has( "exp_path" )) {
-            a_repos.back().set_exp_path( obj.asString() );
-        }
-
-        if ( obj.has( "domain" ) && !obj.value().isNull( )) {
-            a_repos.back().set_domain( obj.asString() );
+        if ( obj.has( "repo_path" )) {
+            a_repos.back().set_repo_path( obj.asString() );
         }
 
         if ( obj.has( "admins" ))

--- a/repository/server/RequestWorker.cpp
+++ b/repository/server/RequestWorker.cpp
@@ -253,7 +253,7 @@ RequestWorker::procDataGetSizeRequest()
     {
         const RecordDataLocation & item = request->loc(i);
 
-        string sanitized_request_path = item.path();
+        /*string sanitized_request_path = item.path();
         while ( ! sanitized_request_path.empty() ) {
           if ( sanitized_request_path.back() == '/' ) {
             sanitized_request_path.pop_back();
@@ -268,7 +268,9 @@ RequestWorker::procDataGetSizeRequest()
         } else {
           local_path += sanitized_request_path;
         }
-        boost::filesystem::path data_path( local_path );
+	*/
+
+        boost::filesystem::path data_path( item.path() /*local_path*/ );
 
         data_sz = reply.add_size();
         data_sz->set_id( item.id() );
@@ -279,10 +281,11 @@ RequestWorker::procDataGetSizeRequest()
         }
         else
         {
-            data_sz->set_size( 0 );
-            DL_ERROR( "DataGetSizeReq - path does not exist: "  << item.path() );
+	    EXCEPT_PARAM( 1, "Repo Server - DataGetSizeReq path not found: " << data_path );
+            //data_sz->set_size( 0 );
+            //DL_ERROR( "DataGetSizeReq - path does not exist: "  << item.path() );
         }
-        DL_INFO( "FILE SIZE: " << data_sz->size() << ", path to collection: " << m_config.globus_collection_path << ", full path to file: " << local_path );
+        DL_INFO( "FILE SIZE: " << data_sz->size() << ", path to file: " << data_path );
     }
 
     PROC_MSG_END

--- a/web/static/dlg_repo_edit.js
+++ b/web/static/dlg_repo_edit.js
@@ -184,7 +184,7 @@ export function show( a_repo_id, a_cb ){
                     node.data.alloc.totalSz = data.totalSz;
                     updateAllocTitle( node );
 
-                    var msg =a_repo_id
+                    var msg =
                     "<table class='info_table'>\
                     <tr><td>No. of Records:</td><td>" + data.recCount + "</td></tr>\
                     <tr><td>No. of Files:</td><td>" + data.fileCount + "</td></tr>\


### PR DESCRIPTION
This PR changes the handling of the Globus 5 base path for repository endpoints. The base (and repo) paths are now set in the repo configuration in the DB and the repo server expects full paths to be sent to it. This fix has been tested on Globus 5; however, it will likely break Globus 4 installations. (No Globus 4 test server is available.) Note that Globus 4 is being deprecated soon.