### PR TITLE
Joshua s brown stop containers before clearing

### DIFF
--- a/.gitlab/stage_clear_cache.yml
+++ b/.gitlab/stage_clear_cache.yml
@@ -6,6 +6,7 @@
 .clear_cache:
   script:
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
+    - docker stop $(docker ps -q)
     - docker system prune -f
     - ./scripts/ci_purge_images.sh
 

--- a/.gitlab/stage_clear_cache.yml
+++ b/.gitlab/stage_clear_cache.yml
@@ -6,7 +6,7 @@
 .clear_cache:
   script:
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
-    - if [[ $(docker ps | wc -l) != "0" ]]; then docker stop $(docker ps -q); fi;
+    - if [[ $(docker ps -q | wc -l) != "0" ]]; then docker stop $(docker ps -q); fi;
     - docker system prune -f
     - ./scripts/ci_purge_images.sh
 

--- a/.gitlab/stage_clear_cache.yml
+++ b/.gitlab/stage_clear_cache.yml
@@ -6,7 +6,7 @@
 .clear_cache:
   script:
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
-    - docker stop $(docker ps -q)
+    - if [[ $(docker ps | wc -l) != "0" ]]; then docker stop $(docker ps -q); fi;
     - docker system prune -f
     - ./scripts/ci_purge_images.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## PATCH Bug fixes/Technical Debt/Documentation
 1. [984] - Fixes {server_default} from showing up in path.
+2. [990] - Will stop running containers so that we can prune them.
 
 # v2024.6.17.10.40
 


### PR DESCRIPTION
# Description

There is currently a problem with the CI pipelines. Several jobs are run to make sure there is enough disk space on the machines. Including running docker system prune. However, this will fail if any of the images are being used by a currently running container.

The error message we encounter is:

```
Image size is 17.29GB
Error response from daemon: conflict: unable to delete 9e543059b1a5 (cannot be forced) - image is being used by running container 2c8ed6ef3694
docker_size_stats
Image size is 17.29GB
Error response from daemon: conflict: unable to delete 9e543059b1a5 (cannot be forced) - image is being used by running container 2c8ed6ef3694
docker_size_stats
```

To fix this we will first stop all the containers.