### PR TITLE
[Compose] 1012 docker build arg base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cmake/sodium_version
 cmake/curl_version
 cmake/zlib_version
 common/proto/common/Version.proto
+compose/metadata/.build-args
 compose/**/.env
 compose/**/.env*
 compose/**/globus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 8. [1011] - Add python script and ci job to clean up GCS node keys.
 9. [1023] - Address unbound variables in harbor ci script.
 10. [1027] - Fix clear_db.sh script by replacing console.log with print
+11. [1012] - Allow customized base build image for Docker dependencies and runtime Dockerfiles
 
 # v2024.6.17.10.40
 

--- a/compose/metadata/build_metadata_images_for_compose.sh
+++ b/compose/metadata/build_metadata_images_for_compose.sh
@@ -6,4 +6,25 @@ SCRIPT=$(realpath "$0")
 SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 
-"${PROJECT_ROOT}/scripts/compose_build_images.sh" -m
+BUILD_ARG_FILE="$SOURCE/.build-args"
+if [ $# -gt 0 ]; then
+    # Do not check if file already exists becuase other generate scripts
+    # from a different repo might have already put their args in the file
+    # and calling this script might be the second step. Where this step would
+    # be appending to an existing file.
+    BUILD_ARG_FILE="$1/.build-args"
+fi
+
+# Generate arg list
+
+if [ ! -f "$BUILD_ARG_FILE" ]
+then
+  echo "Missing .build-args file, please run generate_build_args.sh first."
+fi
+
+# Load the variables from the build_args
+. ./.build-args
+
+echo "BASE_IMAGE is $BASE_IMAGE"
+
+"${PROJECT_ROOT}/scripts/compose_build_images.sh" -m -b "$BASE_IMAGE"

--- a/compose/metadata/build_metadata_images_for_compose.sh
+++ b/compose/metadata/build_metadata_images_for_compose.sh
@@ -23,7 +23,7 @@ then
 fi
 
 # Load the variables from the build_args
-. ./.build-args
+. "$BUILD_ARG_FILE"
 
 echo "BASE_IMAGE is $BASE_IMAGE"
 

--- a/compose/metadata/generate_build_args.sh
+++ b/compose/metadata/generate_build_args.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Description
+#
+# The point of this file is to generate a .build-args file. The .build-args
+# file contains variables that are used when building the docker images.
+#
+# Example
+#
+# ./generate_build_args.sh
+
+SCRIPT=$(realpath "$0")
+SOURCE=$(dirname "$SCRIPT")
+
+BUILD_ARG_FILE="$SOURCE/.build-args"
+if [ $# -gt 0 ]; then
+  # Do not check if file already exists becuase other generate scripts
+  # from a different repo might have already put their args in the file
+  # and calling this script might be the second step. Where this step would
+  # be appending to an existing file.
+  BUILD_ARG_FILE="$1/.build-args"
+else
+
+  # Force the user to manaully rm the file to avoid accidental overwrites.
+  if [ -f "$BUILD_ARG_FILE" ]
+  then
+    echo "$BUILD_ARG_FILE already exist! Will not overwrite!"
+    exit 0
+  fi
+fi
+
+# Needs to append to the ./build-args.sh file not overwrite.
+cat << EOF >> "$BUILD_ARG_FILE"
+BASE_IMAGE=ubuntu:focal
+EOF

--- a/docker/Dockerfile.dependencies
+++ b/docker/Dockerfile.dependencies
@@ -4,8 +4,9 @@ ARG DATAFED_DEPENDENCIES_INSTALL_PATH="/opt/datafed/dependencies"
 ARG            GCS_IMAGE="code.ornl.gov:4567/dlsw/datafed/gcs-ubuntu-focal"
 ARG            BUILD_DIR="$DATAFED_DIR/source"
 ARG              LIB_DIR="/opt/datafed/dependencies/lib"
+ARG           BASE_IMAGE="ubuntu:focal"
 
-FROM ubuntu:focal
+FROM ${BASE_IMAGE} AS base
 
 SHELL ["/bin/bash", "-c"]
 ARG DATAFED_DIR

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -3,8 +3,9 @@ ARG DATAFED_INSTALL_PATH="/opt/datafed"
 ARG            GCS_IMAGE="code.ornl.gov:4567/dlsw/datafed/gcs-ubuntu-focal"
 ARG            BUILD_DIR="$DATAFED_DIR/source"
 ARG              LIB_DIR="/usr/local/lib"
+ARG           BASE_IMAGE="ubuntu:focal"
 
-FROM ubuntu:focal
+FROM ${BASE_IMAGE} AS base
 
 SHELL ["/bin/bash", "-c"]
 ARG DATAFED_DIR

--- a/scripts/compose_build_images.sh
+++ b/scripts/compose_build_images.sh
@@ -10,18 +10,22 @@ Help()
 {
   echo "$(basename $0) Build images for compose run by default will build all."
   echo
-  echo "Syntax: $(basename $0) [-h|r|m]"
+  echo "Syntax: $(basename $0) [-h|r|m|b]"
   echo "options:"
   echo "-h, --help                        Print this help message"
   echo "-r, --repo-images                 Build the repository images for "
   echo "                                  datafed."
   echo "-m, --metadata-images             Build the images for metadata services."
+  echo "-b, --base-image                  Specify the base image to build off of"
+  echo "                                  may be necessary if specific certs "
+  echo "                                  are required."
 }
 
-VALID_ARGS=$(getopt -o hmr --long 'help',repo-images,metadata-images -- "$@")
+VALID_ARGS=$(getopt -o hmrb: --long 'help',repo-images,metadata-images,base-image: -- "$@")
 
 BUILD_REPO="TRUE"
 BUILD_METADATA="TRUE"
+BASE_IMAGE=""
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   case "$1" in
@@ -37,6 +41,11 @@ while [ : ]; do
         BUILD_REPO="FALSE"
         shift 1
         ;;
+    -b | --base-image)
+        echo "BASE"
+        BASE_IMAGE="$2"
+        shift 2
+        ;;
     --) shift; 
         break 
         ;;
