### PR TITLE
Add a bit of debug context

### DIFF
--- a/repository/docker/entrypoint_authz.sh
+++ b/repository/docker/entrypoint_authz.sh
@@ -147,7 +147,7 @@ echo "globus-gridftp-server pid file found!"
 DATAFED_GCS_URL=$(jq -r .domain_name < /var/lib/globus-connect-server/info.json)
 set +e
 HTTP_CODE=$("${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/curl" -s -o /dev/null -w "%{http_code}\n" -I "https://${DATAFED_GCS_URL}/api/info")
-echo "$?"
+echo "curl exit code: $?"
 set -e
 echo "Waiting for domain name (https://${DATAFED_GCS_URL}) to be registered! Code: $HTTP_CODE"
 printf "\n"


### PR DESCRIPTION
I think it could be helpful to know at this point that what is being printed is the exit code of the preceding curl command. It should be 0, of course, but we saw another value (60) while troubleshooting an issue with an endpoint. It took me a while to figure out what it was referring to.

## Summary by Sourcery

Enhancements:
- Add context to debug output by specifying that the printed value is the curl command's exit code.