### PR TITLE
Joshua s brown dylan server default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 13. [956] - Adds improved error message, when paths of repo don't align.
 14. [966] - CI refactor check that containers exist if not force build for branch.
 15. [968] - Fixes bug by creating distinction between base and root path.
+16. [984] - Fixes {server_default} from showing up in path.
 
 # v2023.10.23.15.50
 

--- a/web/static/dlg_start_xfer.js
+++ b/web/static/dlg_start_xfer.js
@@ -124,6 +124,7 @@ export function show( a_mode, a_ids, a_cb ) {
                     cur_ep = data;
                     cur_ep.name = cur_ep.canonical_name || cur_ep.id;
                     path_in.val( cur_ep.name + (cur_ep.default_directory?cur_ep.default_directory:"/"));
+                    path_in.val(path_in.val().replace("{server_default}/",''))
                     updateEndpointOptions( cur_ep );
                 }else{
                     dialogs.dlgAlert("Globus Error", data );


### PR DESCRIPTION
Removed the {server_default} piece of the path_in.val variable when choosing an endpoint in the xfer dialog. A simple .replace function was placed after it populates to remove the unnecessary text.

<img width="697" alt="image" src="https://github.com/user-attachments/assets/3b16f53a-f8c2-40e1-8cb9-45fd42e4ff1f">

 
![image](https://github.com/user-attachments/assets/a6838410-def6-4c9f-b414-feb4edcc9636)