@@ -46,17 +55,30 @@ while [ : ]; do
   esac
 done
 
-
 if [[ "$BUILD_METADATA" == "TRUE" ]]
 then
-  docker build \
-    -f "${PROJECT_ROOT}/docker/Dockerfile.dependencies" \
-    "${PROJECT_ROOT}" \
-    -t datafed-dependencies:latest
-  docker build \
-    -f "${PROJECT_ROOT}/docker/Dockerfile.runtime" \
-    "${PROJECT_ROOT}" \
-    -t datafed-runtime:latest
+  if [ "$BASE_IMAGE" == "" ]
+  then
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.dependencies" \
+      "${PROJECT_ROOT}" \
+      -t datafed-dependencies:latest
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.runtime" \
+      "${PROJECT_ROOT}" \
+      -t datafed-runtime:latest
+  else
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.dependencies" \
+      "${PROJECT_ROOT}" \
+      --build-arg BASE_IMAGE=$BASE_IMAGE \
+      -t datafed-dependencies:latest
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.runtime" \
+      "${PROJECT_ROOT}" \
+      --build-arg BASE_IMAGE=$BASE_IMAGE \
+      -t datafed-runtime:latest
+  fi
   docker build -f \
     "${PROJECT_ROOT}/core/docker/Dockerfile" \
     --build-arg DEPENDENCIES="datafed-dependencies" \
@@ -84,14 +106,29 @@ then
   git checkout "$DATAFED_GCS_SUBMODULE_VERSION"
   docker build --progress plain --tag "gcs-ubuntu-base:latest" - < "./docker-files/Dockerfile.ubuntu-20.04"
   cd "${PROJECT_ROOT}"
-  docker build \
-    -f "${PROJECT_ROOT}/docker/Dockerfile.dependencies" \
-    "${PROJECT_ROOT}" \
-    -t datafed-dependencies:latest
-  docker build \
-    -f "${PROJECT_ROOT}/docker/Dockerfile.runtime" \
-    "${PROJECT_ROOT}" \
-    -t datafed-runtime:latest
+  if [ "$BASE_IMAGE" == "" ]
+  then
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.dependencies" \
+      "${PROJECT_ROOT}" \
+      -t datafed-dependencies:latest
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.runtime" \
+      "${PROJECT_ROOT}" \
+      -t datafed-runtime:latest
+  else
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.dependencies" \
+      "${PROJECT_ROOT}" \
+      --build-arg BASE_IMAGE=$BASE_IMAGE \
+      -t datafed-dependencies:latest
+    docker build \
+      -f "${PROJECT_ROOT}/docker/Dockerfile.runtime" \
+      "${PROJECT_ROOT}" \
+      --build-arg BASE_IMAGE=$BASE_IMAGE \
+      -t datafed-runtime:latest
+
+  fi
   docker build -f \
     "${PROJECT_ROOT}/repository/docker/Dockerfile" \
     --build-arg DEPENDENCIES="datafed-dependencies" \


### PR DESCRIPTION
## Summary by Sourcery

Add support for specifying a base image in Docker builds through a new command-line option and introduce a script to generate build argument files for enhanced configurability.

New Features:
- Introduce the ability to specify a base image for Docker builds using a new command-line option.

Enhancements:
- Add a script to generate a .build-args file for Docker build arguments, allowing for more flexible build configurations.