### PR TITLE
1031 foxx run ArangoDB unit tests as part of  CI

### DIFF
--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -45,6 +45,7 @@ end-to-end-foxx-setup:
     - echo "docker run -d \\" >> "${RUN_FILE}"
     - echo "--name \"foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}\" \\" >> "${RUN_FILE}"
     - echo "-e DATAFED_ZEROMQ_SYSTEM_SECRET=\"$CI_DATAFED_ZEROMQ_SYSTEM_SECRET\" \\" >> "${RUN_FILE}"
+    - echo "-e ENABLE_FOXX_TESTS=\"TRUE\" \\" >> "${RUN_FILE}"
     - echo "-e DATAFED_DOMAIN=\"$CI_DATAFED_DOMAIN\" \\" >> "${RUN_FILE}"
     - echo "-e DATAFED_DATABASE_PASSWORD=\"$CI_DATAFED_DATABASE_PASSWORD\" \\" >> "${RUN_FILE}"
     - echo "-e DATAFED_DATABASE_IP_ADDRESS_PORT=\"$CI_DATAFED_DATABASE_IP_ADDRESS_PORT\" \\" >> "${RUN_FILE}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ setting is turned on DataFed will build it's libraries as shared and try to
 link to shared libraries." OFF)
 OPTION(ENABLE_END_TO_END_API_TESTS "Enable end-to-end API testing" FALSE) 
 OPTION(ENABLE_END_TO_END_WEB_TESTS "Enable end-to-end web testing with Playwright" FALSE)
+OPTION(ENABLE_FOXX_TESTS "Enable Foxx testing, off by default because it
+will overwrite the database." FALSE) 
 
 set(INSTALL_REPO_SERVER ${BUILD_REPO_SERVER})
 set(INSTALL_AUTHZ ${BUILD_AUTHZ})

--- a/core/database/tests/test_foxx.sh
+++ b/core/database/tests/test_foxx.sh
@@ -4,10 +4,11 @@
 # -u has been removed because we are checking for possible non existent env variables
 set -f -o pipefail
 
-SCRIPT=$(realpath "$0")
+SCRIPT=$(realpath "$BASH_SOURCE[0]")
 SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath ${SOURCE}/../../../)
 source ${PROJECT_ROOT}/config/datafed.sh
+source "${PROJECT_ROOT}/scripts/dependency_install_functions.sh"
 
 Help()
 {
@@ -118,20 +119,22 @@ fi
 ## Get the size of the file in bytes
 #bytes=$(wc -c < datafed.zip)
 
-NODE_VERSION="v14.21.3"
-
-export NVM_DIR="$HOME/.nvm"
+export NVM_DIR="${DATAFED_DEPENDENCIES_INSTALL_PATH}/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
 
-nvm use $NODE_VERSION
+nvm use "$DATAFED_NODE_VERSION"
 
 FOXX_PREFIX=""
-{
-	# Determine if exists globally first
-	which foxx
-} || {
-	FOXX_PREFIX="~/bin/"
-}
+if ! command -v foxx > /dev/null 2>&1; then
+    FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
+else
+  {
+    # Determine if exists globally first
+    which foxx
+  } || {
+    FOXX_PREFIX="~/bin/"
+  }
+fi
 
 PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
 if [ "$TEST_TO_RUN" == "all" ]

--- a/core/database/tests/test_setup.sh
+++ b/core/database/tests/test_setup.sh
@@ -2,12 +2,13 @@
 
 # -e has been removed so that if an error occurs the PASSWORD File is deleted and not left lying around
 # -u has been removed because we are checking for possible non existent env variables
-set -f -o pipefail
+set -euf -o pipefail
 
-SCRIPT=$(realpath "$0")
+SCRIPT=$(realpath "$BASH_SOURCE[0]")
 SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../../../")
 source "${PROJECT_ROOT}/config/datafed.sh"
+source "${PROJECT_ROOT}/scripts/dependency_install_functions.sh"
 
 Help()
 {
@@ -31,21 +32,21 @@ Help()
 local_DATABASE_NAME="sdms"
 local_DATABASE_USER="root"
 
-if [ -z "${DATAFED_DATABASE_PASSWORD}" ]
+if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]
 then
   local_DATAFED_DATABASE_PASSWORD=""
 else
   local_DATAFED_DATABASE_PASSWORD=$(printenv DATAFED_DATABASE_PASSWORD)
 fi
 
-if [ -z "${DATAFED_ZEROMQ_SYSTEM_SECRET}" ]
+if [ -z "${DATAFED_ZEROMQ_SYSTEM_SECRET:-}" ]
 then
   local_DATAFED_ZEROMQ_SYSTEM_SECRET=""
 else
   local_DATAFED_ZEROMQ_SYSTEM_SECRET=$(printenv DATAFED_ZEROMQ_SYSTEM_SECRET)
 fi
 
-if [ -z "${FOXX_MAJOR_API_VERSION}" ]
+if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]
 then
   local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs )
 else
