### PR TITLE
Fix docker push tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,7 +194,7 @@ build-ws:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" -f web/docker/Dockerfile -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 build-core:
   needs: ["build-dependencies", "build-runtime"]
@@ -221,7 +221,7 @@ build-core:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" -f core/docker/Dockerfile -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 build-repo:
   needs: ["build-dependencies", "build-runtime"]
@@ -246,7 +246,7 @@ build-repo:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" -f repository/docker/Dockerfile -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 build-gcs-base:
   needs: ["build-dependencies", "build-runtime"]
@@ -275,7 +275,7 @@ build-gcs-base:
     - git checkout "$DATAFED_GCS_SUBMODULE_VERSION"
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
     - docker build --progress plain -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" - < "./docker-files/Dockerfile.ubuntu-20.04"
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 build-gcs:
   needs: ["build-dependencies", "build-runtime", "build-gcs-base"]
@@ -303,7 +303,7 @@ build-gcs:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" --build-arg GCS_IMAGE="${REGISTRY}/datafed/gcs-base-${BRANCH_LOWER}:latest" -f repository/docker/Dockerfile.gcs -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 build-python-client-base:
   needs: ["clear-python-client-cache"]
@@ -345,7 +345,7 @@ build-foxx:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" -f docker/Dockerfile.foxx -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 
 ################################################################################

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
     instead of the auth_client.
 11. [953] - Refactored docker compose build scripts to address technical debt.
 12. [956] - Adds improved error message, when paths of repo don't align.
+13. [997] - Fixes CI pipeline missing :latest tag when pushing to registry
 
 # v2023.10.23.15.50
 

--- a/python/datafed_pkg/datafed/MessageLib.py
+++ b/python/datafed_pkg/datafed/MessageLib.py
@@ -22,11 +22,11 @@ from . import VERSION
 
 # Function to check if a string contains any letters
 def contains_letters(s):
-    return bool(re.search('[a-zA-Z]', s))
+    return bool(re.search("[a-zA-Z]", s))
 
 def remove_after_prefix_with_numbers(s):
     # Use regular expression to match the prefix with numbers
-    match = re.match(r'(\d+.*?)(\D.*)', s)
+    match = re.match(r"(\d+.*?)(\D.*)", s)
     if match:
         return match.group(1)  # Return the part before the remaining string
     return s  # If no match is found, return the original string
@@ -41,8 +41,7 @@ def get_latest_stable_version(package_name):
         # Filter the list to remove entries that contain any letters, we don't
         # want to look at entries that could be a pre-release of some sort and
         # recommend that the user use for instance a beta version.
-        releases = [release for release in releases if not 
-                    contains_letters(release)]
+        releases = [rel for rel in releases if not contains_letters(rel)]
         if not releases:
             return None
 
@@ -234,7 +233,9 @@ class API:
                 "Incompatible server api detected {}.{}.{}, you are running "
                 "{}.{}.{} consider "
                 "upgrading the datafed python client.".format(
-                    reply.api_major, reply.api_minor, reply.api_patch,
+                    reply.api_major,
+                    reply.api_minor,
+                    reply.api_patch,
                     Version_pb2.DATAFED_COMMON_PROTOCOL_API_MAJOR,
                     Version_pb2.DATAFED_COMMON_PROTOCOL_API_MINOR,
                     Version_pb2.DATAFED_COMMON_PROTOCOL_API_PATCH,

--- a/python/datafed_pkg/setup.py
+++ b/python/datafed_pkg/setup.py
@@ -13,7 +13,7 @@ with open("requirements.txt", "r") as f:
     install_requires = [line.strip() for line in f]
 
 setuptools.setup(
-    name=os.getenv('DATAFED_PYPI_REPO', "datafed"),
+    name=os.getenv("DATAFED_PYPI_REPO", "datafed"),
     version=__version__,
     author="Dale Stansberry, Joshua Brown",
     author_email="stansberrydv@ornl.gov, brownjs@ornl.gov",


### PR DESCRIPTION
# Description

In installing a DataFed repo at Drexel, it was discovered that there were problems with the image containers. It turns out that the release CI pipelines were missing the :latest tag when pushing to the registry. This was causing the end-to-end tests to give false positives in the pipelines. It is fixed in the devel branch because the CI pipeline files were refactored. Merging this should cause the CI pipelines to reproduce the errors that Drexel and LeHigh were observing.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the CI pipeline to include the ':latest' tag when pushing Docker images to the registry, addressing issues with image versioning and ensuring accurate end-to-end test results.

CI:
- Add the ':latest' tag to Docker image pushes in the CI pipeline to ensure the latest version is correctly tagged and pushed to the registry.

<!-- Generated by sourcery-ai[bot]: end summary -->