### PR TITLE
Add retries as option when working with data transfers

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -16,7 +16,8 @@ if( BUILD_COMMON )
     "source/operators/*.cpp"
     "source/servers/*.cpp"
     "source/support/zeromq/*.cpp"
-    "source/sockets/*.cpp")
+    "source/sockets/*.cpp"
+    "source/type_converters/*.cpp")
   add_library( common STATIC ${Sources})
   set_target_properties(common PROPERTIES POSITION_INDEPENDENT_CODE ON SOVERSION ${DATAFED_COMMON_LIB_MAJOR} VERSION ${DATAFED_COMMON_LIB_MAJOR}.${DATAFED_COMMON_LIB_MINOR}.${DATAFED_COMMON_LIB_PATCH} )
   target_link_libraries( common Boost::date_time ${Protobuf_LIBRARIES} datafed-protobuf) 

--- a/common/include/common/CppTypes.hpp
+++ b/common/include/common/CppTypes.hpp
@@ -1,0 +1,23 @@
+#ifndef CPP_TYPES_HPP
+#define CPP_TYPES_HPP
+#pragma once
+
+// Standard includes
+#include <string>
+#include <unordered_map>
+
+namespace SDMS {
+
+
+enum class CppType { 
+cpp_double,
+cpp_string,
+cpp_uint32_t,
+cpp_uint64_t,
+cpp_char 
+};
+extern std::unordered_map<CppType, std::string> cpp_enum_type_to_string;
+
+}
+
+#endif // CPP_TYPES_HPP

--- a/common/include/common/CppTypes.hpp
+++ b/common/include/common/CppTypes.hpp
@@ -8,16 +8,15 @@
 
 namespace SDMS {
 
-
-enum class CppType { 
-cpp_double,
-cpp_string,
-cpp_uint32_t,
-cpp_uint64_t,
-cpp_char 
+enum class CppType {
+  cpp_double,
+  cpp_string,
+  cpp_uint32_t,
+  cpp_uint64_t,
+  cpp_char
 };
 extern std::unordered_map<CppType, std::string> cpp_enum_type_to_string;
 
-}
+} // namespace SDMS
 
 #endif // CPP_TYPES_HPP

--- a/common/include/common/ITypeConverter.hpp
+++ b/common/include/common/ITypeConverter.hpp
@@ -1,0 +1,36 @@
+#ifndef ITYPE_CONVERTER_HPP
+#define ITYPE_CONVERTER_HPP
+#pragma once
+
+// Local public includes
+#include "CppTypes.hpp"
+
+// Standard includes
+#include <any>
+#include <string>
+
+namespace SDMS {
+
+  /**
+   * Convert between any two C++ types throw an error if there is a problem
+   **/
+class ITypeConverter {
+
+  public:
+
+    // The name of the type we are converting to
+    virtual std::string to() const noexcept = 0;
+    virtual CppType toType() const noexcept = 0;
+
+    // The name of the type we will convert from
+    virtual std::string from() const noexcept = 0;
+    virtual CppType fromType() const noexcept = 0;
+
+    virtual std::any convert(std::any) = 0;
+    
+};
+}
+
+#endif // ITYPE_CONVERTER_HPP
+
+

--- a/common/include/common/ITypeConverter.hpp
+++ b/common/include/common/ITypeConverter.hpp
@@ -11,26 +11,22 @@
 
 namespace SDMS {
 
-  /**
-   * Convert between any two C++ types throw an error if there is a problem
-   **/
+/**
+ * Convert between any two C++ types throw an error if there is a problem
+ **/
 class ITypeConverter {
 
-  public:
+public:
+  // The name of the type we are converting to
+  virtual std::string to() const noexcept = 0;
+  virtual CppType toType() const noexcept = 0;
 
-    // The name of the type we are converting to
-    virtual std::string to() const noexcept = 0;
-    virtual CppType toType() const noexcept = 0;
+  // The name of the type we will convert from
+  virtual std::string from() const noexcept = 0;
+  virtual CppType fromType() const noexcept = 0;
 
-    // The name of the type we will convert from
-    virtual std::string from() const noexcept = 0;
-    virtual CppType fromType() const noexcept = 0;
-
-    virtual std::any convert(std::any) = 0;
-    
+  virtual std::any convert(std::any) = 0;
 };
-}
+} // namespace SDMS
 
 #endif // ITYPE_CONVERTER_HPP
-
-

--- a/common/include/common/OperatorTypes.hpp
+++ b/common/include/common/OperatorTypes.hpp
@@ -3,8 +3,6 @@
 #define OPERATOR_TYPES_HPP
 #pragma once
 
