### PR TITLE
Should throw and error

### DIFF
--- a/repository/server/RequestWorker.cpp
+++ b/repository/server/RequestWorker.cpp
@@ -337,6 +337,7 @@ RequestWorker::procDataGetSizeRequest(std::unique_ptr<IMessage> &&msg_request) {
       data_sz->set_size(0);
       DL_ERROR(message_log_context,
                "DataGetSizeReq - path does not exist: " << item.path());
+      // This should throw an error if the file does not exist
     }
     DL_DEBUG(message_log_context,
              "FILE SIZE: " << data_sz->size() << ", path to collection: "


### PR DESCRIPTION
We need better error reporting when a task fails on the repo server. Currently, there is the problem that if a list command `ls` command is run on a file and it does not exist then success is being reported instead of failure.