### PR TITLE
1128 Fix GCS Container json permission issues

### DIFF
--- a/repository/docker/Dockerfile.gcs
+++ b/repository/docker/Dockerfile.gcs
@@ -68,9 +68,6 @@ COPY ./scripts/copy_dependency.sh              ${BUILD_DIR}/scripts/
 RUN ${BUILD_DIR}/scripts/generate_datafed.sh
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC ${BUILD_DIR}/scripts/install_authz_dependencies.sh unify
 
-# All files should be owned by the datafed user
-RUN chown -R datafed:root ${DATAFED_DIR}
-
 COPY --chown=datafed:root ./scripts/dependency_versions.sh            ${BUILD_DIR}/scripts/
 COPY --chown=datafed:root ./scripts/generate_authz_config.sh          ${BUILD_DIR}/scripts/generate_authz_config.sh
 COPY --chown=datafed:root ./scripts/utils.sh                          ${BUILD_DIR}/scripts/utils.sh

--- a/repository/docker/entrypoint_authz.sh
+++ b/repository/docker/entrypoint_authz.sh
@@ -69,6 +69,9 @@ fi
 if [ -n "$UID" ]; then
     echo "Switching datafed user to UID: ${UID}"
     usermod -u $UID datafed
+    # All files should be owned by the datafed user
+    chown -R datafed:root ${DATAFED_DIR}
+    chown -R datafed:root ${DATAFED_INSTALL_PATH}/authz
 fi
 
 if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]


### PR DESCRIPTION
Closes #1128 
Different branch name for CI pipeline

# Summary
Update to fix permission issues on directories in gcs container

# Screenshot
Made it through compose up, GCS was the last failing step
![image](https://github.com/user-attachments/assets/dd8f2f5a-fe26-415d-82bf-b3b587e22847)

## Summary by Sourcery

Bug Fixes:
- Fix permission issues by ensuring all files in the GCS container are owned by the datafed user.