### PR TITLE
Make path absolute when using ci script

### DIFF
--- a/.gitlab/build/build_gcs_base_image.yml
+++ b/.gitlab/build/build_gcs_base_image.yml
@@ -38,7 +38,7 @@ build-gcs-base:
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"
     - |
-      while [ "$(./scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
+      while [ "$(${CI_BUILDS_DIR}/scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
         echo "Artifact missing from harbor..."
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"

--- a/.gitlab/build/force_build_gcs_base_image.yml
+++ b/.gitlab/build/force_build_gcs_base_image.yml
@@ -26,7 +26,7 @@ build-gcs-base:
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"
     - |
-      while [ "$(./scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
+      while [ "$(${CI_BUILDS_DIR}/scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
         echo "Artifact missing from harbor..."
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"


### PR DESCRIPTION
## Summary by Sourcery

https://github.com/ORNL/DataFed/issues/1015

CI:
- Update CI script to use an absolute path for the ci_harbor_artifact_count.sh script.