### PR TITLE
Add latest tag

### DIFF
--- a/.gitlab/build/build_gcs_base_image.yml
+++ b/.gitlab/build/build_gcs_base_image.yml
@@ -31,7 +31,7 @@ build-gcs-base:
     - git checkout "$DATAFED_GCS_SUBMODULE_VERSION"
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - docker build --progress plain -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" - < "./docker-files/Dockerfile.ubuntu-20.04"
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 placeholder:
   extends: .placeholder

--- a/.gitlab/build/build_gcs_image.yml
+++ b/.gitlab/build/build_gcs_image.yml
@@ -30,7 +30,7 @@ build-gcs:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" --build-arg GCS_IMAGE="${REGISTRY}/datafed/gcs-base-${BRANCH_LOWER}:latest" -f repository/docker/Dockerfile.gcs -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 placeholder:
   extends: .placeholder

--- a/.gitlab/build/force_build_gcs_base_image.yml
+++ b/.gitlab/build/force_build_gcs_base_image.yml
@@ -19,4 +19,4 @@ build-gcs-base:
     - git checkout "$DATAFED_GCS_SUBMODULE_VERSION"
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - docker build --progress plain -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" - < "./docker-files/Dockerfile.ubuntu-20.04"
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"

--- a/.gitlab/build/force_build_gcs_image.yml
+++ b/.gitlab/build/force_build_gcs_image.yml
@@ -16,4 +16,4 @@ build-gcs:
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" --build-arg GCS_IMAGE="${REGISTRY}/datafed/gcs-base-${BRANCH_LOWER}:latest" -f repository/docker/Dockerfile.gcs -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -44,7 +44,7 @@
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - docker build --build-arg DEPENDENCIES="${REGISTRY}/datafed/dependencies-${BRANCH_LOWER}:latest" --build-arg RUNTIME="${REGISTRY}/datafed/runtime-${BRANCH_LOWER}:latest" -f ${DOCKER_FILE_PATH} -t "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest" .
-    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}"
+    - docker push "${REGISTRY}/${IMAGE_TAG}-${BRANCH_LOWER}:latest"
 
 .error_logs_client_end_to_end:
   stage: log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 18. [995] - Fixes issue with project and user folders in repo being created under root user permissions.
 19. [994] - Fixes issue with spaces not being preserved in shell scripts from docker compose .env file.
 20. [996] - Fixes bug in lego install script where function name had additional s
+21. [998] - Fixing missing :latest tag on push in container, in common.yml of ci files
 
 # v2023.10.23.15.50
 


### PR DESCRIPTION
# Description

In installing a DataFed repo at Drexel, it was discovered that there were problems with the image containers. It turns out that the release CI pipelines were missing the :latest tag when pushing to the registry. This was causing the end-to-end tests to give false positives in the pipelines. It is fixed in the devel branch because the CI pipeline files were refactored. Merging this should cause the CI pipelines to reproduce the errors that Drexel and LeHigh were observing.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add the :latest tag to Docker image pushes in CI pipeline scripts to ensure the latest version is tagged correctly, and update the changelog to reflect this change.

CI:
- Add the :latest tag to Docker image pushes in CI pipeline scripts to ensure the latest version is tagged correctly.

Documentation:
- Update CHANGELOG.md to include the fix for the missing :latest tag in CI pipeline scripts.

<!-- Generated by sourcery-ai[bot]: end summary -->