-#include <string>
-
 namespace SDMS {
 
 enum class OperatorType { Authenticator, RouterBookKeeping };

--- a/common/include/common/TypeConverterFactory.hpp
+++ b/common/include/common/TypeConverterFactory.hpp
@@ -18,8 +18,8 @@ public:
   using ConverterCreateMethod = std::unique_ptr<ITypeConverter> (*)();
 
 private:
-  static std::unordered_map<CppType, 
-    std::unordered_map<CppType, ConverterCreateMethod>>
+  static std::unordered_map<CppType,
+                            std::unordered_map<CppType, ConverterCreateMethod>>
       m_create_methods;
 
 public:
@@ -32,19 +32,20 @@ public:
    * factory.register<StringUint32T,CppType::cpp_string,CppType::cpp_uint32_t>();
    * ```
    **/
-  template <class T, CppType from_type, CppType to_type> static bool registerTypeConverter() {
+  template <class T, CppType from_type, CppType to_type>
+  static bool registerTypeConverter() {
     if (m_create_methods.count(from_type) > 0) {
       if (m_create_methods[from_type].count(to_type) > 0) {
         return false;
       }
-    } 
+    }
     m_create_methods[from_type][to_type] = T::create;
-    
+
     return true;
   }
 
   std::unique_ptr<ITypeConverter> create(const CppType from_type,
-                                    const CppType to_type) const;
+                                         const CppType to_type) const;
 };
 
 } // namespace SDMS

--- a/common/include/common/TypeConverterFactory.hpp
+++ b/common/include/common/TypeConverterFactory.hpp
@@ -1,0 +1,52 @@
+#ifndef TYPECONVERTER_FACTORY_HPP
+#define TYPECONVERTER_FACTORY_HPP
+#pragma once
+
+// Local includes
+#include "CppTypes.hpp"
+#include "ITypeConverter.hpp"
+
+// Standard includes
+#include <any>
+#include <memory>
+#include <unordered_map>
+
+namespace SDMS {
+
+class TypeConverterFactory {
+public:
+  using ConverterCreateMethod = std::unique_ptr<ITypeConverter> (*)();
+
+private:
+  static std::unordered_map<CppType, 
+    std::unordered_map<CppType, ConverterCreateMethod>>
+      m_create_methods;
+
+public:
+  TypeConverterFactory();
+  /**
+   * To register an operator you need to run this command with the factory.
+   *
+   * ```C++
+   * TypeConverterFactory factory;
+   * factory.register<StringUint32T,CppType::cpp_string,CppType::cpp_uint32_t>();
+   * ```
+   **/
+  template <class T, CppType from_type, CppType to_type> static bool registerTypeConverter() {
+    if (m_create_methods.count(from_type) > 0) {
+      if (m_create_methods[from_type].count(to_type) > 0) {
+        return false;
+      }
+    } 
+    m_create_methods[from_type][to_type] = T::create;
+    
+    return true;
+  }
+
+  std::unique_ptr<ITypeConverter> create(const CppType from_type,
+                                    const CppType to_type) const;
+};
+
+} // namespace SDMS
+
+#endif // TYPECONVERTER_FACTORY_HPP

--- a/common/proto/common/SDMS_Auth.proto
+++ b/common/proto/common/SDMS_Auth.proto
@@ -426,6 +426,7 @@ message DataGetRequest
     optional Encryption         encrypt     = 3; // Optional encryption mode (none, if available, required)
     optional bool               orig_fname  = 4; // Optional flag to download to original filenames
     optional bool               check       = 5; // Optional flag to perform initial validation only if true
+    optional uint32             retries     = 6; // Optional number of transfer retries to attempt
 }
 
 // Request to upload raw data to a data records. Auth user must have WRITE_DATA
@@ -439,6 +440,7 @@ message DataPutRequest
     optional Encryption         encrypt     = 3; // Optional encryption mode (none, if available, required)
     optional string             ext         = 4; // Optional extension override
     optional bool               check       = 5; // Optional flag to perform initial validation only if true
+    optional uint32             retries     = 6; // Optional number of transfer retries to attempt
 }
 
 // Reply containing data download information, including associated background task.

--- a/common/source/CppTypes.cpp
+++ b/common/source/CppTypes.cpp
@@ -1,0 +1,19 @@
+// Local pubic includes
+#include "common/CppTypes.hpp"
+
+// Standard includes
+#include <string>
+#include <unordered_map>
+
+namespace SDMS {
+
+std::unordered_map<CppType, std::string> cpp_enum_type_to_string = {
+  {CppType::cpp_double, "double"},
+  {CppType::cpp_string, "string"},
+  {CppType::cpp_uint32_t, "uint32_t"},
+  {CppType::cpp_uint64_t, "uint64_t"},
+  {CppType::cpp_char, "char"}
+};
+
+}
+

--- a/common/source/CppTypes.cpp
+++ b/common/source/CppTypes.cpp
@@ -8,12 +8,10 @@
 namespace SDMS {
 
 std::unordered_map<CppType, std::string> cpp_enum_type_to_string = {
-  {CppType::cpp_double, "double"},
-  {CppType::cpp_string, "string"},
-  {CppType::cpp_uint32_t, "uint32_t"},
-  {CppType::cpp_uint64_t, "uint64_t"},
-  {CppType::cpp_char, "char"}
-};
+    {CppType::cpp_double, "double"},
+    {CppType::cpp_string, "string"},
+    {CppType::cpp_uint32_t, "uint32_t"},
+    {CppType::cpp_uint64_t, "uint64_t"},
+    {CppType::cpp_char, "char"}};
 
 }
-

--- a/common/source/TypeConverterFactory.cpp
+++ b/common/source/TypeConverterFactory.cpp
@@ -15,19 +15,23 @@
 
 namespace SDMS {
 
-std::unordered_map<CppType, 
-  std::unordered_map<CppType, TypeConverterFactory::ConverterCreateMethod>>
+std::unordered_map<
+    CppType,
+    std::unordered_map<CppType, TypeConverterFactory::ConverterCreateMethod>>
     TypeConverterFactory::m_create_methods;
 
 TypeConverterFactory::TypeConverterFactory() {
-  registerTypeConverter<StringUint32T, CppType::cpp_string, CppType::cpp_uint32_t>();
-  registerTypeConverter<StringUint64T, CppType::cpp_string, CppType::cpp_uint64_t>();
-  registerTypeConverter<DoubleUint32T, CppType::cpp_double, CppType::cpp_uint32_t>();
+  registerTypeConverter<StringUint32T, CppType::cpp_string,
+                        CppType::cpp_uint32_t>();
+  registerTypeConverter<StringUint64T, CppType::cpp_string,
+                        CppType::cpp_uint64_t>();
+  registerTypeConverter<DoubleUint32T, CppType::cpp_double,
+                        CppType::cpp_uint32_t>();
 }
 
-std::unique_ptr<ITypeConverter> TypeConverterFactory::create(
-    const CppType from_type,
-    const CppType to_type) const {
+std::unique_ptr<ITypeConverter>
+TypeConverterFactory::create(const CppType from_type,
+                             const CppType to_type) const {
 
   if (m_create_methods.count(from_type)) {
     if (m_create_methods[from_type].count(to_type)) {
@@ -40,7 +44,7 @@ std::unique_ptr<ITypeConverter> TypeConverterFactory::create(
   error_msg += "\nFrom " + cpp_enum_type_to_string[from_type] + " -> To: ";
   error_msg += cpp_enum_type_to_string[to_type];
   EXCEPT(1, error_msg);
-  
+
   return std::unique_ptr<ITypeConverter>();
 }
 

--- a/common/source/TypeConverterFactory.cpp
+++ b/common/source/TypeConverterFactory.cpp
@@ -1,0 +1,47 @@
+
+// Local private includes
+#include "type_converters/DoubleUint32T.hpp"
+#include "type_converters/StringUint32T.hpp"
+#include "type_converters/StringUint64T.hpp"
+
+// Local public includes
+#include "common/CppTypes.hpp"
+#include "common/TraceException.hpp"
+#include "common/TypeConverterFactory.hpp"
+
+// Standard includes
+#include <any>
+#include <memory>
+
+namespace SDMS {
+
+std::unordered_map<CppType, 
+  std::unordered_map<CppType, TypeConverterFactory::ConverterCreateMethod>>
+    TypeConverterFactory::m_create_methods;
+
+TypeConverterFactory::TypeConverterFactory() {
+  registerTypeConverter<StringUint32T, CppType::cpp_string, CppType::cpp_uint32_t>();
+  registerTypeConverter<StringUint64T, CppType::cpp_string, CppType::cpp_uint64_t>();
+  registerTypeConverter<DoubleUint32T, CppType::cpp_double, CppType::cpp_uint32_t>();
+}
+
+std::unique_ptr<ITypeConverter> TypeConverterFactory::create(
+    const CppType from_type,
+    const CppType to_type) const {
+
+  if (m_create_methods.count(from_type)) {
+    if (m_create_methods[from_type].count(to_type)) {
+      return m_create_methods[from_type][to_type]();
+    }
+  }
+
+  std::string error_msg = "There are no registered type converters for the ";
+  error_msg += "requested types and conversion direction.";
+  error_msg += "\nFrom " + cpp_enum_type_to_string[from_type] + " -> To: ";
+  error_msg += cpp_enum_type_to_string[to_type];
+  EXCEPT(1, error_msg);
+  
+  return std::unique_ptr<ITypeConverter>();
+}
+
+} // namespace SDMS

--- a/common/source/type_converters/DoubleUint32T.cpp
+++ b/common/source/type_converters/DoubleUint32T.cpp
@@ -1,0 +1,82 @@
+
+// Local private includes
+#include "DoubleUint32T.hpp"
+
+// Local public includes
+#include "common/TraceException.hpp"
+
+// Third party includes
+#include <boost/numeric/conversion/cast.hpp>
+#include <boost/numeric/conversion/converter.hpp>
+
+// Standard includes
+#include <any>
+#include <cmath>
+#include <string>
+
+namespace SDMS {
+
+
+  std::any DoubleUint32T::convert(std::any input) {
+    double input_double;
+    try {
+      input_double = std::any_cast<double>(input);
+    } catch ( const std::bad_any_cast & e ) {
+      std::string error_msg = "Failed to cast from an any which is supposed ";
+      error_msg += "to be a double.";
+      EXCEPT(1, error_msg);
+    }
+
+    const double allowed_epsilon = 0.0001;
+    if ( input_double < allowed_epsilon * -1.0 ) {
+      std::string error_msg = "Failed to convert double to uint32_t ";
+      error_msg += "double is negative: " + std::to_string(input_double);
+      error_msg += " and is larger in magnitude then the allowed epsilon ";
+      error_msg += std::to_string(allowed_epsilon);
+      EXCEPT_PARAM(1,error_msg << input_double); 
+    } else if ( input_double < 0.0 ) {
+      // If the input is negative but smaller then the epsilon assume it is 0
+      return 0;
+    }
+
+    // Check to make sure that double is a whole number or else throw an error
+    if ( std::floor(input_double) != input_double ) {
+
+      // How small of a fraction is allowed in the rounding before triggering
+      // an error. This is to account for how floating point operations affect
+      // the pecision of the numbers stored in them. Note at this point we
+      // know the double is positive
+      double diff = input_double - std::floor(input_double);
+      if ( diff > allowed_epsilon) {
+        std::string error_msg = "Failed to convert double to uint32_t ";
+        error_msg += "double is not a whole number: ";
+        error_msg += std::to_string(input_double);
+        error_msg += " and is larger than allowed ellowed epsilon value of: ";
+        error_msg += std::to_string(allowed_epsilon);
+        EXCEPT(1,error_msg); 
+      }
+    }
+
+    uint32_t output;
+
+
+    try {
+        output = boost::numeric_cast<uint32_t>(std::floor(input_double));
+				// Don't need to account for negative overflow because we don't have a 
+				// negative number at this point
+    } catch (const boost::numeric::positive_overflow& e) {
+				std::string error_msg = "Failed to convert double to uint32_t, ";
+				error_msg += "positive overflow has occurred, the double is too large ";
+				error_msg += "input is: " + std::to_string(std::floor(input_double));
+        EXCEPT(1,error_msg); 
+    } catch (const boost::numeric::bad_numeric_cast& e) {
+				std::string error_msg = "Failed to convert double to uint32_t, ";
+				error_msg += "general conversion error: ";
+				EXCEPT_PARAM(1, error_msg << e.what());
+    }
+    
+    return output;
+  }
+
+}
+

--- a/common/source/type_converters/DoubleUint32T.cpp
+++ b/common/source/type_converters/DoubleUint32T.cpp
@@ -16,67 +16,64 @@
 
 namespace SDMS {
 
-
-  std::any DoubleUint32T::convert(std::any input) {
-    double input_double;
-    try {
-      input_double = std::any_cast<double>(input);
-    } catch ( const std::bad_any_cast & e ) {
-      std::string error_msg = "Failed to cast from an any which is supposed ";
-      error_msg += "to be a double.";
-      EXCEPT(1, error_msg);
-    }
-
-    const double allowed_epsilon = 0.0001;
-    if ( input_double < allowed_epsilon * -1.0 ) {
-      std::string error_msg = "Failed to convert double to uint32_t ";
-      error_msg += "double is negative: " + std::to_string(input_double);
-      error_msg += " and is larger in magnitude then the allowed epsilon ";
-      error_msg += std::to_string(allowed_epsilon);
-      EXCEPT_PARAM(1,error_msg << input_double); 
-    } else if ( input_double < 0.0 ) {
-      // If the input is negative but smaller then the epsilon assume it is 0
-      return 0;
-    }
-
-    // Check to make sure that double is a whole number or else throw an error
-    if ( std::floor(input_double) != input_double ) {
-
-      // How small of a fraction is allowed in the rounding before triggering
-      // an error. This is to account for how floating point operations affect
-      // the pecision of the numbers stored in them. Note at this point we
-      // know the double is positive
-      double diff = input_double - std::floor(input_double);
-      if ( diff > allowed_epsilon) {
-        std::string error_msg = "Failed to convert double to uint32_t ";
-        error_msg += "double is not a whole number: ";
-        error_msg += std::to_string(input_double);
-        error_msg += " and is larger than allowed ellowed epsilon value of: ";
-        error_msg += std::to_string(allowed_epsilon);
-        EXCEPT(1,error_msg); 
-      }
-    }
-
-    uint32_t output;
-
-
-    try {
-        output = boost::numeric_cast<uint32_t>(std::floor(input_double));
-				// Don't need to account for negative overflow because we don't have a 
-				// negative number at this point
-    } catch (const boost::numeric::positive_overflow& e) {
-				std::string error_msg = "Failed to convert double to uint32_t, ";
-				error_msg += "positive overflow has occurred, the double is too large ";
-				error_msg += "input is: " + std::to_string(std::floor(input_double));
-        EXCEPT(1,error_msg); 
-    } catch (const boost::numeric::bad_numeric_cast& e) {
-				std::string error_msg = "Failed to convert double to uint32_t, ";
-				error_msg += "general conversion error: ";
-				EXCEPT_PARAM(1, error_msg << e.what());
-    }
-    
-    return output;
+std::any DoubleUint32T::convert(std::any input) {
+  double input_double;
+  try {
+    input_double = std::any_cast<double>(input);
+  } catch (const std::bad_any_cast &e) {
+    std::string error_msg = "Failed to cast from an any which is supposed ";
+    error_msg += "to be a double.";
+    EXCEPT(1, error_msg);
   }
 
+  const double allowed_epsilon = 0.0001;
+  if (input_double < allowed_epsilon * -1.0) {
+    std::string error_msg = "Failed to convert double to uint32_t ";
+    error_msg += "double is negative: " + std::to_string(input_double);
+    error_msg += " and is larger in magnitude then the allowed epsilon ";
+    error_msg += std::to_string(allowed_epsilon);
+    EXCEPT_PARAM(1, error_msg << input_double);
+  } else if (input_double < 0.0) {
+    // If the input is negative but smaller then the epsilon assume it is 0
+    return 0;
+  }
+
+  // Check to make sure that double is a whole number or else throw an error
+  if (std::floor(input_double) != input_double) {
+
+    // How small of a fraction is allowed in the rounding before triggering
+    // an error. This is to account for how floating point operations affect
+    // the pecision of the numbers stored in them. Note at this point we
+    // know the double is positive
+    double diff = input_double - std::floor(input_double);
+    if (diff > allowed_epsilon) {
+      std::string error_msg = "Failed to convert double to uint32_t ";
+      error_msg += "double is not a whole number: ";
+      error_msg += std::to_string(input_double);
+      error_msg += " and is larger than allowed ellowed epsilon value of: ";
+      error_msg += std::to_string(allowed_epsilon);
+      EXCEPT(1, error_msg);
+    }
+  }
+
+  uint32_t output;
+
+  try {
+    output = boost::numeric_cast<uint32_t>(std::floor(input_double));
+    // Don't need to account for negative overflow because we don't have a
+    // negative number at this point
+  } catch (const boost::numeric::positive_overflow &e) {
+    std::string error_msg = "Failed to convert double to uint32_t, ";
+    error_msg += "positive overflow has occurred, the double is too large ";
+    error_msg += "input is: " + std::to_string(std::floor(input_double));
+    EXCEPT(1, error_msg);
+  } catch (const boost::numeric::bad_numeric_cast &e) {
+    std::string error_msg = "Failed to convert double to uint32_t, ";
+    error_msg += "general conversion error: ";
+    EXCEPT_PARAM(1, error_msg << e.what());
+  }
+
+  return output;
 }
 
+} // namespace SDMS

--- a/common/source/type_converters/DoubleUint32T.hpp
+++ b/common/source/type_converters/DoubleUint32T.hpp
@@ -1,0 +1,48 @@
+#ifndef DOUBLE_UINT32_T_HPP
+#define DOUBLE_UINT32_T_HPP
+#pragma once
+
+// Local public includes
+#include "common/CppTypes.hpp"
+#include "common/ITypeConverter.hpp"
+
+// Standard includes
+#include <any>
+#include <memory>
+#include <string>
+
+namespace SDMS {
+
+  class DoubleUint32T : public ITypeConverter {
+
+
+    public:
+
+      virtual std::string to() const noexcept final {
+        return cpp_enum_type_to_string[toType()];
+      }
+      virtual CppType toType() const noexcept final {
+        return CppType::cpp_uint32_t;
+      }
+
+      virtual std::string from() const noexcept final {
+        return cpp_enum_type_to_string[fromType()];
+      }
+      virtual CppType fromType() const noexcept final {
+        return CppType::cpp_double;
+      }
+
+      std::any convert(std::any) final;
+
+  
+      static std::unique_ptr<ITypeConverter> create();
+  };
+
+  inline std::unique_ptr<ITypeConverter>
+  DoubleUint32T::create() {
+    return std::make_unique<DoubleUint32T>();
+  }
+
+}
+
+#endif // DOUBLE_UINT32_T_HPP 

--- a/common/source/type_converters/DoubleUint32T.hpp
+++ b/common/source/type_converters/DoubleUint32T.hpp
@@ -13,36 +13,32 @@
 
 namespace SDMS {
 
-  class DoubleUint32T : public ITypeConverter {
+class DoubleUint32T : public ITypeConverter {
 
-
-    public:
-
-      virtual std::string to() const noexcept final {
-        return cpp_enum_type_to_string[toType()];
-      }
-      virtual CppType toType() const noexcept final {
-        return CppType::cpp_uint32_t;
-      }
-
-      virtual std::string from() const noexcept final {
-        return cpp_enum_type_to_string[fromType()];
-      }
-      virtual CppType fromType() const noexcept final {
-        return CppType::cpp_double;
-      }
-
-      std::any convert(std::any) final;
-
-  
-      static std::unique_ptr<ITypeConverter> create();
-  };
-
-  inline std::unique_ptr<ITypeConverter>
-  DoubleUint32T::create() {
-    return std::make_unique<DoubleUint32T>();
+public:
+  virtual std::string to() const noexcept final {
+    return cpp_enum_type_to_string[toType()];
+  }
+  virtual CppType toType() const noexcept final {
+    return CppType::cpp_uint32_t;
   }
 
+  virtual std::string from() const noexcept final {
+    return cpp_enum_type_to_string[fromType()];
+  }
+  virtual CppType fromType() const noexcept final {
+    return CppType::cpp_double;
+  }
+
+  std::any convert(std::any) final;
+
+  static std::unique_ptr<ITypeConverter> create();
+};
+
+inline std::unique_ptr<ITypeConverter> DoubleUint32T::create() {
+  return std::make_unique<DoubleUint32T>();
 }
 
-#endif // DOUBLE_UINT32_T_HPP 
+} // namespace SDMS
+
+#endif // DOUBLE_UINT32_T_HPP

--- a/common/source/type_converters/StringUint32T.cpp
+++ b/common/source/type_converters/StringUint32T.cpp
@@ -14,29 +14,28 @@
 
 namespace SDMS {
 
-
-  std::any StringUint32T::convert(std::any input) {
-    std::string input_str;
-    try {
-      input_str = std::any_cast<std::string>(input);
-    } catch ( const std::bad_any_cast & e ) {
-      std::string error_msg = "Failed to cast from an any which is supposed ";
-      error_msg += "to be a string.";
-      EXCEPT(1, error_msg);
-    }
-
-    // Sanitize the string
-
-    uint32_t output;
-    try {
-      output = boost::lexical_cast<uint32_t>(input_str);
-    } catch ( const boost::bad_lexical_cast & e) {
-      std::string error_msg = "Failed to cast from an any which is a string ";
-      error_msg += "to a uint32_t. Boost error: ";
-      error_msg += e.what();
-      EXCEPT(1,error_msg); 
-    }
-    return output;
+std::any StringUint32T::convert(std::any input) {
+  std::string input_str;
+  try {
+    input_str = std::any_cast<std::string>(input);
+  } catch (const std::bad_any_cast &e) {
+    std::string error_msg = "Failed to cast from an any which is supposed ";
+    error_msg += "to be a string.";
+    EXCEPT(1, error_msg);
   }
 
+  // Sanitize the string
+
+  uint32_t output;
+  try {
+    output = boost::lexical_cast<uint32_t>(input_str);
+  } catch (const boost::bad_lexical_cast &e) {
+    std::string error_msg = "Failed to cast from an any which is a string ";
+    error_msg += "to a uint32_t. Boost error: ";
+    error_msg += e.what();
+    EXCEPT(1, error_msg);
+  }
+  return output;
 }
+
+} // namespace SDMS

--- a/common/source/type_converters/StringUint32T.cpp
+++ b/common/source/type_converters/StringUint32T.cpp
@@ -1,0 +1,42 @@
+
+// Local private includes
+#include "StringUint32T.hpp"
+
+// Local public includes
+#include "common/TraceException.hpp"
+
+// Third party includes
+#include <boost/lexical_cast.hpp>
+
+// Standard includes
+#include <any>
+#include <string>
+
+namespace SDMS {
+
+
+  std::any StringUint32T::convert(std::any input) {
+    std::string input_str;
+    try {
+      input_str = std::any_cast<std::string>(input);
+    } catch ( const std::bad_any_cast & e ) {
+      std::string error_msg = "Failed to cast from an any which is supposed ";
+      error_msg += "to be a string.";
+      EXCEPT(1, error_msg);
+    }
+
+    // Sanitize the string
+
+    uint32_t output;
+    try {
+      output = boost::lexical_cast<uint32_t>(input_str);
+    } catch ( const boost::bad_lexical_cast & e) {
+      std::string error_msg = "Failed to cast from an any which is a string ";
+      error_msg += "to a uint32_t. Boost error: ";
+      error_msg += e.what();
+      EXCEPT(1,error_msg); 
+    }
+    return output;
+  }
+
+}

--- a/common/source/type_converters/StringUint32T.hpp
+++ b/common/source/type_converters/StringUint32T.hpp
@@ -1,0 +1,50 @@
+#ifndef STRING_UINT32_T_HPP
+#define STRING_UINT32_T_HPP
+#pragma once
+
+// Local public includes
+#include "common/CppTypes.hpp"
+#include "common/ITypeConverter.hpp"
+
+// Standard includes
+#include <any>
+#include <memory>
+#include <string>
+
+namespace SDMS {
+
+  class StringUint32T : public ITypeConverter {
+
+
+    public:
+
+      virtual CppType toType() const noexcept final {
+        return CppType::cpp_uint32_t;
+      }
+
+      virtual std::string to() const noexcept final {
+        return cpp_enum_type_to_string[toType()];
+      }
+
+      virtual CppType fromType() const noexcept final {
+        return CppType::cpp_string;
+      }
+
+      virtual std::string from() const noexcept final {
+        return cpp_enum_type_to_string[fromType()];
+      }
+
+      std::any convert(std::any) final;
+
+  
+      static std::unique_ptr<ITypeConverter> create();
+  };
+
+  inline std::unique_ptr<ITypeConverter>
+  StringUint32T::create() {
+    return std::make_unique<StringUint32T>();
+  }
+
+}
+
+#endif // STRING_UINT32_T_HPP 

--- a/common/source/type_converters/StringUint32T.hpp
+++ b/common/source/type_converters/StringUint32T.hpp
@@ -13,38 +13,34 @@
 
 namespace SDMS {
 
-  class StringUint32T : public ITypeConverter {
+class StringUint32T : public ITypeConverter {
 
-
-    public:
-
-      virtual CppType toType() const noexcept final {
-        return CppType::cpp_uint32_t;
-      }
-
-      virtual std::string to() const noexcept final {
-        return cpp_enum_type_to_string[toType()];
-      }
-
-      virtual CppType fromType() const noexcept final {
-        return CppType::cpp_string;
-      }
-
-      virtual std::string from() const noexcept final {
-        return cpp_enum_type_to_string[fromType()];
-      }
-
-      std::any convert(std::any) final;
-
-  
-      static std::unique_ptr<ITypeConverter> create();
-  };
-
-  inline std::unique_ptr<ITypeConverter>
-  StringUint32T::create() {
-    return std::make_unique<StringUint32T>();
+public:
+  virtual CppType toType() const noexcept final {
+    return CppType::cpp_uint32_t;
   }
 
+  virtual std::string to() const noexcept final {
+    return cpp_enum_type_to_string[toType()];
+  }
+
+  virtual CppType fromType() const noexcept final {
+    return CppType::cpp_string;
+  }
+
+  virtual std::string from() const noexcept final {
+    return cpp_enum_type_to_string[fromType()];
+  }
+
+  std::any convert(std::any) final;
+
+  static std::unique_ptr<ITypeConverter> create();
+};
+
+inline std::unique_ptr<ITypeConverter> StringUint32T::create() {
+  return std::make_unique<StringUint32T>();
 }
 
-#endif // STRING_UINT32_T_HPP 
+} // namespace SDMS
+
+#endif // STRING_UINT32_T_HPP

--- a/common/source/type_converters/StringUint64T.cpp
+++ b/common/source/type_converters/StringUint64T.cpp
@@ -14,29 +14,28 @@
 
 namespace SDMS {
 
-
-  std::any StringUint64T::convert(std::any input) {
-    std::string input_str;
-    try {
-      input_str = std::any_cast<std::string>(input);
-    } catch ( const std::bad_any_cast & e ) {
-      std::string error_msg = "Failed to cast from an any which is supposed ";
-      error_msg += "to be a string.";
-      EXCEPT(1, error_msg);
-    }
-
-    // Sanitize the string
-
-    uint32_t output;
-    try {
-      output = boost::lexical_cast<uint64_t>(input_str);
-    } catch ( const boost::bad_lexical_cast & e) {
-      std::string error_msg = "Failed to cast from an any which is a string ";
-      error_msg += "to a uint64_t. Boost error: ";
-      error_msg += e.what();
-      EXCEPT(1,error_msg); 
-    }
-    return output;
+std::any StringUint64T::convert(std::any input) {
+  std::string input_str;
+  try {
+    input_str = std::any_cast<std::string>(input);
+  } catch (const std::bad_any_cast &e) {
+    std::string error_msg = "Failed to cast from an any which is supposed ";
+    error_msg += "to be a string.";
+    EXCEPT(1, error_msg);
   }
 
+  // Sanitize the string
+
+  uint32_t output;
+  try {
+    output = boost::lexical_cast<uint64_t>(input_str);
+  } catch (const boost::bad_lexical_cast &e) {
+    std::string error_msg = "Failed to cast from an any which is a string ";
+    error_msg += "to a uint64_t. Boost error: ";
+    error_msg += e.what();
+    EXCEPT(1, error_msg);
+  }
+  return output;
 }
+
+} // namespace SDMS

--- a/common/source/type_converters/StringUint64T.cpp
+++ b/common/source/type_converters/StringUint64T.cpp
@@ -1,0 +1,42 @@
+
+// Local private includes
+#include "StringUint64T.hpp"
+
+// Local public includes
+#include "common/TraceException.hpp"
+
+// Third party includes
+#include <boost/lexical_cast.hpp>
+
+// Standard includes
+#include <any>
+#include <string>
+
+namespace SDMS {
+
+
+  std::any StringUint64T::convert(std::any input) {
+    std::string input_str;
+    try {
+      input_str = std::any_cast<std::string>(input);
+    } catch ( const std::bad_any_cast & e ) {
+      std::string error_msg = "Failed to cast from an any which is supposed ";
+      error_msg += "to be a string.";
+      EXCEPT(1, error_msg);
+    }
+
+    // Sanitize the string
+
+    uint32_t output;
+    try {
+      output = boost::lexical_cast<uint64_t>(input_str);
+    } catch ( const boost::bad_lexical_cast & e) {
+      std::string error_msg = "Failed to cast from an any which is a string ";
+      error_msg += "to a uint64_t. Boost error: ";
+      error_msg += e.what();
+      EXCEPT(1,error_msg); 
+    }
+    return output;
+  }
+
+}

--- a/common/source/type_converters/StringUint64T.hpp
+++ b/common/source/type_converters/StringUint64T.hpp
@@ -13,36 +13,32 @@
 
 namespace SDMS {
 
-  class StringUint64T : public ITypeConverter {
+class StringUint64T : public ITypeConverter {
 
-
-    public:
-
-      virtual std::string to() const noexcept  final {
-        return cpp_enum_type_to_string[toType()];
-      }
-      virtual CppType toType() const noexcept final {
-        return CppType::cpp_uint64_t;
-      }
-
-      virtual std::string from() const noexcept final {
-        return cpp_enum_type_to_string[fromType()];
-      }
-      virtual CppType fromType() const noexcept final {
-        return CppType::cpp_string;
-      }
-
-      std::any convert(std::any) final;
-
-      static std::unique_ptr<ITypeConverter> create();
-  };
-
-  inline std::unique_ptr<ITypeConverter>
-  StringUint64T::create() {
-    return std::make_unique<StringUint64T>();
+public:
+  virtual std::string to() const noexcept final {
+    return cpp_enum_type_to_string[toType()];
+  }
+  virtual CppType toType() const noexcept final {
+    return CppType::cpp_uint64_t;
   }
 
+  virtual std::string from() const noexcept final {
+    return cpp_enum_type_to_string[fromType()];
+  }
+  virtual CppType fromType() const noexcept final {
+    return CppType::cpp_string;
+  }
 
+  std::any convert(std::any) final;
+
+  static std::unique_ptr<ITypeConverter> create();
+};
+
+inline std::unique_ptr<ITypeConverter> StringUint64T::create() {
+  return std::make_unique<StringUint64T>();
 }
 
-#endif // STRING_UINT64_T_HPP 
+} // namespace SDMS
+
+#endif // STRING_UINT64_T_HPP

--- a/common/source/type_converters/StringUint64T.hpp
+++ b/common/source/type_converters/StringUint64T.hpp
@@ -1,0 +1,48 @@
+#ifndef STRING_UINT64_T_HPP
+#define STRING_UINT64_T_HPP
+#pragma once
+
+// Local public includes
+#include "common/CppTypes.hpp"
+#include "common/ITypeConverter.hpp"
+
+// Standard includes
+#include <any>
+#include <memory>
+#include <string>
+
+namespace SDMS {
+
+  class StringUint64T : public ITypeConverter {
+
+
+    public:
+
+      virtual std::string to() const noexcept  final {
+        return cpp_enum_type_to_string[toType()];
+      }
+      virtual CppType toType() const noexcept final {
+        return CppType::cpp_uint64_t;
+      }
+
+      virtual std::string from() const noexcept final {
+        return cpp_enum_type_to_string[fromType()];
+      }
+      virtual CppType fromType() const noexcept final {
+        return CppType::cpp_string;
+      }
+
+      std::any convert(std::any) final;
+
+      static std::unique_ptr<ITypeConverter> create();
+  };
+
+  inline std::unique_ptr<ITypeConverter>
+  StringUint64T::create() {
+    return std::make_unique<StringUint64T>();
+  }
+
+
+}
+
+#endif // STRING_UINT64_T_HPP 

--- a/common/tests/unit/CMakeLists.txt
+++ b/common/tests/unit/CMakeLists.txt
@@ -13,6 +13,7 @@ foreach(PROG
     test_ProxyBasicZMQ
     test_SocketFactory
     test_SocketOptions
+    test_TypeConverter
 )
 
   include_directories(${PROJECT_SOURCE_DIR}/common/source)

--- a/common/tests/unit/test_TypeConverter.cpp
+++ b/common/tests/unit/test_TypeConverter.cpp
@@ -1,0 +1,46 @@
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE buffer
+#include <boost/test/unit_test.hpp>
+
+// Local public includes
+#include "common/ITypeConverter.hpp"
+#include "common/TraceException.hpp"
+#include "common/TypeConverterFactory.hpp"
+
+// Standard includes
+#include <iostream>
+#include <limits>
+
+using namespace SDMS;
+
+BOOST_AUTO_TEST_SUITE(TypeConverterTest)
+
+BOOST_AUTO_TEST_CASE(testing_double_to_uint32_t) {
+  TypeConverterFactory factory;
+  auto converter = factory.create(CppType::cpp_double, CppType::cpp_uint32_t);
+  std::any output_any;
+  { // Should pass
+    double input = 0.0;
+    BOOST_CHECK_NO_THROW(output_any = converter->convert(input)); 
+    uint32_t output = std::any_cast<uint32_t>(output_any); 
+    BOOST_CHECK(output == 0);
+  } 
+  { // Should pass
+    double input = 4294967295.0;
+    BOOST_CHECK_NO_THROW(output_any = converter->convert(input)); 
+    uint32_t output = std::any_cast<uint32_t>(output_any); 
+    BOOST_CHECK(output == 4294967295);
+  }
+  { // Should throw
+    double input = 4294967295.0 + 1;
+    BOOST_CHECK_THROW(converter->convert(input), TraceException); 
+  }
+  { // Should throw
+    double input = -0.1;
+    BOOST_CHECK_THROW(converter->convert(input), TraceException); 
+  }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/common/tests/unit/test_TypeConverter.cpp
+++ b/common/tests/unit/test_TypeConverter.cpp
@@ -22,25 +22,24 @@ BOOST_AUTO_TEST_CASE(testing_double_to_uint32_t) {
   std::any output_any;
   { // Should pass
     double input = 0.0;
-    BOOST_CHECK_NO_THROW(output_any = converter->convert(input)); 
-    uint32_t output = std::any_cast<uint32_t>(output_any); 
+    BOOST_CHECK_NO_THROW(output_any = converter->convert(input));
+    uint32_t output = std::any_cast<uint32_t>(output_any);
     BOOST_CHECK(output == 0);
-  } 
+  }
   { // Should pass
     double input = 4294967295.0;
-    BOOST_CHECK_NO_THROW(output_any = converter->convert(input)); 
-    uint32_t output = std::any_cast<uint32_t>(output_any); 
+    BOOST_CHECK_NO_THROW(output_any = converter->convert(input));
+    uint32_t output = std::any_cast<uint32_t>(output_any);
     BOOST_CHECK(output == 4294967295);
   }
   { // Should throw
     double input = 4294967295.0 + 1;
-    BOOST_CHECK_THROW(converter->convert(input), TraceException); 
+    BOOST_CHECK_THROW(converter->convert(input), TraceException);
   }
   { // Should throw
     double input = -0.1;
-    BOOST_CHECK_THROW(converter->convert(input), TraceException); 
+    BOOST_CHECK_THROW(converter->convert(input), TraceException);
   }
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/core/database/foxx/api/data_router.js
+++ b/core/database/foxx/api/data_router.js
@@ -1379,16 +1379,21 @@ router.post('/get', function(req, res) {
                 action: function() {
                     const client = g_lib.getUserFromClientID(req.queryParams.client);
                     var id, res_ids = [];
+                    // The number is the max value for a unit32_t
+                    var retries = 4294967295; 
 
                     if (!req.body.check && !req.body.path)
                         throw [g_lib.ERR_INVALID_PARAM, "Must provide path parameter if not running check."];
+
+                    if (req.retries)
+                      retries = req.retries;
 
                     for (var i in req.body.id) {
                         id = g_lib.resolveDataCollID(req.body.id[i], client);
                         res_ids.push(id);
                     }
 
-                    var result = g_tasks.taskInitDataGet(client, req.body.path, req.body.encrypt, res_ids, req.body.orig_fname, req.body.check);
+                    var result = g_tasks.taskInitDataGet(client, req.body.path, req.body.encrypt, res_ids, req.body.orig_fname, req.body.check, retries);
 
                     if (!req.body.check)
                         g_lib.saveRecentGlobusPath(client, req.body.path, g_lib.TT_DATA_GET);
@@ -1407,6 +1412,7 @@ router.post('/get', function(req, res) {
         path: joi.string().optional(),
         encrypt: joi.number().optional(),
         orig_fname: joi.boolean().optional(),
+        retries: joi.number().optional(),
         check: joi.boolean().optional()
     }).required(), 'Parameters')
     .summary('Get (download) data to Globus destination path')
@@ -1425,6 +1431,12 @@ router.post('/put', function(req, res) {
                     const client = g_lib.getUserFromClientID(req.queryParams.client);
                     var res_ids = [];
 
+                    // The number is the max value for a unit32_t
+                    var retries = 4294967295; 
+
+                    if (req.retries)
+                      retries = req.retries;
+
                     if (!req.body.check && !req.body.path)
                         throw [g_lib.ERR_INVALID_PARAM, "Must provide path parameter if not running check."];
 
@@ -1435,7 +1447,7 @@ router.post('/put', function(req, res) {
                         res_ids.push(g_lib.resolveDataID(req.body.id[i], client));
                     }
 
-                    var result = g_tasks.taskInitDataPut(client, req.body.path, req.body.encrypt, req.body.ext, res_ids, req.body.check);
+                    var result = g_tasks.taskInitDataPut(client, req.body.path, req.body.encrypt, req.body.ext, res_ids, req.body.check, retries);
 
                     if (!req.body.check)
                         g_lib.saveRecentGlobusPath(client, req.body.path, g_lib.TT_DATA_PUT);
@@ -1454,6 +1466,7 @@ router.post('/put', function(req, res) {
         path: joi.string().optional(),
         encrypt: joi.number().optional(),
         ext: joi.string().optional(),
+        retries: joi.number().optional(),
         check: joi.boolean().optional()
     }).required(), 'Parameters')
     .summary('Put (upload) raw data to record')

--- a/core/database/foxx/api/tasks.js
+++ b/core/database/foxx/api/tasks.js
@@ -230,7 +230,7 @@ var tasks_func = function() {
 
     // ----------------------- DATA GET ----------------------------
 
-    obj.taskInitDataGet = function(a_client, a_path, a_encrypt, a_res_ids, a_orig_fname, a_check) {
+    obj.taskInitDataGet = function(a_client, a_path, a_encrypt, a_res_ids, a_orig_fname, a_check, a_retries) {
         console.log("taskInitDataGet");
 
         var result = g_proc.preprocessItems(a_client, null, a_res_ids, g_lib.TT_DATA_GET);
@@ -268,7 +268,8 @@ var tasks_func = function() {
                     encrypt: a_encrypt,
                     orig_fname: a_orig_fname,
                     glob_data: result.glob_data,
-                    ext_data: result.ext_data
+                    ext_data: result.ext_data,
+                    retries: a_retries
                 },
                 task = obj._createTask(a_client._id, g_lib.TT_DATA_GET, 2, state),
                 i, dep_ids = [];
@@ -329,11 +330,20 @@ var tasks_func = function() {
         if (a_task.step < a_task.steps - 1) {
             //console.log("taskRunDataGet - do xfr");
             // Transfer data step
+         
+            // This is only needed if it is an old task and a task entry does
+            // not exist in the database with he retries field
+            // the number is the max value for a unit32_t
+            var a_retries = 4294967295;
+            if (a_task.state.retries) {
+              a_retries = a_task.state.retries;
+            }
 
             var tokens = g_lib.getAccessToken(a_task.client);
             var params = {
                 uid: a_task.client,
                 type: a_task.type,
+                retries: a_retries,
                 encrypt: state.encrypt,
                 acc_tok: tokens.acc_tok,
                 ref_tok: tokens.ref_tok,
@@ -362,7 +372,7 @@ var tasks_func = function() {
 
     // ----------------------- DATA PUT ----------------------------
 
-    obj.taskInitDataPut = function(a_client, a_path, a_encrypt, a_ext, a_res_ids, a_check) {
+    obj.taskInitDataPut = function(a_client, a_path, a_encrypt, a_ext, a_res_ids, a_check, a_retries) {
         console.log("taskInitDataPut");
 
         var result = g_proc.preprocessItems(a_client, null, a_res_ids, g_lib.TT_DATA_PUT);
@@ -376,6 +386,7 @@ var tasks_func = function() {
                 path: a_path,
                 encrypt: a_encrypt,
                 ext: a_ext,
+                retries: a_retries,
                 glob_data: result.glob_data
             };
             var task = obj._createTask(a_client._id, g_lib.TT_DATA_PUT, 2, state);
@@ -433,11 +444,20 @@ var tasks_func = function() {
         if (a_task.step < a_task.steps - 2) {
             //console.log("taskRunDataPut - do xfr");
             // Transfer data step
+          
+            // This is only needed if it is an old task and a task entry does
+            // not exist in the database with he retries field
+            // the number is the max value for a unit32_t
+            var a_retries = 4294967295;
+            if (a_task.state.retries) {
+              a_retries = a_task.state.retries;
+            }
 
             var tokens = g_lib.getAccessToken(a_task.client);
             params = {
                 uid: a_task.client,
                 type: a_task.type,
+                retries: a_retries,
                 encrypt: state.encrypt,
                 acc_tok: tokens.acc_tok,
                 ref_tok: tokens.ref_tok,

--- a/core/server/DatabaseAPI.cpp
+++ b/core/server/DatabaseAPI.cpp
@@ -3136,6 +3136,9 @@ void DatabaseAPI::taskInitDataGet(const Auth::DataGetRequest &a_request,
   if (a_request.has_orig_fname() && a_request.orig_fname())
     body += ",\"orig_fname\":true";
 
+  if (a_request.has_retries())
+    body += ",\"retries\":\"" + to_string(a_request.retries()) + "\"";
+
   if (a_request.has_check() && a_request.check())
     body += ",\"check\":true";
 
@@ -3191,6 +3194,9 @@ void DatabaseAPI::taskInitDataPut(const Auth::DataPutRequest &a_request,
 
   if (a_request.has_ext())
     body += ",\"ext\":\"" + a_request.ext() + "\"";
+
+  if (a_request.has_retries())
+    body += ",\"retries\":\"" + to_string(a_request.retries()) + "\"";
 
   if (a_request.has_check() && a_request.check())
     body += ",\"check\":true";

--- a/core/server/GlobusAPI.cpp
+++ b/core/server/GlobusAPI.cpp
@@ -354,7 +354,7 @@ bool GlobusAPI::checkTransferStatus(const std::string &a_task_id,
 
       // Safely convert double to uint32_t, resp_obj returns a double the
       // converter makes sure that the double fits appropriately into a uint32_t
-      const uint32_t faults = std::any_cast<uint32_t>(double_to_uint32_converter.convert(resp_obj.getNumber("faults")));
+      const uint32_t faults = std::any_cast<uint32_t>(double_to_uint32_converter->convert(resp_obj.getNumber("faults")));
 
       if (faults > retries) {
 

--- a/core/server/GlobusAPI.cpp
+++ b/core/server/GlobusAPI.cpp
@@ -320,7 +320,8 @@ string GlobusAPI::transfer(
 bool GlobusAPI::checkTransferStatus(const std::string &a_task_id,
                                     const std::string &a_acc_tok,
                                     XfrStatus &a_status,
-                                    std::string &a_err_msg) {
+                                    std::string &a_err_msg,
+                                    const uint32_t retries) {
 
   a_status = XS_INIT;
   a_err_msg.clear();
@@ -346,10 +347,14 @@ bool GlobusAPI::checkTransferStatus(const std::string &a_task_id,
     if (status == "ACTIVE") {
 
       double faults = resp_obj.getNumber("faults");
+
+      uint32_t faults_converted;
+      // Safely convert double to uint32_t
+
       if (faults > 0.0) {
 
         DL_WARNING(m_log_context, "faults encountered for task: "
-                                      << a_task_id << " faults " << faults);
+                                      << a_task_id << " faults " << faults << " allowed retries " << retries);
         string raw_result2;
         get(m_curl_xfr, m_config.glob_xfr_url + "task/",
             a_task_id + "/event_list", a_acc_tok, {}, raw_result2);

--- a/core/server/GlobusAPI.cpp
+++ b/core/server/GlobusAPI.cpp
@@ -322,8 +322,7 @@ string GlobusAPI::transfer(
 
 bool GlobusAPI::checkTransferStatus(const std::string &a_task_id,
                                     const std::string &a_acc_tok,
-                                    XfrStatus &a_status,
-                                    std::string &a_err_msg,
+                                    XfrStatus &a_status, std::string &a_err_msg,
                                     const uint32_t retries) {
 
   a_status = XS_INIT;
@@ -331,7 +330,8 @@ bool GlobusAPI::checkTransferStatus(const std::string &a_task_id,
   string raw_result;
 
   TypeConverterFactory factory;
-  auto double_to_uint32_converter = factory.create(CppType::cpp_double, CppType::cpp_uint32_t);
+  auto double_to_uint32_converter =
+      factory.create(CppType::cpp_double, CppType::cpp_uint32_t);
 
   // First check task global status for "SUCEEDED", "FAILED", "INACTIVE"
 
@@ -354,12 +354,14 @@ bool GlobusAPI::checkTransferStatus(const std::string &a_task_id,
 
       // Safely convert double to uint32_t, resp_obj returns a double the
       // converter makes sure that the double fits appropriately into a uint32_t
-      const uint32_t faults = std::any_cast<uint32_t>(double_to_uint32_converter->convert(resp_obj.getNumber("faults")));
+      const uint32_t faults = std::any_cast<uint32_t>(
+          double_to_uint32_converter->convert(resp_obj.getNumber("faults")));
 
       if (faults > retries) {
 
         DL_WARNING(m_log_context, "faults encountered for task: "
-                                      << a_task_id << " faults " << faults << " allowed retries " << retries);
+                                      << a_task_id << " faults " << faults
+                                      << " allowed retries " << retries);
         string raw_result2;
         get(m_curl_xfr, m_config.glob_xfr_url + "task/",
             a_task_id + "/event_list", a_acc_tok, {}, raw_result2);

--- a/core/server/GlobusAPI.hpp
+++ b/core/server/GlobusAPI.hpp
@@ -59,10 +59,8 @@ public:
            const std::vector<std::pair<std::string, std::string>> &a_files,
            bool a_encrypt, const std::string &a_acc_token);
   bool checkTransferStatus(const std::string &a_task_id,
-                           const std::string &a_acc_tok,
-                           XfrStatus &a_status,
-                           std::string &a_err_msg,
-                           const uint32_t retries);
+                           const std::string &a_acc_tok, XfrStatus &a_status,
+                           std::string &a_err_msg, const uint32_t retries);
   void cancelTask(const std::string &a_task_id, const std::string &a_acc_tok);
   void getEndpointInfo(const std::string &a_ep_id,
                        const std::string &a_acc_token, EndpointInfo &a_ep_info);

--- a/core/server/GlobusAPI.hpp
+++ b/core/server/GlobusAPI.hpp
@@ -59,8 +59,10 @@ public:
            const std::vector<std::pair<std::string, std::string>> &a_files,
            bool a_encrypt, const std::string &a_acc_token);
   bool checkTransferStatus(const std::string &a_task_id,
-                           const std::string &a_acc_tok, XfrStatus &a_status,
-                           std::string &a_err_msg);
+                           const std::string &a_acc_tok,
+                           XfrStatus &a_status,
+                           std::string &a_err_msg,
+                           const uint32_t retries);
   void cancelTask(const std::string &a_task_id, const std::string &a_acc_tok);
   void getEndpointInfo(const std::string &a_ep_id,
                        const std::string &a_acc_token, EndpointInfo &a_ep_info);

--- a/core/server/TaskWorker.cpp
+++ b/core/server/TaskWorker.cpp
@@ -172,6 +172,7 @@ TaskWorker::cmdRawDataTransfer(TaskWorker &me, const Value &a_task_params,
   const string &uid = obj.getString("uid");
   TaskType type = (TaskType)obj.getNumber("type");
   Encryption encrypt = (Encryption)obj.getNumber("encrypt");
+  const uint32_t retries = (uint32_t)obj.getNumber("retries");
   const string &src_ep = obj.getString("src_repo_ep");
   const string &src_path = obj.getString("src_repo_path");
   const string &dst_ep = obj.getString("dst_repo_ep");
@@ -247,7 +248,8 @@ TaskWorker::cmdRawDataTransfer(TaskWorker &me, const Value &a_task_params,
       sleep(5);
 
       if (me.m_glob.checkTransferStatus(glob_task_id, acc_tok, xfr_status,
-                                        err_msg)) {
+                                        err_msg,
+                                        retries)) {
         // Transfer task needs to be cancelled
         DL_DEBUG(log_context, "Cancelling task: " << glob_task_id);
         me.m_glob.cancelTask(glob_task_id, acc_tok);

--- a/core/server/TaskWorker.cpp
+++ b/core/server/TaskWorker.cpp
@@ -248,8 +248,7 @@ TaskWorker::cmdRawDataTransfer(TaskWorker &me, const Value &a_task_params,
       sleep(5);
 
       if (me.m_glob.checkTransferStatus(glob_task_id, acc_tok, xfr_status,
-                                        err_msg,
-                                        retries)) {
+                                        err_msg, retries)) {
         // Transfer task needs to be cancelled
         DL_DEBUG(log_context, "Cancelling task: " << glob_task_id);
         me.m_glob.cancelTask(glob_task_id, acc_tok);

--- a/python/datafed_pkg/datafed/CLI.py
+++ b/python/datafed_pkg/datafed/CLI.py
@@ -876,7 +876,7 @@ def _dataCreate(
     repository,
     deps,
     context,
-    retries
+    retries,
 ):
     """
     Create a new data record. The data record 'title' is required, but all
@@ -900,7 +900,7 @@ def _dataCreate(
         error_msg = "Invalid option, cannot specify retries if raw data file"
         error_msg += "has not been specified."
         raise Exception(error_msg)
-    
+
     if retries and external:
         error_msg = "Invalid option, cannot specify retries on external data."
         error_msg += " The data is not transferred when using an external repo."
@@ -932,16 +932,13 @@ def _dataCreate(
         repo_id=repository,
         raw_data_file=raw_data_file,
         external=external,
-        context=context
+        context=context,
     )
     _generic_reply_handler(reply, _print_data)
 
     if raw_data_file and not external:
         click.echo("")
-        reply = _capi.dataPut(
-                reply[0].data[0].id,
-                raw_data_file,
-                retries=retries)
+        reply = _capi.dataPut(reply[0].data[0].id, raw_data_file, retries=retries)
         _generic_reply_handler(reply, _print_task)
 
 
@@ -1048,7 +1045,7 @@ def _dataUpdate(
     deps_add,
     deps_rem,
     context,
-    retries
+    retries,
 ):
     """
     Update an existing data record. The data record ID is required and can be
@@ -1072,7 +1069,7 @@ def _dataUpdate(
         error_msg = "Invalid option, cannot specify retries if raw data file"
         error_msg += "has not been specified."
         raise Exception(error_msg)
-    
+
     if retries and external:
         error_msg = "Invalid option, cannot specify retries on external data."
         error_msg += " The data is not transferred when using an external repo."
@@ -1099,16 +1096,13 @@ def _dataUpdate(
         deps_add=deps_add,
         deps_rem=deps_rem,
         raw_data_file=raw_data_file if external else None,
-        context=context
+        context=context,
     )
     _generic_reply_handler(reply, _print_data)
 
     if raw_data_file and not external:
         click.echo("")
-        reply = _capi.dataPut(
-                reply[0].data[0].id,
-                raw_data_file,
-                retries=retries)
+        reply = _capi.dataPut(reply[0].data[0].id, raw_data_file, retries=retries)
         _generic_reply_handler(reply, _print_task)
 
 
@@ -1195,7 +1189,7 @@ def _dataGet(df_id, path, wait, encrypt, orig_fname, context, retries):
         orig_fname=orig_fname,
         wait=wait,
         context=context,
-        retries=retries
+        retries=retries,
     )
 
     if reply[1] == "DataGetReply":
@@ -1254,7 +1248,7 @@ def _dataPut(data_id, path, wait, extension, encrypt, context, retries):
         wait=wait,
         extension=extension,
         context=context,
-        retries=retries
+        retries=retries,
     )
 
     if reply[1] == "DataPutReply":

--- a/python/datafed_pkg/datafed/CLI.py
+++ b/python/datafed_pkg/datafed/CLI.py
@@ -847,6 +847,17 @@ def _dataView(data_id, context):
         "component of', and 'ver' for 'a new version of'."
     ),
 )
+@click.option(
+    "-q",
+    "--retries",
+    type=int,
+    required=False,
+    help=(
+        "Number of retries allowed before failing when uploading a raw data "
+        "file using Globus. If none is specified will resort to the default "
+        "Globus behavior."
+    ),
+)
 @_global_context_options
 @_global_output_options
 def _dataCreate(
@@ -865,6 +876,7 @@ def _dataCreate(
     repository,
     deps,
     context,
+    retries
 ):
     """
     Create a new data record. The data record 'title' is required, but all
@@ -883,6 +895,16 @@ def _dataCreate(
 
     if repository and external:
         raise Exception("Cannot specify a repository for external raw data.")
+
+    if retries and not raw_data_file:
+        error_msg = "Invalid option, cannot specify retries if raw data file"
+        error_msg += "has not been specified."
+        raise Exception(error_msg)
+    
+    if retries and external:
+        error_msg = "Invalid option, cannot specify retries on external data."
+        error_msg += " The data is not transferred when using an external repo."
+        raise Exception(error_msg)
 
     if metadata and metadata_file:
         raise Exception("Cannot specify both --metadata and --metadata-file options.")
@@ -911,6 +933,7 @@ def _dataCreate(
         raw_data_file=raw_data_file,
         external=external,
         context=context,
+        retries=retries
     )
     _generic_reply_handler(reply, _print_data)
 

--- a/python/datafed_pkg/datafed/CommandLib.py
+++ b/python/datafed_pkg/datafed/CommandLib.py
@@ -692,7 +692,7 @@ class API:
         wait=False,
         timeout_sec=0,
         context=None,
-        retries=None
+        retries=None,
     ):
         """
         Get (download) raw data for one or more data records and/or collections
@@ -821,7 +821,7 @@ class API:
         timeout_sec=0,
         extension=None,
         context=None,
-        retries=None
+        retries=None,
     ):
         """
         Put (upload) raw data for a data record

--- a/python/datafed_pkg/datafed/CommandLib.py
+++ b/python/datafed_pkg/datafed/CommandLib.py
@@ -692,6 +692,7 @@ class API:
         wait=False,
         timeout_sec=0,
         context=None,
+        retries=None
     ):
         """
         Get (download) raw data for one or more data records and/or collections
@@ -726,6 +727,10 @@ class API:
             By default, there is no timeout.
         context : str, Optional. Default = None
             User ID or project ID to use for alias resolution.
+        retries : int, Optional. Default = None
+            The acceptable number of faults to allow before cancelling a Globus
+            transfer, if none is specified will default to the Globus default
+            behavior.
 
         Returns
         -------
@@ -749,6 +754,9 @@ class API:
         for ids in item_id:
             msg.id.append(self._resolve_id(ids, context))
 
+        if retries:
+            msg.retries = retries
+
         reply = self._mapi.sendRecv(msg)
 
         # May initiate multiple transfers - one per repo with multiple records per transfer
@@ -766,6 +774,9 @@ class API:
             msg.path = self._resolvePathForGlobus(path, False)
             msg.encrypt = encrypt
             msg.orig_fname = orig_fname
+
+            if retries:
+                msg.retries = retries
 
             reply = self._mapi.sendRecv(msg)
 
@@ -810,6 +821,7 @@ class API:
         timeout_sec=0,
         extension=None,
         context=None,
+        retries=None
     ):
         """
         Put (upload) raw data for a data record
@@ -839,6 +851,10 @@ class API:
             By default, the extension is detected automatically.
         context : str, Optional. Default = None
             User ID or project ID to use for alias resolution.
+        retries : int, Optional. Default = None
+            The acceptable number of faults to allow before cancelling a Globus
+            transfer, if none is specified will default to the Globus default
+            behavior.
 
         Returns
         -------
@@ -855,6 +871,9 @@ class API:
         msg.encrypt = encrypt
         if extension:
             msg.ext = extension
+
+        if retries:
+            msg.retries = retries
 
         reply = self._mapi.sendRecv(msg)
 


### PR DESCRIPTION
# Description

In the face of network faults, DataFed is canceling tasks. This needs to be controlled with an option. Instead, the default Globus behavior should be used, if a user specifically wants to cancel a transfer after a determined number of faults that is an option they can specify. This is particularly important when first testing a repository and attempting to detect network errors, but it is also useful to cancel tasks early in cases where there is high network traffic and an alternative transfer request to a different Globus endpoint might be preferable.

# Tasks

* [x] - Upgrade version
* [ ] - Changelog comment
* [ ] - Add tests
* [ ] - Feature description
* [ ] - Working tests in ci
* [ ] - Formatting passes
* [ ] - Documentation added
* [x] - Add labels
* [ ] - Assign work
* [x] - Assign expected time

# Work time

Expected time: 24 hours