### PR TITLE
Append to log file instead of rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ## PATCH Bug fixes/Technical Debt/Documentation
 
-
 # v2024.6.17.10.40
 
 ## MAJOR Breaking changes
@@ -31,7 +30,7 @@
 2. [910] - Static code analysis and status checks fixed, improvements to CI
 3. [923] - Fixed missing flag in certificate refresh script
 4. [917] - Add additional files to .gitignore
-5. [915] - Refactor CI to use pipelines Gitlab feature along with pipelines 
+5. [915] - Refactor CI to use pipelines Gitlab feature along with pipelines
 6. [927] - Add vim swp files to .gitignore
 7. [935] - Fixed CI branching with dynamic children, swiched to Harbor registry.
    Moved Blake's files into the correct folders.
@@ -51,12 +50,13 @@
 19. [994] - Fixes issue with spaces not being preserved in shell scripts from docker compose .env file.
 20. [996] - Fixes bug in lego install script where function name had additional s
 21. [998] - Fixing missing :latest tag on push in container, in common.yml of ci files
+22. [999] - Fixes repo service entrypoint script to append to log file instead of rewriting
 
 # v2023.10.23.15.50
 
 ## MINOR Feature
 
-1. [906] - Added backup and cert refresh scripts. 
+1. [906] - Added backup and cert refresh scripts.
 
 ## PATCH Bug Fixes/Technical Debt/Documentation
 

--- a/repository/docker/entrypoint_repo.sh
+++ b/repository/docker/entrypoint_repo.sh
@@ -11,42 +11,38 @@ PROJECT_ROOT=$(realpath "${SOURCE}/../..")
 
 # This is only part of the solution the other part is running chown
 if [ -n "$UID" ]; then
-    echo "Switching datafed user to UID: ${UID}"
-    usermod -u "$UID" datafed
-    chown -R datafed:root "${PROJECT_ROOT}"
-    chown -R datafed:root "${DATAFED_INSTALL_PATH}/repo/"
-    # Make sure the folder exists
-    mkdir -p "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
-    chown -R datafed:root "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
+	echo "Switching datafed user to UID: ${UID}"
+	usermod -u "$UID" datafed
+	chown -R datafed:root "${PROJECT_ROOT}"
+	chown -R datafed:root "${DATAFED_INSTALL_PATH}/repo/"
+	# Make sure the folder exists
+	mkdir -p "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
+	chown -R datafed:root "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
 fi
-
 
 log_path="$DATAFED_DEFAULT_LOG_PATH"
 
-if [ ! -d "${log_path}" ]
-then
-  su -c "mkdir -p ${log_path}" datafed
+if [ ! -d "${log_path}" ]; then
+	su -c "mkdir -p ${log_path}" datafed
 fi
 
-if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]
-then
-  echo "datafed-core-key.pub not found, downloading from the core server"
-  wget --no-check-certificate "https://${DATAFED_DOMAIN}/datafed-core-key.pub" -P "${DATAFED_INSTALL_PATH}/keys/"
+if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]; then
+	echo "datafed-core-key.pub not found, downloading from the core server"
+	wget --no-check-certificate "https://${DATAFED_DOMAIN}/datafed-core-key.pub" -P "${DATAFED_INSTALL_PATH}/keys/"
 fi
 
 datafed_repo_exec=$(basename "$1")
-if [ "${datafed_repo_exec}" = "datafed-repo" ]
-then
-  # Send output to log file
-  # For this to work all commands must be passed in as a single string
-  su datafed -c '"$@"' -- argv0 "$@" 2>&1 | tee "$log_path/datafed-repo.log"
+if [ "${datafed_repo_exec}" = "datafed-repo" ]; then
+	# Send output to log file
+	# For this to work all commands must be passed in as a single string
+	su datafed -c '"$@"' -- argv0 "$@" 2>&1 | tee "$log_path/datafed-repo.log"
 else
-  echo "Not sending output to datafed-core.log"
-  # If not do not by default send to log file
-  su datafed -c '"$@"' -- argv0 "$@"
+	echo "Not sending output to datafed-core.log"
+	# If not do not by default send to log file
+	su datafed -c '"$@"' -- argv0 "$@"
 fi
 
-# Allow the container to exist for a bit in case we need to jump in and look 
+# Allow the container to exist for a bit in case we need to jump in and look
 # around
 echo "Container sleeping"
 sleep 10000

--- a/repository/docker/entrypoint_repo.sh
+++ b/repository/docker/entrypoint_repo.sh
@@ -35,7 +35,7 @@ datafed_repo_exec=$(basename "$1")
 if [ "${datafed_repo_exec}" = "datafed-repo" ]; then
 	# Send output to log file
 	# For this to work all commands must be passed in as a single string
-	su datafed -c '"$@"' -- argv0 "$@" 2>&1 | tee "$log_path/datafed-repo.log"
+	su datafed -c '"$@"' -- argv0 "$@" 2>&1 | tee -a "$log_path/datafed-repo.log"
 else
 	echo "Not sending output to datafed-core.log"
 	# If not do not by default send to log file


### PR DESCRIPTION
As discussed in yesterday's meeting. There are two commits here, since I ran `shfmt` on the script for good measure, but I kept the meaningful change (adding `-a`) in a commit of its own.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the logging functionality by appending to the log file instead of overwriting it, and reformat the script for improved readability.

Enhancements:
- Modify the logging mechanism to append to the log file instead of overwriting it, ensuring that log data is preserved across multiple runs.

Chores:
- Reformat the script using 'shfmt' for consistent code style and readability improvements.

<!-- Generated by sourcery-ai[bot]: end summary -->