@@ -146,21 +147,30 @@ fi
 ## Get the size of the file in bytes
 #bytes=$(wc -c < datafed.zip)
 
-NODE_VERSION="v14.21.3"
-
-export NVM_DIR="$HOME/.nvm"
+export NVM_DIR="${DATAFED_DEPENDENCIES_INSTALL_PATH}/nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
 
-nvm install "$NODE_VERSION"
-nvm use "$NODE_VERSION"
+nvm use "$DATAFED_NODE_VERSION"
 
 PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
 # Install foxx service node module
-$NVM_DIR/nvm-exec npm install --global foxx-cli
+#$NVM_DIR/nvm-exec npm install --global foxx-cli
 echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
 
+FOXX_PREFIX=""
+if ! command -v foxx > /dev/null 2>&1; then
+    FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
+else
+  {
+    # Determine if exists globally first
+    which foxx
+  } || {
+    FOXX_PREFIX="~/bin/"
+  }
+fi
+
 # Check if database foxx services have already been installed
-existing_services=$(foxx list -a -u "$local_DATABASE_USER" -p "${PATH_TO_PASSWD_FILE}" --database "$local_DATABASE_NAME")
+existing_services=$(${FOXX_PREFIX}foxx list -a -u "$local_DATABASE_USER" -p "${PATH_TO_PASSWD_FILE}" --database "$local_DATABASE_NAME")
 echo "existing services ${existing_services}"
 
 if [[ "$existing_services" =~ .*"DataFed".* ]]

