### PR TITLE
move flag to the correct position after ps

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -93,7 +93,7 @@
   stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
-    - docker logs $(docker -a ps --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
+    - docker logs $(docker ps -a --filter "ancestor=${REGISTRY}/${IMAGE_TAG}${BRANCH_LOWER}" --format "{{.Names}}")
   rules:
     - when: always
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Correct the position of the '-a' flag in the 'docker ps' command within the GitLab CI configuration.