### PR TITLE
Add fix to admin refresh cert script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## PATCH Bug fixes/Technical Debt/Documentation
 1. [914] - Improve GitHub template
 2. [910] - Static code analysis and status checks fixed, improvements to CI
+3. [923] - Fixed missing flag in certificate refresh script
 
 # v2023.10.23.15.50
 

--- a/scripts/generate_certificate_refresh_script.sh
+++ b/scripts/generate_certificate_refresh_script.sh
@@ -9,7 +9,7 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/..")
 source "${PROJECT_ROOT}/config/datafed.sh"
 
-VERSION="1.0.0"
+VERSION="1.0.1"
 echo "$FILE_NAME $VERSION"
 
 ERROR_DETECTED=0
@@ -54,7 +54,7 @@ cat << OUTER_EOF > "$PROJECT_ROOT/scripts/admin_refresh_certs.sh"
 # and root root
 DOMAIN="${DATAFED_DOMAIN}"
 systemctl stop datafed-ws.service
-lego --email="${DATAFED_LEGO_EMAIL}" --domains="${DATAFED_DOMAIN}" --tls run
+lego --accept-tos --email="${DATAFED_LEGO_EMAIL}" --domains="${DATAFED_DOMAIN}" --tls run
 DIR_NAME=\$(date +%m-%Y)
 mkdir -p "\${DIR_NAME}"
 # Create a copy so we can always go back and check when the last time was


### PR DESCRIPTION
# Description

The admin certificate refresh script is meant to be run non-interactively, but the lego client requires the --accept-tos flag to run non-interactively and this was causing the script to hang. This pr addresses that issue.

# Tasks

* [x] - Assign PR
* [x] - Assign reviewer
* [x] - Add labels
* [x] - Add Changelog line