### PR TITLE
ArangoDB script error behavior

### DIFF
--- a/.gitlab/build/build_gcs_base_image.yml
+++ b/.gitlab/build/build_gcs_base_image.yml
@@ -38,7 +38,7 @@ build-gcs-base:
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"
     - |
-      while [ "$(./scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
+      while [ "$(${CI_BUILDS_DIR}/scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
         echo "Artifact missing from harbor..."
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"

--- a/.gitlab/build/force_build_gcs_base_image.yml
+++ b/.gitlab/build/force_build_gcs_base_image.yml
@@ -26,7 +26,7 @@ build-gcs-base:
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"
     - |
-      while [ "$(./scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
+      while [ "$(${CI_BUILDS_DIR}/scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
         echo "Artifact missing from harbor..."
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"

--- a/scripts/run_arango_service.sh
+++ b/scripts/run_arango_service.sh
@@ -12,7 +12,11 @@ if [[ ! -z $systemctl_exists ]]
 then
   sudo systemctl daemon-reload
 
+  # Turn off exit - on non zero exit code for the below command, we don't want
+  # it to exit if arangodb is not reported as active.
+  set +e
   arango_status=$(systemctl is-active arangodb3.service)
+  set -e
   if [ ! "active" = "$arango_status" ]
   then
     sudo systemctl restart arangodb3.service


### PR DESCRIPTION
surround systemctl call with set +e and set -e to prevent incorrect erroring behavior

## Summary by Sourcery

Bug Fixes:
- Prevent script from exiting on non-zero exit code when checking the status of arangodb3.service.