### PR TITLE
Bug add missing env variable to compose file.

### DIFF
--- a/compose/repo/compose.yml
+++ b/compose/repo/compose.yml
@@ -45,6 +45,7 @@ services:
       UID: "${DATAFED_UID}"
       HOST_HOSTNAME: "localhost"
       DATAFED_AUTHZ_USER: "datafed"
+      DATAFED_GCS_IP: "${DATAFED_GCS_IP}"
     network_mode: host
     image: datafed-gcs:latest
     volumes:


### PR DESCRIPTION
# Description

The gcs service in the repo compose file was missing an env variable that should have been included. The variable DATAFED_GCS_IP is used to specify the IP address to use when setting up the Globus container. 