--- a/docker/Dockerfile.foxx
+++ b/docker/Dockerfile.foxx
@@ -28,6 +28,8 @@ ENV DATAFED_DEPENDENCIES_INSTALL_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}"
 ENV                              PATH=${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin:${PATH}
 ENV              DATAFED_INSTALL_PATH="$DATAFED_INSTALL_PATH"
 ENV          DATAFED_DEFAULT_LOG_PATH="$DATAFED_INSTALL_PATH/logs"
+# Foxx tests should be off by default to avoid accidentally wipping the database
+ENV                 ENABLE_FOXX_TESTS="FALSE"
 
 COPY ./core/CMakeLists.txt             ${BUILD_DIR}/core/CMakeLists.txt
 COPY ./CMakeLists.txt                  ${BUILD_DIR}

--- a/docker/entrypoint_foxx.sh
+++ b/docker/entrypoint_foxx.sh
@@ -28,33 +28,56 @@ then
     su -c "mkdir -p ${log_path}" datafed
   fi
   
-  # It should be fine to run this as root because it is an ephemeral container anyway
+  # It should be fine to run this as root because it is an ephemeral container
+  # anyway
   cd "${PROJECT_ROOT}"
   # Check to see if foxx has previously been installed
   "${PROJECT_ROOT}/scripts/generate_datafed.sh"
 
-  "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" -S. -B build						\
-    -DBUILD_REPO_SERVER=False		\
-    -DBUILD_COMMON=False        \
-    -DBUILD_AUTHZ=False					\
-    -DBUILD_CORE_SERVER=False		\
-    -DBUILD_WEB_SERVER=False		\
-    -DBUILD_DOCS=False					\
-    -DBUILD_PYTHON_CLIENT=False	\
-    -DBUILD_FOXX=True           \
-    -DINSTALL_FOXX=True
-
+  if [ "$ENABLE_FOXX_TESTS" == "TRUE" ]
+  then
+    "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" -S. -B build            \
+      -DBUILD_REPO_SERVER=False   \
+      -DBUILD_COMMON=False        \
+      -DBUILD_AUTHZ=False         \
+      -DBUILD_CORE_SERVER=False   \
+      -DBUILD_WEB_SERVER=False    \
+      -DBUILD_DOCS=False          \
+      -DBUILD_PYTHON_CLIENT=False \
+      -DBUILD_FOXX=True           \
+      -DINSTALL_FOXX=True         \
+      -DENABLE_FOXX_TESTS=True
+  else
+    "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" -S. -B build            \
+      -DBUILD_REPO_SERVER=False   \
+      -DBUILD_COMMON=False        \
+      -DBUILD_AUTHZ=False         \
+      -DBUILD_CORE_SERVER=False   \
+      -DBUILD_WEB_SERVER=False    \
+      -DBUILD_DOCS=False          \
+      -DBUILD_PYTHON_CLIENT=False \
+      -DBUILD_FOXX=True           \
+      -DINSTALL_FOXX=True
+  fi
 
   "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" --build build
 
   # Give arango container a minute to initialize
   # should be replaced with health check at some point
   sleep 5
-  "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" --build build --target install
+  "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" \
+    --build build \
+    --target install
   
   touch "$install_flag"
   chown -R "$UID":"$UID" "/tmp"
 
+  if [ "$ENABLE_FOXX_TESTS" == "TRUE" ]
+  then
+    "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" \
+      --build build \
+      --target test
+  fi
 else
   echo "/tmp/.foxx_is_installed has been found skipping reinstall"
 fi

--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SCRIPT=$(realpath "$0")
+SCRIPT=$(realpath "${BASH_SOURCE[0]}")
 SOURCE=$(dirname "$SCRIPT")
 source "${SOURCE}/dependency_versions.sh"
 PROJECT_ROOT=$(realpath "${SOURCE}/..")
@@ -384,8 +384,12 @@ install_node() {
 
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
     nvm install "$DATAFED_NODE_VERSION"
-    # Mark node as installed
-    touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.node_installed-${DATAFED_NODE_VERSION}"
+    code="$?"
+    if [ "$code" == "0" ]
+    then 
+      # Mark node as installed
+      touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.node_installed-${DATAFED_NODE_VERSION}"
+    fi
     cd "$original_dir"
   else
     export NVM_DIR="${DATAFED_DEPENDENCIES_INSTALL_PATH}/nvm"
@@ -409,8 +413,12 @@ install_foxx_cli() {
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
     export NODE_VERSION="$DATAFED_NODE_VERSION"
     "$NVM_DIR/nvm-exec" npm install --global foxx-cli --prefix "${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm"
-    # Mark foxx_cli as installed
-    touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.foxx_cli_installed"
+    code="$?"
+    if [ "$code" == "0" ]
+    then
+      # Mark foxx_cli as installed
+      touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.foxx_cli_installed"
+    fi
     cd "$original_dir"
   else
     export NVM_DIR="${DATAFED_DEPENDENCIES_INSTALL_PATH}/nvm"
@@ -420,17 +428,17 @@ install_foxx_cli() {
     # check that foxx can be found
     if [ ! -d "${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm" ]
     then
-	echo "Something went wrong Foxx is supposed to be installed i.e. "
-	echo "(${DATAFED_DEPENDENCIES_INSTALL_PATH}/.foxx_cli_installed) "
-	echo "exists. But there is no npm folder in: ${DATAFED_DEPENDENCIES_INSTALL_PATH}"
-	exit 1
+      echo "Something went wrong Foxx is supposed to be installed i.e. "
+      echo "(${DATAFED_DEPENDENCIES_INSTALL_PATH}/.foxx_cli_installed) "
+      echo "exists. But there is no npm folder in: ${DATAFED_DEPENDENCIES_INSTALL_PATH}"
+      exit 1
     fi
     if [ ! -e "${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/foxx" ]
     then
-	echo "Something went wrong Foxx is supposed to be installed i.e. "
-	echo "(${DATAFED_DEPENDENCIES_INSTALL_PATH}/.foxx_cli_installed) "
-	echo "exists. But there is no foxx binary here: ${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/foxx"
-	exit 1
+      echo "Something went wrong Foxx is supposed to be installed i.e. "
+      echo "(${DATAFED_DEPENDENCIES_INSTALL_PATH}/.foxx_cli_installed) "
+      echo "exists. But there is no foxx binary here: ${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/foxx"
+      exit 1
     fi
   fi
 }

--- a/scripts/install_foxx.sh
+++ b/scripts/install_foxx.sh
@@ -225,7 +225,6 @@ echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
 
   RESULT=$(curl -s http://${local_DATAFED_DATABASE_HOST}:8529/_db/sdms/api/${local_FOXX_MAJOR_API_VERSION}/version)
   CODE=$(echo "${RESULT}" | jq '.code' )
-  echo "Code is $CODE"
   if [ -z "${FOUND_API}" ]
   then
       INSTALL_API="TRUE"


### PR DESCRIPTION
# Description 

This pr is to make sure that Foxx tests are running as part of the CI pipelines, without it, it makes it very difficult to add, remove or change any of the code implementation in Foxx javascript files.

#1031

## Summary by Sourcery

CI:
- Integrate Foxx tests into the CI pipeline to ensure they are executed as part of the continuous integration process.