### PR TITLE
1015 path to ci script is invalid

### DIFF
--- a/.gitlab/build/build_gcs_base_image.yml
+++ b/.gitlab/build/build_gcs_base_image.yml
@@ -38,7 +38,7 @@ build-gcs-base:
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"
     - |
-      while [ "$(./scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
+      while [ "$(${CI_BUILDS_DIR}/scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
         echo "Artifact missing from harbor..."
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"

--- a/.gitlab/build/force_build_gcs_base_image.yml
+++ b/.gitlab/build/force_build_gcs_base_image.yml
@@ -26,7 +26,7 @@ build-gcs-base:
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
     - docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"
     - |
-      while [ "$(./scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
+      while [ "$(${CI_BUILDS_DIR}/scripts/ci_harbor_artifact_count.sh)" == "0" ]; do
         echo "Artifact missing from harbor..."
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:latest"
         docker push "${REGISTRY}/${DATAFED_HARBOR_REPOSITORY}:$CI_COMMIT_SHA"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 3. [988] - Removed non-working subscribe function.
 4. [958] - Addresses issues raised by static code analyzer.
 5. [962] - Adds script that will check that docker image is in registry
+6. [1015] - Uses abs path to ci pipeline script for gcs build jobs
 
 # v2024.6.17.10.40
 

--- a/scripts/run_arango_service.sh
+++ b/scripts/run_arango_service.sh
@@ -12,7 +12,11 @@ if [[ ! -z $systemctl_exists ]]
 then
   sudo systemctl daemon-reload
 
+  # Turn off exit - on non zero exit code for the below command, we don't want
+  # it to exit if arangodb is not reported as active.
+  set +e
   arango_status=$(systemctl is-active arangodb3.service)
+  set -e
   if [ ! "active" = "$arango_status" ]
   then
     sudo systemctl restart arangodb3.service


### PR DESCRIPTION
closes 1015

## Summary by Sourcery

Fix the invalid path to the CI script in the GitLab build configuration files and enhance the ArangoDB service script to prevent exit on non-zero status when checking service activity.

Bug Fixes:
- Fix the invalid path to the CI script in the GitLab build configuration files.

Enhancements:
- Modify the ArangoDB service script to prevent exit on non-zero status when checking service activity.