### PR TITLE
Removed --no-cache flag

### DIFF
--- a/scripts/compose_build_images.sh
+++ b/scripts/compose_build_images.sh
@@ -86,7 +86,6 @@ then
     "${PROJECT_ROOT}/core/docker/Dockerfile" \
     --build-arg DEPENDENCIES="datafed-dependencies:latest" \
     --build-arg RUNTIME="datafed-runtime:latest" \
-    --no-cache \
     "${PROJECT_ROOT}" \
     -t datafed-core:latest
   docker build -f \


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Remove the --no-cache flag from the Docker build command in the compose_build_images.sh script.