### PR TITLE
grab log output even if container fails

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -93,7 +93,7 @@
   stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
-    - docker logs $(docker ps --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
+    - docker logs $(docker -a ps --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
   rules:
     - when: always
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Ensure log output is captured even if the container fails by modifying the docker command to include all containers.