### PR TITLE
Add scripts for locating globus and gss api libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ if( NOT DEFINED GLOBUS_VERSION )
   set(GLOBUS_VERSION  5)
 endif()
 OPTION(BUILD_AUTHZ "Build DataFed Authz library" FALSE)
+OPTION(BUILD_AUTHZ_TESTS "Build DataFed Authz Tests" FALSE)
 OPTION(BUILD_AUTHZ_WITH_SYSLOG "Build Authz without syslog" TRUE)
 OPTION(BUILD_CORE_SERVER "Build DataFed Core Server" TRUE)
 OPTION(BUILD_COMMON "Build DataFed common library" TRUE)
@@ -123,6 +124,11 @@ if( BUILD_WEB_SERVER )
     set_tests_properties(unit_tests_web PROPERTIES WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/web)
   endif()
 
+endif()
+
+if( BUILD_AUTHZ_TESTS )
+  include(./cmake/GSSAPI.cmake)
+  include(./cmake/GlobusCommon.cmake)
 endif()
 
 if ( BUILD_REPO_SERVER OR BUILD_CORE_SERVER OR BUILD_AUTHZ OR BUILD_COMMON OR BUILD_PYTHON_CLIENT) 
@@ -285,5 +291,7 @@ message("             boost system Library: ${DATAFED_BOOST_SYSTEM_LIBRARY_PATH}
 message("         boost filesystem Library: ${DATAFED_BOOST_FILESYSTEM_LIBRARY_PATH}")
 message("    boost program_options Library: ${DATAFED_BOOST_PROGRAM_OPTIONS_LIBRARY_PATH}")
 message("                     zlib Library: ${DATAFED_ZLIB_LIBRARIES}")
+message("                   gssapi Library: ${DATAFED_GSSAPI_LIBRARIES}")
+message("            globus_common Library: ${DATAFED_GLOBUS_COMMON_LIBRARIES}")
 message("")
 

--- a/cmake/GSSAPI.cmake
+++ b/cmake/GSSAPI.cmake
@@ -1,0 +1,14 @@
+
+function(find_gssapi_library)
+
+  find_library(GSSAPI_LIBRARIES NAMES libgssapi.so.3 libgssapi.so gssapi gssapi )
+
+  if(NOT GSSAPI_LIBRARIES)
+    set(GSSAPI_LIBRARIES "")
+  endif()
+
+  set(DATAFED_GSSAPI_LIBRARIES "${GSSAPI_LIBRARIES}" PARENT_SCOPE)
+
+endfunction()
+
+find_gssapi_library()

--- a/cmake/GSSAPI.cmake
+++ b/cmake/GSSAPI.cmake
@@ -1,7 +1,7 @@
 
 function(find_gssapi_library)
 
-  find_library(GSSAPI_LIBRARIES NAMES libgssapi.so.3 libgssapi.so gssapi gssapi )
+  find_library(GSSAPI_LIBRARIES NAMES libgssapi.so.3 libgssapi.so gssapi gssapi libgssapi_krb5.so )
 
   if(NOT GSSAPI_LIBRARIES)
     set(GSSAPI_LIBRARIES "")

--- a/cmake/GlobusCommon.cmake
+++ b/cmake/GlobusCommon.cmake
@@ -1,0 +1,14 @@
+
+function(find_globus_common_library)
+
+  find_library(GLOBUS_COMMON_LIBRARIES globus_common)
+
+  if(NOT GLOBUS_COMMON_LIBRARIES)
+    set(GLOBUS_COMMON_LIBRARIES "")
+  endif()
+
+  set(DATAFED_GLOBUS_COMMON_LIBRARIES "${GLOBUS_COMMON_LIBRARIES}" PARENT_SCOPE)
+
+endfunction()
+
+find_globus_common_library()

--- a/scripts/install_authz_dependencies.sh
+++ b/scripts/install_authz_dependencies.sh
@@ -12,7 +12,7 @@ source "${PROJECT_ROOT}/scripts/dependency_install_functions.sh"
 
 packages=("host" "libtool" "build-essential" "g++" "gcc" "autoconf"
   "automake" "make" "git" "python3-pkg-resources" "python3-pip" "pkg-config"
-  "libglobus-common-dev" "wget" "jq" "sudo" "libboost-all-dev" "python3-venv")
+  "libglobus-common-dev" "wget" "jq" "sudo" "libboost-all-dev" "python3-venv" "libgssapi-krb5-2")
 pip_packages=("setuptools" "distro" "jwt" "globus_sdk")
 externals=("cmake" "protobuf" "libsodium" "libzmq" )
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add options to build DataFed Authz tests and include GSSAPI and GlobusCommon scripts when enabled.