### PR TITLE
Add error log output if end-to-end test fails

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ stages:
   - end-to-end-setup-arango
   - end-to-end-setup
   - end-to-end-test
+  - log
   - deploy-pypi-package
 
 # WARNING

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -46,6 +46,21 @@
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" -f ${DOCKER_FILE_PATH} -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
     - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
 
+.error_logs_client_end_to_end:
+  stage: end-to-end-test
+  script:
+    - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
+    - docker logs $(docker ps --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
+  needs:
+    - job: end_to_end_client-test
+      artifacts: false
+  rules:
+    - if: '$CI_JOB_STATUS == "failed" && $CI_JOB_NAME == "end_to_end_client-test"'
+      when: always
+    - when: never
+
+
+
 # Prevents downstream pipeline from being empty and triggering a failure, the
 # build-ws job above may or may not run because of the rules section, if there
 # are no jobs in the pipeline GitLab has the unfortunate behavior of reporting

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -54,6 +54,8 @@
   needs:
     - job: end_to_end_client-test
       artifacts: false
+  rules:
+    - when: always
 
 
 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -51,9 +51,6 @@
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
     - docker logs $(docker ps --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
-  needs:
-    - job: end_to_end_client-test
-      artifacts: false
   rules:
     - when: always
 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -47,17 +47,13 @@
     - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
 
 .error_logs_client_end_to_end:
-  stage: end-to-end-test
+  stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
     - docker logs $(docker ps --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
   needs:
     - job: end_to_end_client-test
       artifacts: false
-  rules:
-    - if: '$CI_JOB_STATUS == "failed" && $CI_JOB_NAME == "end_to_end_client-test"'
-      when: always
-    - when: never
 
 
 

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -359,9 +359,6 @@ end_to_end_error_discovery_arango:
     - ci-datafed-arango
   script:
     - sudo journalctl --no-pager -u arangodb3.service
-  needs:
-    - job: end_to_end_client-test
-      artifacts: false
   rules:
     - when: always
 

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -354,7 +354,7 @@ end_to_end_client-test:
     - cmake --build build --target test
 
 end_to_end_error_discovery_arango:
-  stage: end-to-end-test
+  stage: log
   tags:
     - ci-datafed-arango
   script:
@@ -362,10 +362,6 @@ end_to_end_error_discovery_arango:
   needs:
     - job: end_to_end_client-test
       artifacts: false
-  rules:
-    - if: '$CI_JOB_STATUS == "failed" && $CI_JOB_NAME == "end_to_end_client-test"'
-      when: always
-    - when: never
 
 end_to_end_error_discovery_gcs:
   extends: .error_logs_client_end_to_end

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -362,6 +362,8 @@ end_to_end_error_discovery_arango:
   needs:
     - job: end_to_end_client-test
       artifacts: false
+  rules:
+    - when: always
 
 end_to_end_error_discovery_gcs:
   extends: .error_logs_client_end_to_end

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -352,3 +352,49 @@ end_to_end_client-test:
     - cmake --build build
     - cmake --build build --target pydatafed
     - cmake --build build --target test
+
+end_to_end_error_discovery_arango:
+  stage: end-to-end-test
+  tags:
+    - ci-datafed-arango
+  script:
+    - sudo journalctl --no-pager -u arangodb3.service
+  needs:
+    - job: end_to_end_client-test
+      artifacts: false
+  rules:
+    - if: '$CI_JOB_STATUS == "failed" && $CI_JOB_NAME == "end_to_end_client-test"'
+      when: always
+    - when: never
+
+end_to_end_error_discovery_gcs:
+  extends: .error_logs_client_end_to_end
+  variables:
+    IMAGE_TAG: "datafed/gcs-"
+  tags:
+    - ci-datafed-globus
+    - docker
+
+end_to_end_error_discovery_repo:
+  extends: .error_logs_client_end_to_end
+  variables:
+    IMAGE_TAG: "datafed/repo-"
+  tags:
+    - ci-datafed-globus
+    - docker
+
+end_to_end_error_discovery_core:
+  extends: .error_logs_client_end_to_end
+  variables:
+    IMAGE_TAG: "datafed/core-"
+  tags:
+    - ci-datafed-core
+    - docker
+
+end_to_end_error_discovery_web:
+  extends: .error_logs_client_end_to_end
+  variables:
+    IMAGE_TAG: "datafed/ws-"
+  tags:
+    - ci-datafed-core
+    - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 5. [937] - Working metadata services running together as part of CI
 6. [946] - Added docker compose for DataFed Repository and for Metadata Services
 7. [955] - Adds repo pieces to CI with working end-to-end tests
+8. [973] - Adds log output at the end of CI test pipeline
 
 ## PATCH Bug fixes/Technical Debt/Documentation
 

--- a/python/datafed_pkg/datafed/MessageLib.py
+++ b/python/datafed_pkg/datafed/MessageLib.py
@@ -22,14 +22,16 @@ from . import VERSION
 
 # Function to check if a string contains any letters
 def contains_letters(s):
-    return bool(re.search('[a-zA-Z]', s))
+    return bool(re.search("[a-zA-Z]", s))
+
 
 def remove_after_prefix_with_numbers(s):
     # Use regular expression to match the prefix with numbers
-    match = re.match(r'(\d+.*?)(\D.*)', s)
+    match = re.match(r"(\d+.*?)(\D.*)", s)
     if match:
         return match.group(1)  # Return the part before the remaining string
     return s  # If no match is found, return the original string
+
 
 # Check with pypi if a newer release is available, only look for stable
 # versions
@@ -41,8 +43,7 @@ def get_latest_stable_version(package_name):
         # Filter the list to remove entries that contain any letters, we don't
         # want to look at entries that could be a pre-release of some sort and
         # recommend that the user use for instance a beta version.
-        releases = [release for release in releases if not 
-                    contains_letters(release)]
+        releases = [release for release in releases if not contains_letters(release)]
         if not releases:
             return None
 
@@ -234,7 +235,9 @@ class API:
                 "Incompatible server api detected {}.{}.{}, you are running "
                 "{}.{}.{} consider "
                 "upgrading the datafed python client.".format(
-                    reply.api_major, reply.api_minor, reply.api_patch,
+                    reply.api_major,
+                    reply.api_minor,
+                    reply.api_patch,
                     Version_pb2.DATAFED_COMMON_PROTOCOL_API_MAJOR,
                     Version_pb2.DATAFED_COMMON_PROTOCOL_API_MINOR,
                     Version_pb2.DATAFED_COMMON_PROTOCOL_API_PATCH,

--- a/python/datafed_pkg/setup.py
+++ b/python/datafed_pkg/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt", "r") as f:
     install_requires = [line.strip() for line in f]
 
 setuptools.setup(
-    name=os.getenv('DATAFED_PYPI_REPO', "datafed"),
+    name=os.getenv("DATAFED_PYPI_REPO", "datafed"),
     version=__version__,
     author="Dale Stansberry, Joshua Brown",
     author_email="stansberrydv@ornl.gov, brownjs@ornl.gov",


### PR DESCRIPTION
If the CI end to end test fails we want to see the log output of all of the containers this pr addresses this problem.