### PR TITLE
1159 refactor authz cpp file

### DIFF
--- a/repository/gridftp/globus5/authz/source/AuthzWorker.cpp
+++ b/repository/gridftp/globus5/authz/source/AuthzWorker.cpp
@@ -1,5 +1,6 @@
 // Local private includes
 #include "Config.h"
+#include "AuthzWorker.hpp"
 #include "Version.hpp"
 
 // Common public includes
@@ -20,6 +21,7 @@
 #include "common/Version.pb.h"
 
 // Standard includes
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <random>
@@ -31,6 +33,10 @@ using namespace SDMS::Anon;
 using namespace SDMS::Auth;
 
 namespace {
+
+/**
+ * \brief Designed to generated a random string of characters
+ **/
 std::string randomAlphaNumericCode() {
   std::string chars =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -48,117 +54,64 @@ std::string randomAlphaNumericCode() {
 
 namespace SDMS {
 
-class AuthzWorker {
-public:
-  AuthzWorker(struct Config *a_config, LogContext log_context)
-      : m_config(a_config), m_test_path_len(strlen(a_config->test_path)) {
+   AuthzWorker::AuthzWorker(struct Config *a_config, LogContext log_context)
+      : m_config(a_config) {
 
     m_log_context = log_context;
     m_log_context.thread_name += "-authz_worker";
     m_log_context.thread_id = 0;
+
+    // Convert config item to string for easier manipulation
+    m_local_globus_path_root = std::string(m_config->globus_collection_path); 
+
+    m_test_path = std::string(m_config->test_path);
+    // NOTE the test_path MUST end with '/' this is to prevent authorization
+    // by accident to a subfolder i.e.
+    //
+    // /foobar
+    // /foo
+    //
+    // If m_test_path was meant just for the foo folder but an '/' is missing
+    // then both /foobar and /foo would be valid
+    //
+    // NOTE we also do not want add a '/' if the test_path is emtpy because that 
+    // would indicate no test path is being used.
+		if (!m_test_path.empty() && m_test_path.back() != '/') {
+		  m_test_path += '/';
+		}
+
+		// Add a backslash if not present
+    initCommunicator();
   }
 
-  ~AuthzWorker() {}
+	/**
+	 * This method is used to initialize the communicator which will talk with
+   * the core services
+   *
+   * Setting up a communicator consists of several steps.
+   * 1. Setting up credentials that are needed to communicate securely
+   * 2. Creating the configuration options for how the communication should
+   *    occur
+   * 3. Creating the communicator.
+   *
+   **/
+  void AuthzWorker::initCommunicator() {
 
-  AuthzWorker &operator=(const AuthzWorker &) = delete;
-
-  int checkAuth(char *client_id, char *path, char *action) {
-    DL_DEBUG(m_log_context, "Checking auth for client: " << client_id);
-
-    if (m_test_path_len > 0 &&
-        strncmp(path, m_config->test_path, m_test_path_len) == 0) {
-      DL_INFO(m_log_context, "Allowing request within TEST PATH: "
-                                 << m_config->test_path
-                                 << " actual path: " << path);
-      return 0;
-    }
-
-    // This should point to the root of the globus collection on the POSIX
-    // system It must be stripped from the path Expecting a path with the
-    // following form ftp://hostname/globus_collection_root_path
-
-    // Start by making sure the format is as expected
-
-    std::string scheme = "ftp://";
-    // std::string local_globus_path_root = "ftp://";
-    std::string local_path = path;
-    if (local_path.substr(0, scheme.length()).compare(scheme) != 0) {
-      DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
-                              "be prefixed with ftp:// but is: "
-                                  << path);
-      EXCEPT(1, "Format error detected in path");
-    }
-
-    // 2 grab substr after third backslash (and including backslash) should
-    // remove ftp://hostname
-
-    char backslash = '/';
-    int count = 0;
-    size_t index = 0;
-
-    for (size_t i = 0; i < local_path.length(); i++) {
-      if (local_path[i] == backslash) {
-        count++;
-        if (count == 3) {
-          index = i;
-          break;
-        }
-      }
-    }
-
-    if (count != 3) {
-      DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
-                              "be prefixed with ftp://hostname but is: "
-                                  << path);
-      EXCEPT(1, "Format error detected in path");
-    }
-
-    // extract the substring after the third occurrence of the character
-    local_path = local_path.substr(index);
-
-    std::string local_globus_path_root = std::string(
-        m_config
-            ->globus_collection_path); // +
-                                       // repo_id.substr(repo_prefix.length()-1);
-    if (local_globus_path_root.length() > local_path.length()) {
-      ;
-      std::string err_message =
-          "Provided path is not properly formatted, should be prefixed with "
-          "globus_root_collection_path: ";
-      err_message += local_globus_path_root + " but is: " + path;
-      DL_ERROR(m_log_context, err_message);
-      EXCEPT(1, "Path to data item is not within the collection");
-    }
-
-    auto prefix = local_path.substr(0, local_globus_path_root.length());
-    if (prefix.compare(local_globus_path_root) != 0) {
-      std::string err_message =
-          "Provided path is not properly formatted, should be prefixed with "
-          "globus_root_collection_path: ";
-      err_message += local_globus_path_root + " but is: " + path;
-      DL_ERROR(m_log_context, err_message);
-      EXCEPT(1, "Path to data item is not within the collection");
-    }
-
-    auto sanitized_path = local_path.substr(prefix.length());
-    std::unique_ptr<SDMS::ICredentials> m_sec_ctx;
-
-    std::unordered_map<CredentialType, std::string> cred_options;
-    cred_options[CredentialType::PUBLIC_KEY] = m_config->pub_key;
-    cred_options[CredentialType::PRIVATE_KEY] = m_config->priv_key;
-    cred_options[CredentialType::SERVER_KEY] = m_config->server_key;
+    m_cred_options[CredentialType::PUBLIC_KEY] = m_config->pub_key;
+    m_cred_options[CredentialType::PRIVATE_KEY] = m_config->priv_key;
+    m_cred_options[CredentialType::SERVER_KEY] = m_config->server_key;
     CredentialFactory cred_factory;
-    m_sec_ctx = cred_factory.create(ProtocolType::ZQTP, cred_options);
+    m_sec_ctx = cred_factory.create(ProtocolType::ZQTP, m_cred_options);
 
     // Need to attach a random number to the authz_client_socket so that
     // each authz client is distinct
-    std::string authz_thread_id =
-        "authz_client_socket-" + randomAlphaNumericCode();
-    auto client = [&](const std::string &socket_id, const std::string &address,
+    std::string authz_thread_id;
+    authz_thread_id = "authz_client_socket-" + randomAlphaNumericCode();
+
+    m_comm = [&](const std::string &socket_id, const std::string &address,
                       ICredentials &credentials) {
+      
       /// Creating input parameters for constructing Communication Instance
-      DL_INFO(m_log_context,
-              "Creating client with adress to server: " << address);
       AddressSplitter splitter(address);
 
       SocketOptions socket_options;
@@ -183,19 +136,391 @@ public:
                          << socket_options.port.value());
         }
       }
-      // socket_options.port = 1341;
       socket_options.local_id = socket_id;
 
       uint32_t timeout_on_receive = 50000;
       long timeout_on_poll = 50000;
 
       CommunicatorFactory comm_factory(m_log_context);
-      // When creating a communication channel with a server application we need
-      // to locally have a client socket. So though we have specified a client
-      // socket we will actually be communicating with the server.
+
       return comm_factory.create(socket_options, credentials,
                                  timeout_on_receive, timeout_on_poll);
     }(authz_thread_id, m_config->server_addr, *m_sec_ctx);
+
+  }
+
+  /**
+	 * @brief Determine if the given POSIX path is within the configured test path.
+	 *
+	 * A test path can be set in the authorization configuration file to assist
+	 * with debugging and setup of a DataFed-managed Globus collection.
+	 * Any authorization associated with this path and its subpaths in the
+	 * folder hierarchy is automatically approved.
+	 *
+	 * @param posix_path The POSIX-style file path to evaluate.
+	 * @return `true` if the provided path is within the configured test path,
+	 *         `false` otherwise.
+	 *
+	 * @note This method uses the `m_test_path` and its length `m_test_path_len`
+	 *       to determine if the `posix_path` starts with the test path.
+	 *       If the test path is not set (`m_test_path_len == 0`), the function
+	 *       will always return `false`.
+	 *
+	 * @attention Use caution when setting a test path, as it bypasses normal
+	 *            authorization checks for all matching paths.
+	 *
+	 * Example:
+	 * @code
+	 * AuthzWorker authzWorker;
+	 * std::string path = "/data/test_path/example_file";
+	 * if (authzWorker.isTestPath(path)) {
+	 *     std::cout << "Path is within the test path!" << std::endl;
+	 * } else {
+	 *     std::cout << "Path is not within the test path." << std::endl;
+	 * }
+	 * @endcode
+	 */
+  bool AuthzWorker::isTestPath(const std::string & posix_path) const {
+    if (m_test_path_len > 0 &&
+        posix_path.compare(0, m_test_path.size(), m_test_path) == 0) {
+      DL_INFO(m_log_context, "Allowing request within TEST PATH: "
+          << m_config->test_path);
+      return true;
+    }
+    return false;
+  }
+
+	/**
+	 * @brief Validates whether the provided POSIX path is properly formatted.
+	 *
+	 * This method checks if the given POSIX path starts with the configured
+	 * Globus root collection path (`m_local_globus_path_root`). If the path is not
+	 * properly formatted, an error message is logged, and the method returns `false`.
+	 *
+	 * @param posix_path The POSIX-style file path to validate.
+	 * @return `true` if the provided path is valid (properly formatted),
+	 *         `false` otherwise.
+	 *
+	 * @note The validation ensures that the `posix_path` begins with the
+	 *       `m_local_globus_path_root` prefix. If the path is shorter than the
+	 *       root prefix, it is considered invalid.
+	 *
+	 * @attention An improperly formatted path indicates a configuration or
+	 *            user error and will result in an error log message.
+	 *
+	 * Example:
+	 * @code
+	 * AuthzWorker authzWorker;
+	 * std::string path = "/data/globus_root/example_file";
+	 * if (authzWorker.isPathValid(path)) {
+	 *     std::cout << "Path is valid!" << std::endl;
+	 * } else {
+	 *     std::cout << "Path is invalid." << std::endl;
+	 * }
+	 * @endcode
+	 *
+	 * Errors:
+	 * - Logs an error if the path does not start with `m_local_globus_path_root`.
+	 * - Logs an error if the path is shorter than `m_local_globus_path_root`.
+	 */
+  bool AuthzWorker::isPathValid(const std::string & posix_path) const {
+    if (m_local_globus_path_root.length() > posix_path.length()) {
+      std::string err_message =
+          "Provided path is not properly formatted, should be prefixed with "
+          "globus_root_collection_path: ";
+      err_message += m_local_globus_path_root + " but is: " + posix_path;
+      DL_ERROR(m_log_context, err_message);
+      return false;
+    }
+
+    auto prefix = posix_path.substr(0, m_local_globus_path_root.length());
+    if (prefix.compare(m_local_globus_path_root) != 0) {
+      std::string err_message =
+          "Provided path is not properly formatted, should be prefixed with "
+          "globus_root_collection_path: ";
+      err_message += m_local_globus_path_root + " but is: " + prefix;
+      DL_ERROR(m_log_context, err_message);
+      return false;
+    }
+    return true;
+  }
+
+	/**
+	 * @brief Validates whether the provided FTP URL is properly formatted.
+	 *
+	 * This method checks if the given FTP URL starts with the required scheme
+	 * (`ftp://`) and contains at least three slashes, which indicates the presence
+	 * of a hostname after the scheme. If the URL is not properly formatted, an
+	 * error message is logged, and the method returns `false`.
+	 *
+	 * @param full_ftp_url A C-style string representing the full FTP URL to validate.
+	 * @return `true` if the URL is valid (properly formatted),
+	 *         `false` otherwise.
+	 *
+	 * @note The method performs the following checks:
+	 *       - The URL must begin with the `ftp://` scheme.
+	 *       - The URL must include at least three slashes to indicate a valid
+	 *         scheme and hostname.
+	 *
+	 * @attention Improperly formatted URLs result in error log messages to help
+	 *            diagnose issues.
+	 *
+	 * Example:
+	 * @code
+	 * AuthzWorker authzWorker;
+	 * char url[] = "ftp://hostname/path/to/file";
+	 * if (authzWorker.isURLValid(url)) {
+	 *     std::cout << "URL is valid!" << std::endl;
+	 * } else {
+	 *     std::cout << "URL is invalid." << std::endl;
+	 * }
+	 * @endcode
+	 *
+	 * Errors:
+	 * - Logs an error if the URL does not start with `ftp://`.
+	 * - Logs an error if the URL contains fewer than three slashes.
+	 */
+  bool AuthzWorker::isURLValid(char * full_ftp_url) const {
+
+    std::string scheme = "ftp://";
+    auto local_path = std::string(full_ftp_url);
+    if (local_path.substr(0, scheme.length()).compare(scheme) != 0) {
+      DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
+                              "be prefixed with ftp:// but is: "
+                                  << full_ftp_url);
+      return false;
+    }
+
+    int count = std::count(local_path.begin(), local_path.end(), '/');
+    if (count < 3) {
+      DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
+                              "be prefixed with ftp://hostname but is: "
+                                  << full_ftp_url);
+      return false;
+    }
+
+    return true;
+  } 
+
+
+	/**
+	 * @brief Removes the origin (ftp://hostname) from the given FTP URL.
+	 *
+	 * This method strips the `ftp://hostname` portion from a provided FTP URL, leaving
+	 * only the path portion starting from the Globus collection root path.
+	 * The URL is expected to be in the format: `ftp://hostname/globus_collection_root_path`.
+	 * The method extracts the substring that follows the third occurrence of a slash (`/`),
+	 * which is used to identify the path after the hostname.
+	 *
+	 * @param full_ftp_url A C-style string representing the full FTP URL, including the hostname and path.
+	 * @return A string containing the remaining path after the `ftp://hostname` portion.
+	 *
+	 * @note The method assumes the URL follows the `ftp://hostname/globus_collection_root_path` format.
+	 *       If there are fewer than three slashes in the URL, it will return the entire string after
+	 *       the first two slashes.
+	 *
+	 * @attention The method does not validate the URL structure beyond checking for slashes,
+	 *            so improper formatting may result in unexpected behavior.
+	 *
+	 * Example:
+	 * @code
+	 * AuthzWorker authzWorker;
+	 * char url[] = "ftp://hostname/globus_root_path/some/file";
+	 * std::string path = authzWorker.removeOrigin(url);
+	 * std::cout << "Path after origin removed: " << path << std::endl;
+	 * @endcode
+	 *
+	 * Errors:
+	 * - Logs an error if the format does not meet the expected `ftp://hostname/` structure.
+	 */
+  std::string AuthzWorker::removeOrigin(char * full_ftp_url) const {
+
+    if (isURLValid(full_ftp_path) == false) {
+      EXCEPT(1, "Invalid formatted ftp url.");
+    }
+
+    auto local_path = std::string(full_ftp_url);
+    char backslash = '/';
+    int count = 0;
+    size_t index = 0;
+
+    for (size_t i = 0; i < local_path.length(); i++) {
+      if (local_path[i] == backslash) {
+        count++;
+        if (count == 3) {
+          index = i;
+          break;
+        }
+      }
+    }
+
+    // Extract the substring after the third occurrence of the character
+    return local_path.substr(index);
+  }
+
+	/**
+	 * @brief Retrieves the authorization path from the given FTP URL by removing the origin and validating the path.
+	 *
+	 * This method first removes the `ftp://hostname` portion from the provided FTP path using the `removeOrigin` method.
+	 * Then, it validates the remaining path to ensure it is properly formatted with the expected Globus collection root path.
+	 * If the path is invalid, an exception is thrown. Finally, it returns the path after the Globus collection root prefix.
+	 *
+	 * @param full_ftp_path A C-style string representing the full FTP URL, which includes the scheme, hostname, and path.
+	 * @return A string containing the authorization path after the `ftp://hostname` portion and the Globus collection root path.
+	 *
+	 * @throws EXCEPT(1, "Invalid POSIX path.") If the path is not valid according to the `isPathValid` method.
+	 *
+	 * @note The method relies on the `removeOrigin` method to remove the `ftp://hostname` portion and expects the remaining path
+	 *       to start with a valid Globus collection root path.
+	 *
+	 * Example:
+	 * @code
+	 * AuthzWorker authzWorker;
+	 * char path[] = "ftp://hostname/globus_root_path/some/file";
+	 * std::string authzPath = authzWorker.getAuthzPath(path);
+	 * std::cout << "Authorization Path: " << authzPath << std::endl;
+	 * @endcode
+	 *
+	 * Errors:
+	 * - Throws an exception if the path is invalid.
+	 */
+  std::string AuthzWorker::getAuthzPath(char * full_ftp_path) {
+    std::string local_path = removeOrigin(full_ftp_path);
+
+    if (isPathValid(local_path) == false) {
+      EXCEPT(1, "Invalid POSIX path.");
+    }
+    auto prefix = local_path.substr(0, m_local_globus_path_root.length());
+
+    return local_path.substr(prefix.length());
+  }
+
+	/**
+	 * @brief Processes the response received from the core service and handles different scenarios such as timeout, errors, and valid responses.
+	 *
+	 * This method is designed to process a response from the core service, checking for various conditions such as whether the response 
+	 * contains a message, whether there was a timeout, or whether an error occurred. If the response is valid and contains the expected 
+	 * payload, the method will further inspect it to check for a NACK reply.
+	 *
+	 * The method performs the following:
+	 * - If the response contains a valid message, it extracts the correlation ID.
+	 * - If the response has a timeout, it logs a warning with details about the service's address and port.
+	 * - If an error occurs, it logs the error message.
+	 * - If no errors or timeouts are present, it checks if the payload is a NACK reply.
+	 * - If the response is a NACK, it logs a debug message.
+	 *
+	 * @param response A reference to an `ICommunicator::Response` object that contains the response data.
+	 * @return `1` if a NACK response was received, `0` otherwise.
+	 *
+	 * @throws EXCEPT(1, "Core service did not respond") If the core service response times out.
+	 *
+	 * @note This method assumes that the response message and error fields are populated correctly before processing.
+	 *
+	 * Example:
+	 * @code
+	 * ICommunicator::Response response = communicator.getResponse();
+	 * int result = authzWorker.processResponse(response);
+	 * if (result == 1) {
+	 *     std::cout << "Received NACK reply" << std::endl;
+	 * } else {
+	 *     std::cout << "Response processed successfully" << std::endl;
+	 * }
+	 * @endcode
+	 */
+  int AuthzWorker::processResponse(ICommunicator::Response & response) {
+    if (response.message) { // Make sure the message exists before we try to
+                            // access it
+      m_log_context.correlation_id = std::get<std::string>(
+          response.message->get(MessageAttribute::CORRELATION_ID));
+    }
+    if (response.time_out) {
+      std::string error_msg =
+          "AuthWorker.cpp Core service did not respond within timeout.";
+
+      AddressSplitter splitter(m_comm->address());
+
+      if (splitter.port().value() != 7512) {
+
+        error_msg += "Port number is defined for: " + m_comm->address() +
+                     " however, it is a non standard port, the standard port "
+                     "for connecting to the core server is port number 7512, "
+                     "whereas here you are using port: " +
+                     std::to_string(splitter.port().value());
+      }
+
+      DL_WARNING(m_log_context, error_msg);
+      EXCEPT(1, "Core service did not respond");
+    } else if (response.error) {
+      DL_ERROR(m_log_context, "AuthWorker.cpp there was an error when "
+                            "communicating with the core service: "
+                                << response.error_msg);
+    } else {
+
+      if (not response.message) {
+        DL_ERROR(m_log_context, "No error was reported and no time out occured "
+                              "but message is not defined.");
+      }
+
+      auto payload =
+          std::get<google::protobuf::Message *>(response.message->getPayload());
+      Anon::NackReply *nack = dynamic_cast<Anon::NackReply *>(payload);
+      if (!nack) {
+        return 0;
+      } else {
+        DL_DEBUG(m_log_context, "Received NACK reply");
+      }
+    }
+    return 1;
+  }
+
+	/**
+	 * @brief Checks the authorization for a given client and action on a specific path.
+	 *
+	 * This method performs the following steps to check authorization:
+	 * - Logs the client ID being checked.
+	 * - Sanitizes the provided path using the `getAuthzPath` method. If the path is invalid, an exception is raised.
+	 * - If the path is determined to be a test path, the method returns early with a `0`, allowing access without further checks.
+	 * - Constructs an authorization request (`AuthzRequest`) and sets the repository ID, client ID, path, and action to be validated.
+	 * - Creates a message using `MessageFactory` and sets the public key from the credentials options.
+	 * - Sends the message through the communicator and waits for a response.
+	 * - Processes the response using the `processResponse` method and returns the result.
+	 *
+	 * This method is used to ensure that the client has proper authorization to perform a specific action on a file or resource.
+	 * It validates the action against the provided path and client ID, contacting the core service for verification.
+	 *
+	 * @param client_id The client ID requesting the action.
+	 * @param path The path to the file or resource to be accessed.
+	 * @param action The action (e.g., read, write) that the client wants to perform.
+	 * @return An integer result based on the response:
+	 * - `0` if the path is a test path or authorization is granted.
+	 * - Non-zero value indicating the result of the authorization process (such as the result of the NACK check).
+	 *
+	 * @throws EXCEPT(1, "Invalid POSIX path.") If the path cannot be sanitized or is invalid.
+	 * 
+	 * @note This method relies on the communication layer to send and receive messages to validate authorization and requires a 
+	 * configured communicator and credentials options.
+	 * 
+	 * Example:
+	 * @code
+	 * char client_id[] = "client123";
+	 * char path[] = "/some/path/to/resource";
+	 * char action[] = "read";
+	 * AuthzWorker auth_worker;
+	 * int result = auth_worker.checkAuth(client_id, path, action);
+	 * if (result == 0) {
+	 *     std::cout << "Authorization granted or path is a test path" << std::endl;
+	 * } else {
+	 *     std::cout << "Authorization failed or additional checks required" << std::endl;
+	 * }
+	 * @endcode
+	 */
+  int AuthzWorker::checkAuth(char *client_id, char *path, char *action) {
+    DL_DEBUG(m_log_context, "Checking auth for client: " << client_id);
+
+    // An exception will be raised here if the path is invalid
+    std::string sanitized_path = getAuthzPath(path);
+
+    if (isTestPath(sanitized_path)) { return 0; }
 
     auto auth_req = std::make_unique<Auth::RepoAuthzRequest>();
 
@@ -207,73 +532,18 @@ public:
     MessageFactory msg_factory;
     auto message = msg_factory.create(MessageType::GOOGLE_PROTOCOL_BUFFER);
     message->set(MessageAttribute::KEY,
-                 cred_options[CredentialType::PUBLIC_KEY]);
+                 m_cred_options[CredentialType::PUBLIC_KEY]);
     message->setPayload(std::move(auth_req));
 
-    client->send(*message);
+    m_comm->send(*message);
     LogContext log_context = m_log_context;
     log_context.correlation_id =
         std::get<std::string>(message->get(MessageAttribute::CORRELATION_ID));
-    DL_DEBUG(log_context,
-             "PUB KEY:  " << cred_options[CredentialType::PUBLIC_KEY]);
-    DL_DEBUG(log_context,
-             "PRIV KEY: " << cred_options[CredentialType::PRIVATE_KEY]);
-    DL_DEBUG(log_context,
-             "SERV KEY: " << cred_options[CredentialType::SERVER_KEY]);
-    DL_DEBUG(log_context, "Sending request to core service at address."
-                              << client->address());
 
-    auto response = client->receive(MessageType::GOOGLE_PROTOCOL_BUFFER);
-    if (response.message) { // Make sure the message exists before we try to
-                            // access it
-      log_context.correlation_id = std::get<std::string>(
-          response.message->get(MessageAttribute::CORRELATION_ID));
-    }
-    if (response.time_out) {
-      std::string error_msg =
-          "AuthWorker.cpp Core service did not respond within timeout.";
+    auto response = m_comm->receive(MessageType::GOOGLE_PROTOCOL_BUFFER);
 
-      AddressSplitter splitter(client->address());
-
-      if (splitter.port().value() != 7512) {
-
-        error_msg += "Port number is defined for: " + client->address() +
-                     " however, it is a non standard port, the standard port "
-                     "for connecting to the core server is port number 7512, "
-                     "whereas here you are using port: " +
-                     std::to_string(splitter.port().value());
-      }
-
-      DL_WARNING(log_context, error_msg);
-      EXCEPT(1, "Core service did not respond");
-    } else if (response.error) {
-      DL_ERROR(log_context, "AuthWorker.cpp there was an error when "
-                            "communicating with the core service: "
-                                << response.error_msg);
-    } else {
-
-      if (not response.message) {
-        DL_ERROR(log_context, "No error was reported and no time out occured "
-                              "but message is not defined.");
-      }
-
-      auto payload =
-          std::get<google::protobuf::Message *>(response.message->getPayload());
-      Anon::NackReply *nack = dynamic_cast<Anon::NackReply *>(payload);
-      if (!nack) {
-        return 0;
-      } else {
-        DL_DEBUG(log_context, "Received NACK reply");
-      }
-    }
-    return 1;
+    return processResponse(response);
   }
-
-private:
-  struct Config *m_config;
-  size_t m_test_path_len;
-  LogContext m_log_context;
-};
 
 } // End namespace SDMS
 

--- a/repository/gridftp/globus5/authz/source/AuthzWorker.cpp
+++ b/repository/gridftp/globus5/authz/source/AuthzWorker.cpp
@@ -1,6 +1,6 @@
 // Local private includes
-#include "Config.h"
 #include "AuthzWorker.hpp"
+#include "Config.h"
 #include "Version.hpp"
 
 // Common public includes
@@ -54,512 +54,546 @@ std::string randomAlphaNumericCode() {
 
 namespace SDMS {
 
-   AuthzWorker::AuthzWorker(struct Config *a_config, LogContext log_context)
-      : m_config(a_config) {
+AuthzWorker::AuthzWorker(struct Config *a_config, LogContext log_context)
+    : m_config(a_config) {
 
-    m_log_context = log_context;
-    m_log_context.thread_name += "-authz_worker";
-    m_log_context.thread_id = 0;
+  m_log_context = log_context;
+  m_log_context.thread_name += "-authz_worker";
+  m_log_context.thread_id = 0;
 
-    // Convert config item to string for easier manipulation
-    m_local_globus_path_root = std::string(m_config->globus_collection_path); 
+  // Convert config item to string for easier manipulation
+  m_local_globus_path_root = std::string(m_config->globus_collection_path);
 
-    m_test_path = std::string(m_config->test_path);
-    // NOTE the test_path MUST end with '/' this is to prevent authorization
-    // by accident to a subfolder i.e.
-    //
-    // /foobar
-    // /foo
-    //
-    // If m_test_path was meant just for the foo folder but an '/' is missing
-    // then both /foobar and /foo would be valid
-    //
-    // NOTE we also do not want add a '/' if the test_path is emtpy because that 
-    // would indicate no test path is being used.
-		if (!m_test_path.empty() && m_test_path.back() != '/') {
-		  m_test_path += '/';
-		}
-
-		// Add a backslash if not present
-    initCommunicator();
+  m_test_path = std::string(m_config->test_path);
+  // NOTE the test_path MUST end with '/' this is to prevent authorization
+  // by accident to a subfolder i.e.
+  //
+  // /foobar
+  // /foo
+  //
+  // If m_test_path was meant just for the foo folder but an '/' is missing
+  // then both /foobar and /foo would be valid
+  //
+  // NOTE we also do not want add a '/' if the test_path is emtpy because that
+  // would indicate no test path is being used.
+  if (!m_test_path.empty() && m_test_path.back() != '/') {
+    m_test_path += '/';
   }
 
-	/**
-	 * This method is used to initialize the communicator which will talk with
-   * the core services
-   *
-   * Setting up a communicator consists of several steps.
-   * 1. Setting up credentials that are needed to communicate securely
-   * 2. Creating the configuration options for how the communication should
-   *    occur
-   * 3. Creating the communicator.
-   *
-   **/
-  void AuthzWorker::initCommunicator() {
+  // Add a backslash if not present
+  initCommunicator();
+}
 
-    m_cred_options[CredentialType::PUBLIC_KEY] = m_config->pub_key;
-    m_cred_options[CredentialType::PRIVATE_KEY] = m_config->priv_key;
-    m_cred_options[CredentialType::SERVER_KEY] = m_config->server_key;
-    CredentialFactory cred_factory;
-    m_sec_ctx = cred_factory.create(ProtocolType::ZQTP, m_cred_options);
+/**
+ * This method is used to initialize the communicator which will talk with
+ * the core services
+ *
+ * Setting up a communicator consists of several steps.
+ * 1. Setting up credentials that are needed to communicate securely
+ * 2. Creating the configuration options for how the communication should
+ *    occur
+ * 3. Creating the communicator.
+ *
+ **/
+void AuthzWorker::initCommunicator() {
 
-    // Need to attach a random number to the authz_client_socket so that
-    // each authz client is distinct
-    std::string authz_thread_id;
-    authz_thread_id = "authz_client_socket-" + randomAlphaNumericCode();
+  m_cred_options[CredentialType::PUBLIC_KEY] = m_config->pub_key;
+  m_cred_options[CredentialType::PRIVATE_KEY] = m_config->priv_key;
+  m_cred_options[CredentialType::SERVER_KEY] = m_config->server_key;
+  CredentialFactory cred_factory;
+  m_sec_ctx = cred_factory.create(ProtocolType::ZQTP, m_cred_options);
 
-    m_comm = [&](const std::string &socket_id, const std::string &address,
-                      ICredentials &credentials) {
-      
-      /// Creating input parameters for constructing Communication Instance
-      AddressSplitter splitter(address);
+  // Need to attach a random number to the authz_client_socket so that
+  // each authz client is distinct
+  std::string authz_thread_id;
+  authz_thread_id = "authz_client_socket-" + randomAlphaNumericCode();
 
-      SocketOptions socket_options;
-      socket_options.scheme = splitter.scheme();
-      socket_options.class_type = SocketClassType::CLIENT;
-      socket_options.direction_type = SocketDirectionalityType::BIDIRECTIONAL;
-      socket_options.communication_type = SocketCommunicationType::ASYNCHRONOUS;
-      socket_options.connection_life = SocketConnectionLife::INTERMITTENT;
-      socket_options.protocol_type = ProtocolType::ZQTP;
-      socket_options.connection_security = SocketConnectionSecurity::SECURE;
-      socket_options.host = splitter.host();
-      socket_options.port = splitter.port();
+  m_comm = [&](const std::string &socket_id, const std::string &address,
+               ICredentials &credentials) {
+    /// Creating input parameters for constructing Communication Instance
+    AddressSplitter splitter(address);
 
-      if (socket_options.port.has_value()) {
-        if (socket_options.port.value() != 7512) {
-          DL_WARNING(m_log_context,
-                     "Port number is defined for: "
-                         << address
-                         << " however, it is a non standard port, the standard "
-                            "port for connecting to the core server is port "
-                            "number 7512, whereas here you are using port: "
-                         << socket_options.port.value());
-        }
+    SocketOptions socket_options;
+    socket_options.scheme = splitter.scheme();
+    socket_options.class_type = SocketClassType::CLIENT;
+    socket_options.direction_type = SocketDirectionalityType::BIDIRECTIONAL;
+    socket_options.communication_type = SocketCommunicationType::ASYNCHRONOUS;
+    socket_options.connection_life = SocketConnectionLife::INTERMITTENT;
+    socket_options.protocol_type = ProtocolType::ZQTP;
+    socket_options.connection_security = SocketConnectionSecurity::SECURE;
+    socket_options.host = splitter.host();
+    socket_options.port = splitter.port();
+
+    if (socket_options.port.has_value()) {
+      if (socket_options.port.value() != 7512) {
+        DL_WARNING(m_log_context,
+                   "Port number is defined for: "
+                       << address
+                       << " however, it is a non standard port, the standard "
+                          "port for connecting to the core server is port "
+                          "number 7512, whereas here you are using port: "
+                       << socket_options.port.value());
       }
-      socket_options.local_id = socket_id;
-
-      uint32_t timeout_on_receive = 50000;
-      long timeout_on_poll = 50000;
-
-      CommunicatorFactory comm_factory(m_log_context);
-
-      return comm_factory.create(socket_options, credentials,
-                                 timeout_on_receive, timeout_on_poll);
-    }(authz_thread_id, m_config->server_addr, *m_sec_ctx);
-
-  }
-
-  /**
-	 * @brief Determine if the given POSIX path is within the configured test path.
-	 *
-	 * A test path can be set in the authorization configuration file to assist
-	 * with debugging and setup of a DataFed-managed Globus collection.
-	 * Any authorization associated with this path and its subpaths in the
-	 * folder hierarchy is automatically approved.
-	 *
-	 * @param posix_path The POSIX-style file path to evaluate.
-	 * @return `true` if the provided path is within the configured test path,
-	 *         `false` otherwise.
-	 *
-	 * @note This method uses the `m_test_path` and its length `m_test_path_len`
-	 *       to determine if the `posix_path` starts with the test path.
-	 *       If the test path is not set (`m_test_path_len == 0`), the function
-	 *       will always return `false`.
-	 *
-	 * @attention Use caution when setting a test path, as it bypasses normal
-	 *            authorization checks for all matching paths.
-	 *
-	 * Example:
-	 * @code
-	 * AuthzWorker authzWorker;
-	 * std::string path = "/data/test_path/example_file";
-	 * if (authzWorker.isTestPath(path)) {
-	 *     std::cout << "Path is within the test path!" << std::endl;
-	 * } else {
-	 *     std::cout << "Path is not within the test path." << std::endl;
-	 * }
-	 * @endcode
-	 */
-  bool AuthzWorker::isTestPath(const std::string & posix_path) const {
-    if (m_test_path.size() > 0 &&
-        posix_path.compare(0, m_test_path.size(), m_test_path) == 0) {
-      DL_INFO(m_log_context, "Allowing request within TEST PATH: "
-          << m_config->test_path);
-      return true;
     }
+    socket_options.local_id = socket_id;
+
+    uint32_t timeout_on_receive = 50000;
+    long timeout_on_poll = 50000;
+
+    CommunicatorFactory comm_factory(m_log_context);
+
+    return comm_factory.create(socket_options, credentials, timeout_on_receive,
+                               timeout_on_poll);
+  }(authz_thread_id, m_config->server_addr, *m_sec_ctx);
+}
+
+/**
+ * @brief Determine if the given POSIX path is within the configured test path.
+ *
+ * A test path can be set in the authorization configuration file to assist
+ * with debugging and setup of a DataFed-managed Globus collection.
+ * Any authorization associated with this path and its subpaths in the
+ * folder hierarchy is automatically approved.
+ *
+ * @param posix_path The POSIX-style file path to evaluate.
+ * @return `true` if the provided path is within the configured test path,
+ *         `false` otherwise.
+ *
+ * @note This method uses the `m_test_path` and its length `m_test_path_len`
+ *       to determine if the `posix_path` starts with the test path.
+ *       If the test path is not set (`m_test_path_len == 0`), the function
+ *       will always return `false`.
+ *
+ * @attention Use caution when setting a test path, as it bypasses normal
+ *            authorization checks for all matching paths.
+ *
+ * Example:
+ * @code
+ * AuthzWorker authzWorker;
+ * std::string path = "/data/test_path/example_file";
+ * if (authzWorker.isTestPath(path)) {
+ *     std::cout << "Path is within the test path!" << std::endl;
+ * } else {
+ *     std::cout << "Path is not within the test path." << std::endl;
+ * }
+ * @endcode
+ */
+bool AuthzWorker::isTestPath(const std::string &posix_path) const {
+  if (m_test_path.size() > 0 &&
+      posix_path.compare(0, m_test_path.size(), m_test_path) == 0) {
+    DL_INFO(m_log_context,
+            "Allowing request within TEST PATH: " << m_config->test_path);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Validates whether the provided POSIX path is properly formatted.
+ *
+ * This method checks if the given POSIX path starts with the configured
+ * Globus root collection path (`m_local_globus_path_root`). If the path is not
+ * properly formatted, an error message is logged, and the method returns
+ * `false`.
+ *
+ * @param posix_path The POSIX-style file path to validate.
+ * @return `true` if the provided path is valid (properly formatted),
+ *         `false` otherwise.
+ *
+ * @note The validation ensures that the `posix_path` begins with the
+ *       `m_local_globus_path_root` prefix. If the path is shorter than the
+ *       root prefix, it is considered invalid.
+ *
+ * @attention An improperly formatted path indicates a configuration or
+ *            user error and will result in an error log message.
+ *
+ * Example:
+ * @code
+ * AuthzWorker authzWorker;
+ * std::string path = "/data/globus_root/example_file";
+ * if (authzWorker.isPathValid(path)) {
+ *     std::cout << "Path is valid!" << std::endl;
+ * } else {
+ *     std::cout << "Path is invalid." << std::endl;
+ * }
+ * @endcode
+ *
+ * Errors:
+ * - Logs an error if the path does not start with `m_local_globus_path_root`.
+ * - Logs an error if the path is shorter than `m_local_globus_path_root`.
+ */
+bool AuthzWorker::isPathValid(const std::string &posix_path) const {
+  if (m_local_globus_path_root.length() > posix_path.length()) {
+    std::string err_message =
+        "Provided path is not properly formatted, should be prefixed with "
+        "globus_root_collection_path: ";
+    err_message += m_local_globus_path_root + " but is: " + posix_path;
+    DL_ERROR(m_log_context, err_message);
     return false;
   }
 
-	/**
-	 * @brief Validates whether the provided POSIX path is properly formatted.
-	 *
-	 * This method checks if the given POSIX path starts with the configured
-	 * Globus root collection path (`m_local_globus_path_root`). If the path is not
-	 * properly formatted, an error message is logged, and the method returns `false`.
-	 *
-	 * @param posix_path The POSIX-style file path to validate.
-	 * @return `true` if the provided path is valid (properly formatted),
-	 *         `false` otherwise.
-	 *
-	 * @note The validation ensures that the `posix_path` begins with the
-	 *       `m_local_globus_path_root` prefix. If the path is shorter than the
-	 *       root prefix, it is considered invalid.
-	 *
-	 * @attention An improperly formatted path indicates a configuration or
-	 *            user error and will result in an error log message.
-	 *
-	 * Example:
-	 * @code
-	 * AuthzWorker authzWorker;
-	 * std::string path = "/data/globus_root/example_file";
-	 * if (authzWorker.isPathValid(path)) {
-	 *     std::cout << "Path is valid!" << std::endl;
-	 * } else {
-	 *     std::cout << "Path is invalid." << std::endl;
-	 * }
-	 * @endcode
-	 *
-	 * Errors:
-	 * - Logs an error if the path does not start with `m_local_globus_path_root`.
-	 * - Logs an error if the path is shorter than `m_local_globus_path_root`.
-	 */
-  bool AuthzWorker::isPathValid(const std::string & posix_path) const {
-    if (m_local_globus_path_root.length() > posix_path.length()) {
-      std::string err_message =
-          "Provided path is not properly formatted, should be prefixed with "
-          "globus_root_collection_path: ";
-      err_message += m_local_globus_path_root + " but is: " + posix_path;
-      DL_ERROR(m_log_context, err_message);
-      return false;
-    }
+  auto prefix = posix_path.substr(0, m_local_globus_path_root.length());
+  if (prefix.compare(m_local_globus_path_root) != 0) {
+    std::string err_message =
+        "Provided path is not properly formatted, should be prefixed with "
+        "globus_root_collection_path: ";
+    err_message += m_local_globus_path_root + " but is: " + prefix;
+    DL_ERROR(m_log_context, err_message);
+    return false;
+  }
+  return true;
+}
 
-    auto prefix = posix_path.substr(0, m_local_globus_path_root.length());
-    if (prefix.compare(m_local_globus_path_root) != 0) {
-      std::string err_message =
-          "Provided path is not properly formatted, should be prefixed with "
-          "globus_root_collection_path: ";
-      err_message += m_local_globus_path_root + " but is: " + prefix;
-      DL_ERROR(m_log_context, err_message);
-      return false;
-    }
-    return true;
+/**
+ * @brief Validates whether the provided FTP URL is properly formatted.
+ *
+ * This method checks if the given FTP URL starts with the required scheme
+ * (`ftp://`) and contains at least three slashes, which indicates the presence
+ * of a hostname after the scheme. If the URL is not properly formatted, an
+ * error message is logged, and the method returns `false`.
+ *
+ * @param full_ftp_url A C-style string representing the full FTP URL to
+ * validate.
+ * @return `true` if the URL is valid (properly formatted),
+ *         `false` otherwise.
+ *
+ * @note The method performs the following checks:
+ *       - The URL must begin with the `ftp://` scheme.
+ *       - The URL must include at least three slashes to indicate a valid
+ *         scheme and hostname.
+ *
+ * @attention Improperly formatted URLs result in error log messages to help
+ *            diagnose issues.
+ *
+ * Example:
+ * @code
+ * AuthzWorker authzWorker;
+ * char url[] = "ftp://hostname/path/to/file";
+ * if (authzWorker.isURLValid(url)) {
+ *     std::cout << "URL is valid!" << std::endl;
+ * } else {
+ *     std::cout << "URL is invalid." << std::endl;
+ * }
+ * @endcode
+ *
+ * Errors:
+ * - Logs an error if the URL does not start with `ftp://`.
+ * - Logs an error if the URL contains fewer than three slashes.
+ */
+bool AuthzWorker::isURLValid(char *full_ftp_url) const {
+
+  std::string scheme = "ftp://";
+  auto local_path = std::string(full_ftp_url);
+  if (local_path.substr(0, scheme.length()).compare(scheme) != 0) {
+    DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
+                            "be prefixed with ftp:// but is: "
+                                << full_ftp_url);
+    return false;
   }
 
-	/**
-	 * @brief Validates whether the provided FTP URL is properly formatted.
-	 *
-	 * This method checks if the given FTP URL starts with the required scheme
-	 * (`ftp://`) and contains at least three slashes, which indicates the presence
-	 * of a hostname after the scheme. If the URL is not properly formatted, an
-	 * error message is logged, and the method returns `false`.
-	 *
-	 * @param full_ftp_url A C-style string representing the full FTP URL to validate.
-	 * @return `true` if the URL is valid (properly formatted),
-	 *         `false` otherwise.
-	 *
-	 * @note The method performs the following checks:
-	 *       - The URL must begin with the `ftp://` scheme.
-	 *       - The URL must include at least three slashes to indicate a valid
-	 *         scheme and hostname.
-	 *
-	 * @attention Improperly formatted URLs result in error log messages to help
-	 *            diagnose issues.
-	 *
-	 * Example:
-	 * @code
-	 * AuthzWorker authzWorker;
-	 * char url[] = "ftp://hostname/path/to/file";
-	 * if (authzWorker.isURLValid(url)) {
-	 *     std::cout << "URL is valid!" << std::endl;
-	 * } else {
-	 *     std::cout << "URL is invalid." << std::endl;
-	 * }
-	 * @endcode
-	 *
-	 * Errors:
-	 * - Logs an error if the URL does not start with `ftp://`.
-	 * - Logs an error if the URL contains fewer than three slashes.
-	 */
-  bool AuthzWorker::isURLValid(char * full_ftp_url) const {
+  int count = std::count(local_path.begin(), local_path.end(), '/');
+  if (count < 3) {
+    DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
+                            "be prefixed with ftp://hostname but is: "
+                                << full_ftp_url);
+    return false;
+  }
 
-    std::string scheme = "ftp://";
-    auto local_path = std::string(full_ftp_url);
-    if (local_path.substr(0, scheme.length()).compare(scheme) != 0) {
-      DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
-                              "be prefixed with ftp:// but is: "
-                                  << full_ftp_url);
-      return false;
-    }
+  // Make sure there are at least 8 characters
+  // i.e. ftp://b/
+  if (local_path.length() < 8) {
+    DL_ERROR(m_log_context,
+             "Provided ftp URL is invalid, URL must have host and trailing /");
+    return false;
+  }
 
-    int count = std::count(local_path.begin(), local_path.end(), '/');
-    if (count < 3) {
-      DL_ERROR(m_log_context, "Provided path is not properly formatted, should "
-                              "be prefixed with ftp://hostname but is: "
-                                  << full_ftp_url);
-      return false;
-    }
+  // index of character after ftp:// index 6
+  size_t char_index = 6;
+  if (local_path.at(char_index) == '/') {
+    DL_ERROR(m_log_context, "Provided ftp URL is missing hostname");
+    return false;
+  }
+  return true;
+}
 
-    // Make sure there are at least 8 characters
-    // i.e. ftp://b/
-    if ( local_path.length() < 8 ) {
-      DL_ERROR(m_log_context, "Provided ftp URL is invalid, URL must have host and trailing /");
-      return false;
-    }
+/**
+ * @brief Removes the origin (ftp://hostname) from the given FTP URL.
+ *
+ * This method strips the `ftp://hostname` portion from a provided FTP URL,
+ * leaving only the path portion starting from the Globus collection root path.
+ * The URL is expected to be in the format:
+ * `ftp://hostname/globus_collection_root_path`. The method extracts the
+ * substring that follows the third occurrence of a slash (`/`), which is used
+ * to identify the path after the hostname.
+ *
+ * @param full_ftp_url A C-style string representing the full FTP URL, including
+ * the hostname and path.
+ * @return A string containing the remaining path after the `ftp://hostname`
+ * portion.
+ *
+ * @note The method assumes the URL follows the
+ * `ftp://hostname/globus_collection_root_path` format. If there are fewer than
+ * three slashes in the URL, it will return the entire string after the first
+ * two slashes.
+ *
+ * @attention The method does not validate the URL structure beyond checking for
+ * slashes, so improper formatting may result in unexpected behavior.
+ *
+ * Example:
+ * @code
+ * AuthzWorker authzWorker;
+ * char url[] = "ftp://hostname/globus_root_path/some/file";
+ * std::string path = authzWorker.removeOrigin(url);
+ * std::cout << "Path after origin removed: " << path << std::endl;
+ * @endcode
+ *
+ * Errors:
+ * - Logs an error if the format does not meet the expected `ftp://hostname/`
+ * structure.
+ */
+std::string AuthzWorker::removeOrigin(char *full_ftp_url) const {
 
-    // index of character after ftp:// index 6
-    size_t char_index = 6; 
-    if ( local_path.at(char_index) == '/' ) {
-      DL_ERROR(m_log_context, "Provided ftp URL is missing hostname");
-      return false;
-    }
-    return true;
-  } 
+  if (isURLValid(full_ftp_url) == false) {
+    EXCEPT(1, "Invalid formatted ftp url.");
+  }
 
+  auto local_path = std::string(full_ftp_url);
+  char backslash = '/';
+  int count = 0;
+  size_t index = 0;
 
-	/**
-	 * @brief Removes the origin (ftp://hostname) from the given FTP URL.
-	 *
-	 * This method strips the `ftp://hostname` portion from a provided FTP URL, leaving
-	 * only the path portion starting from the Globus collection root path.
-	 * The URL is expected to be in the format: `ftp://hostname/globus_collection_root_path`.
-	 * The method extracts the substring that follows the third occurrence of a slash (`/`),
-	 * which is used to identify the path after the hostname.
-	 *
-	 * @param full_ftp_url A C-style string representing the full FTP URL, including the hostname and path.
-	 * @return A string containing the remaining path after the `ftp://hostname` portion.
-	 *
-	 * @note The method assumes the URL follows the `ftp://hostname/globus_collection_root_path` format.
-	 *       If there are fewer than three slashes in the URL, it will return the entire string after
-	 *       the first two slashes.
-	 *
-	 * @attention The method does not validate the URL structure beyond checking for slashes,
-	 *            so improper formatting may result in unexpected behavior.
-	 *
-	 * Example:
-	 * @code
-	 * AuthzWorker authzWorker;
-	 * char url[] = "ftp://hostname/globus_root_path/some/file";
-	 * std::string path = authzWorker.removeOrigin(url);
-	 * std::cout << "Path after origin removed: " << path << std::endl;
-	 * @endcode
-	 *
-	 * Errors:
-	 * - Logs an error if the format does not meet the expected `ftp://hostname/` structure.
-	 */
-  std::string AuthzWorker::removeOrigin(char * full_ftp_url) const {
-
-    if (isURLValid(full_ftp_url) == false) {
-      EXCEPT(1, "Invalid formatted ftp url.");
-    }
-
-    auto local_path = std::string(full_ftp_url);
-    char backslash = '/';
-    int count = 0;
-    size_t index = 0;
-
-    for (size_t i = 0; i < local_path.length(); i++) {
-      if (local_path[i] == backslash) {
-        count++;
-        if (count == 3) {
-          index = i;
-          break;
-        }
+  for (size_t i = 0; i < local_path.length(); i++) {
+    if (local_path[i] == backslash) {
+      count++;
+      if (count == 3) {
+        index = i;
+        break;
       }
     }
-
-    // Extract the substring after the third occurrence of the character
-    return local_path.substr(index);
   }
 
-	/**
-	 * @brief Retrieves the authorization path from the given FTP URL by removing the origin and validating the path.
-	 *
-	 * This method first removes the `ftp://hostname` portion from the provided FTP path using the `removeOrigin` method.
-	 * Then, it validates the remaining path to ensure it is properly formatted with the expected Globus collection root path.
-	 * If the path is invalid, an exception is thrown. Finally, it returns the path after the Globus collection root prefix.
-	 *
-	 * @param full_ftp_path A C-style string representing the full FTP URL, which includes the scheme, hostname, and path.
-	 * @return A string containing the authorization path after the `ftp://hostname` portion and the Globus collection root path.
-	 *
-	 * @throws EXCEPT(1, "Invalid POSIX path.") If the path is not valid according to the `isPathValid` method.
-	 *
-	 * @note The method relies on the `removeOrigin` method to remove the `ftp://hostname` portion and expects the remaining path
-	 *       to start with a valid Globus collection root path.
-	 *
-	 * Example:
-	 * @code
-	 * AuthzWorker authzWorker;
-	 * char path[] = "ftp://hostname/globus_root_path/some/file";
-	 * std::string authzPath = authzWorker.getAuthzPath(path);
-	 * std::cout << "Authorization Path: " << authzPath << std::endl;
-	 * @endcode
-	 *
-	 * Errors:
-	 * - Throws an exception if the path is invalid.
-	 */
-  std::string AuthzWorker::getAuthzPath(char * full_ftp_path) {
-    std::string local_path = removeOrigin(full_ftp_path);
+  // Extract the substring after the third occurrence of the character
+  return local_path.substr(index);
+}
 
-    if (isPathValid(local_path) == false) {
-      EXCEPT(1, "Invalid POSIX path.");
-    }
-    auto prefix = local_path.substr(0, m_local_globus_path_root.length());
+/**
+ * @brief Retrieves the authorization path from the given FTP URL by removing
+ * the origin and validating the path.
+ *
+ * This method first removes the `ftp://hostname` portion from the provided FTP
+ * path using the `removeOrigin` method. Then, it validates the remaining path
+ * to ensure it is properly formatted with the expected Globus collection root
+ * path. If the path is invalid, an exception is thrown. Finally, it returns the
+ * path after the Globus collection root prefix.
+ *
+ * @param full_ftp_path A C-style string representing the full FTP URL, which
+ * includes the scheme, hostname, and path.
+ * @return A string containing the authorization path after the `ftp://hostname`
+ * portion and the Globus collection root path.
+ *
+ * @throws EXCEPT(1, "Invalid POSIX path.") If the path is not valid according
+ * to the `isPathValid` method.
+ *
+ * @note The method relies on the `removeOrigin` method to remove the
+ * `ftp://hostname` portion and expects the remaining path to start with a valid
+ * Globus collection root path.
+ *
+ * Example:
+ * @code
+ * AuthzWorker authzWorker;
+ * char path[] = "ftp://hostname/globus_root_path/some/file";
+ * std::string authzPath = authzWorker.getAuthzPath(path);
+ * std::cout << "Authorization Path: " << authzPath << std::endl;
+ * @endcode
+ *
+ * Errors:
+ * - Throws an exception if the path is invalid.
+ */
+std::string AuthzWorker::getAuthzPath(char *full_ftp_path) {
+  std::string local_path = removeOrigin(full_ftp_path);
 
-    return local_path.substr(prefix.length());
+  if (isPathValid(local_path) == false) {
+    EXCEPT(1, "Invalid POSIX path.");
   }
+  auto prefix = local_path.substr(0, m_local_globus_path_root.length());
 
-	/**
-	 * @brief Processes the response received from the core service and handles different scenarios such as timeout, errors, and valid responses.
-	 *
-	 * This method is designed to process a response from the core service, checking for various conditions such as whether the response 
-	 * contains a message, whether there was a timeout, or whether an error occurred. If the response is valid and contains the expected 
-	 * payload, the method will further inspect it to check for a NACK reply.
-	 *
-	 * The method performs the following:
-	 * - If the response contains a valid message, it extracts the correlation ID.
-	 * - If the response has a timeout, it logs a warning with details about the service's address and port.
-	 * - If an error occurs, it logs the error message.
-	 * - If no errors or timeouts are present, it checks if the payload is a NACK reply.
-	 * - If the response is a NACK, it logs a debug message.
-	 *
-	 * @param response A reference to an `ICommunicator::Response` object that contains the response data.
-	 * @return `1` if a NACK response was received, `0` otherwise.
-	 *
-	 * @throws EXCEPT(1, "Core service did not respond") If the core service response times out.
-	 *
-	 * @note This method assumes that the response message and error fields are populated correctly before processing.
-	 *
-	 * Example:
-	 * @code
-	 * ICommunicator::Response response = communicator.getResponse();
-	 * int result = authzWorker.processResponse(response);
-	 * if (result == 1) {
-	 *     std::cout << "Received NACK reply" << std::endl;
-	 * } else {
-	 *     std::cout << "Response processed successfully" << std::endl;
-	 * }
-	 * @endcode
-	 */
-  int AuthzWorker::processResponse(ICommunicator::Response & response) {
-    if (response.message) { // Make sure the message exists before we try to
-                            // access it
-      m_log_context.correlation_id = std::get<std::string>(
-          response.message->get(MessageAttribute::CORRELATION_ID));
+  return local_path.substr(prefix.length());
+}
+
+/**
+ * @brief Processes the response received from the core service and handles
+ * different scenarios such as timeout, errors, and valid responses.
+ *
+ * This method is designed to process a response from the core service, checking
+ * for various conditions such as whether the response contains a message,
+ * whether there was a timeout, or whether an error occurred. If the response is
+ * valid and contains the expected payload, the method will further inspect it
+ * to check for a NACK reply.
+ *
+ * The method performs the following:
+ * - If the response contains a valid message, it extracts the correlation ID.
+ * - If the response has a timeout, it logs a warning with details about the
+ * service's address and port.
+ * - If an error occurs, it logs the error message.
+ * - If no errors or timeouts are present, it checks if the payload is a NACK
+ * reply.
+ * - If the response is a NACK, it logs a debug message.
+ *
+ * @param response A reference to an `ICommunicator::Response` object that
+ * contains the response data.
+ * @return `1` if a NACK response was received, `0` otherwise.
+ *
+ * @throws EXCEPT(1, "Core service did not respond") If the core service
+ * response times out.
+ *
+ * @note This method assumes that the response message and error fields are
+ * populated correctly before processing.
+ *
+ * Example:
+ * @code
+ * ICommunicator::Response response = communicator.getResponse();
+ * int result = authzWorker.processResponse(response);
+ * if (result == 1) {
+ *     std::cout << "Received NACK reply" << std::endl;
+ * } else {
+ *     std::cout << "Response processed successfully" << std::endl;
+ * }
+ * @endcode
+ */
+int AuthzWorker::processResponse(ICommunicator::Response &response) {
+  if (response.message) { // Make sure the message exists before we try to
+                          // access it
+    m_log_context.correlation_id = std::get<std::string>(
+        response.message->get(MessageAttribute::CORRELATION_ID));
+  }
+  if (response.time_out) {
+    std::string error_msg =
+        "AuthWorker.cpp Core service did not respond within timeout.";
+
+    AddressSplitter splitter(m_comm->address());
+
+    if (splitter.port().value() != 7512) {
+
+      error_msg += "Port number is defined for: " + m_comm->address() +
+                   " however, it is a non standard port, the standard port "
+                   "for connecting to the core server is port number 7512, "
+                   "whereas here you are using port: " +
+                   std::to_string(splitter.port().value());
     }
-    if (response.time_out) {
-      std::string error_msg =
-          "AuthWorker.cpp Core service did not respond within timeout.";
 
-      AddressSplitter splitter(m_comm->address());
-
-      if (splitter.port().value() != 7512) {
-
-        error_msg += "Port number is defined for: " + m_comm->address() +
-                     " however, it is a non standard port, the standard port "
-                     "for connecting to the core server is port number 7512, "
-                     "whereas here you are using port: " +
-                     std::to_string(splitter.port().value());
-      }
-
-      DL_WARNING(m_log_context, error_msg);
-      EXCEPT(1, "Core service did not respond");
-    } else if (response.error) {
-      // This will just log the output without throwing.
-      DL_ERROR(m_log_context, "AuthWorker.cpp there was an error when "
+    DL_WARNING(m_log_context, error_msg);
+    EXCEPT(1, "Core service did not respond");
+  } else if (response.error) {
+    // This will just log the output without throwing.
+    DL_ERROR(m_log_context, "AuthWorker.cpp there was an error when "
                             "communicating with the core service: "
                                 << response.error_msg);
-    } else {
+  } else {
 
-      if (not response.message) {
-        DL_ERROR(m_log_context, "No error was reported and no time out occured "
+    if (not response.message) {
+      DL_ERROR(m_log_context, "No error was reported and no time out occured "
                               "but message is not defined.");
-        EXCEPT(1, "This exception indicates that something is very wrong.");
-          
-      }
-
-      auto payload =
-          std::get<google::protobuf::Message *>(response.message->getPayload());
-      Anon::NackReply *nack = dynamic_cast<Anon::NackReply *>(payload);
-      if (!nack) {
-        return 0;
-      } else {
-        DL_DEBUG(m_log_context, "Received NACK reply");
-      }
+      EXCEPT(1, "This exception indicates that something is very wrong.");
     }
-    return 1;
+
+    auto payload =
+        std::get<google::protobuf::Message *>(response.message->getPayload());
+    Anon::NackReply *nack = dynamic_cast<Anon::NackReply *>(payload);
+    if (!nack) {
+      return 0;
+    } else {
+      DL_DEBUG(m_log_context, "Received NACK reply");
+    }
+  }
+  return 1;
+}
+
+/**
+ * @brief Checks the authorization for a given client and action on a specific
+ * path.
+ *
+ * This method performs the following steps to check authorization:
+ * - Logs the client ID being checked.
+ * - Sanitizes the provided path using the `getAuthzPath` method. If the path is
+ * invalid, an exception is raised.
+ * - If the path is determined to be a test path, the method returns early with
+ * a `0`, allowing access without further checks.
+ * - Constructs an authorization request (`AuthzRequest`) and sets the
+ * repository ID, client ID, path, and action to be validated.
+ * - Creates a message using `MessageFactory` and sets the public key from the
+ * credentials options.
+ * - Sends the message through the communicator and waits for a response.
+ * - Processes the response using the `processResponse` method and returns the
+ * result.
+ *
+ * This method is used to ensure that the client has proper authorization to
+ * perform a specific action on a file or resource. It validates the action
+ * against the provided path and client ID, contacting the core service for
+ * verification.
+ *
+ * @param client_id The client ID requesting the action.
+ * @param path The path to the file or resource to be accessed.
+ * @param action The action (e.g., read, write) that the client wants to
+ * perform.
+ * @return An integer result based on the response:
+ * - `0` if the path is a test path or authorization is granted.
+ * - Non-zero value indicating the result of the authorization process (such as
+ * the result of the NACK check).
+ *
+ * @throws EXCEPT(1, "Invalid POSIX path.") If the path cannot be sanitized or
+ * is invalid.
+ *
+ * @note This method relies on the communication layer to send and receive
+ * messages to validate authorization and requires a configured communicator and
+ * credentials options.
+ *
+ * Example:
+ * @code
+ * char client_id[] = "client123";
+ * char path[] = "/some/path/to/resource";
+ * char action[] = "read";
+ * AuthzWorker auth_worker;
+ * int result = auth_worker.checkAuth(client_id, path, action);
+ * if (result == 0) {
+ *     std::cout << "Authorization granted or path is a test path" << std::endl;
+ * } else {
+ *     std::cout << "Authorization failed or additional checks required" <<
+ * std::endl;
+ * }
+ * @endcode
+ */
+int AuthzWorker::checkAuth(char *client_id, char *path, char *action) {
+  DL_DEBUG(m_log_context, "Checking auth for client: " << client_id);
+
+  // An exception will be raised here if the path is invalid
+  std::string sanitized_path = getAuthzPath(path);
+
+  if (isTestPath(sanitized_path)) {
+    return 0;
   }
 
-	/**
-	 * @brief Checks the authorization for a given client and action on a specific path.
-	 *
-	 * This method performs the following steps to check authorization:
-	 * - Logs the client ID being checked.
-	 * - Sanitizes the provided path using the `getAuthzPath` method. If the path is invalid, an exception is raised.
-	 * - If the path is determined to be a test path, the method returns early with a `0`, allowing access without further checks.
-	 * - Constructs an authorization request (`AuthzRequest`) and sets the repository ID, client ID, path, and action to be validated.
-	 * - Creates a message using `MessageFactory` and sets the public key from the credentials options.
-	 * - Sends the message through the communicator and waits for a response.
-	 * - Processes the response using the `processResponse` method and returns the result.
-	 *
-	 * This method is used to ensure that the client has proper authorization to perform a specific action on a file or resource.
-	 * It validates the action against the provided path and client ID, contacting the core service for verification.
-	 *
-	 * @param client_id The client ID requesting the action.
-	 * @param path The path to the file or resource to be accessed.
-	 * @param action The action (e.g., read, write) that the client wants to perform.
-	 * @return An integer result based on the response:
-	 * - `0` if the path is a test path or authorization is granted.
-	 * - Non-zero value indicating the result of the authorization process (such as the result of the NACK check).
-	 *
-	 * @throws EXCEPT(1, "Invalid POSIX path.") If the path cannot be sanitized or is invalid.
-	 * 
-	 * @note This method relies on the communication layer to send and receive messages to validate authorization and requires a 
-	 * configured communicator and credentials options.
-	 * 
-	 * Example:
-	 * @code
-	 * char client_id[] = "client123";
-	 * char path[] = "/some/path/to/resource";
-	 * char action[] = "read";
-	 * AuthzWorker auth_worker;
-	 * int result = auth_worker.checkAuth(client_id, path, action);
-	 * if (result == 0) {
-	 *     std::cout << "Authorization granted or path is a test path" << std::endl;
-	 * } else {
-	 *     std::cout << "Authorization failed or additional checks required" << std::endl;
-	 * }
-	 * @endcode
-	 */
-  int AuthzWorker::checkAuth(char *client_id, char *path, char *action) {
-    DL_DEBUG(m_log_context, "Checking auth for client: " << client_id);
+  auto auth_req = std::make_unique<Auth::RepoAuthzRequest>();
 
-    // An exception will be raised here if the path is invalid
-    std::string sanitized_path = getAuthzPath(path);
+  auth_req->set_repo(m_config->repo_id);
+  auth_req->set_client(client_id);
+  auth_req->set_file(sanitized_path);
+  auth_req->set_action(action);
 
-    if (isTestPath(sanitized_path)) { return 0; }
+  MessageFactory msg_factory;
+  auto message = msg_factory.create(MessageType::GOOGLE_PROTOCOL_BUFFER);
+  message->set(MessageAttribute::KEY,
+               m_cred_options[CredentialType::PUBLIC_KEY]);
+  message->setPayload(std::move(auth_req));
 
-    auto auth_req = std::make_unique<Auth::RepoAuthzRequest>();
+  m_comm->send(*message);
+  LogContext log_context = m_log_context;
+  log_context.correlation_id =
+      std::get<std::string>(message->get(MessageAttribute::CORRELATION_ID));
 
-    auth_req->set_repo(m_config->repo_id);
-    auth_req->set_client(client_id);
-    auth_req->set_file(sanitized_path);
-    auth_req->set_action(action);
+  auto response = m_comm->receive(MessageType::GOOGLE_PROTOCOL_BUFFER);
 
-    MessageFactory msg_factory;
-    auto message = msg_factory.create(MessageType::GOOGLE_PROTOCOL_BUFFER);
-    message->set(MessageAttribute::KEY,
-                 m_cred_options[CredentialType::PUBLIC_KEY]);
-    message->setPayload(std::move(auth_req));
-
-    m_comm->send(*message);
-    LogContext log_context = m_log_context;
-    log_context.correlation_id =
-        std::get<std::string>(message->get(MessageAttribute::CORRELATION_ID));
-
-    auto response = m_comm->receive(MessageType::GOOGLE_PROTOCOL_BUFFER);
-
-    return processResponse(response);
-  }
+  return processResponse(response);
+}
 
 } // End namespace SDMS
 

--- a/repository/gridftp/globus5/authz/source/AuthzWorker.hpp
+++ b/repository/gridftp/globus5/authz/source/AuthzWorker.hpp
@@ -2,6 +2,9 @@
 #define AUTHZWORKER_HPP
 #pragma once
 
+// Private includes
+#include "Config.h"
+
 // Common public includes
 #include "common/DynaLog.hpp"
 #include "common/ICommunicator.hpp"
@@ -51,7 +54,6 @@ namespace SDMS {
 
       void initCommunicator();
       struct Config *m_config;
-      size_t m_test_path_len;
       std::string m_test_path;
       std::string m_local_globus_path_root;
       LogContext m_log_context;

--- a/repository/gridftp/globus5/authz/source/AuthzWorker.hpp
+++ b/repository/gridftp/globus5/authz/source/AuthzWorker.hpp
@@ -16,52 +16,57 @@
 
 namespace SDMS {
 
-	/**
-	 * @class AuthzWorker
-	 * @brief Handles authorization checking, path validation, and FTP URL processing.
-	 *
-	 * The `AuthzWorker` class is responsible for handling authorization requests,
-	 * validating paths, processing FTP URLs, and interacting with a core service to
-	 * perform authorization checks. It utilizes a communicator for sending and receiving
-	 * messages and manages security credentials to perform its operations.
-	 *
-	 * The class provides various methods for:
-	 * - Checking the validity of paths and URLs.
-	 * - Verifying authorization for a client on a given path with a specified action.
-	 * - Removing the origin portion of an FTP URL to extract the path.
-	 * - Processing responses from the core service to determine authorization success or failure.
-	 * 
-	 * The class requires configuration and logging context for proper initialization.
-	 */
-  class AuthzWorker {
-    public:
-      AuthzWorker(struct Config *a_config, LogContext log_context);
+/**
+ * @class AuthzWorker
+ * @brief Handles authorization checking, path validation, and FTP URL
+ * processing.
+ *
+ * The `AuthzWorker` class is responsible for handling authorization requests,
+ * validating paths, processing FTP URLs, and interacting with a core service to
+ * perform authorization checks. It utilizes a communicator for sending and
+ * receiving messages and manages security credentials to perform its
+ * operations.
+ *
+ * The class provides various methods for:
+ * - Checking the validity of paths and URLs.
+ * - Verifying authorization for a client on a given path with a specified
+ * action.
+ * - Removing the origin portion of an FTP URL to extract the path.
+ * - Processing responses from the core service to determine authorization
+ * success or failure.
+ *
+ * The class requires configuration and logging context for proper
+ * initialization.
+ */
+class AuthzWorker {
+public:
+  AuthzWorker(struct Config *a_config, LogContext log_context);
 
-      ~AuthzWorker() {}
+  ~AuthzWorker() {}
 
-      AuthzWorker &operator=(const AuthzWorker &) = delete;
+  AuthzWorker &operator=(const AuthzWorker &) = delete;
 
-      int checkAuth(char *client_id, char *path, char *action);
+  int checkAuth(char *client_id, char *path, char *action);
 
-      bool isTestPath(const std::string &) const;
-      bool isURLValid(char * full_ftp_url) const;
-      bool isPathValid(const std::string & posix_path) const;
-      std::string getAuthzPath(char * full_ftp_url);
-      std::string removeOrigin(char * full_ftp_url) const;
+  bool isTestPath(const std::string &) const;
+  bool isURLValid(char *full_ftp_url) const;
+  bool isPathValid(const std::string &posix_path) const;
+  std::string getAuthzPath(char *full_ftp_url);
+  std::string removeOrigin(char *full_ftp_url) const;
 
-      int processResponse(ICommunicator::Response & response);
-    private:
+  int processResponse(ICommunicator::Response &response);
 
-      void initCommunicator();
-      struct Config *m_config;
-      std::string m_test_path;
-      std::string m_local_globus_path_root;
-      LogContext m_log_context;
+private:
+  void initCommunicator();
+  struct Config *m_config;
+  std::string m_test_path;
+  std::string m_local_globus_path_root;
+  LogContext m_log_context;
 
-      std::unique_ptr<ICredentials> m_sec_ctx;
-      std::unique_ptr<ICommunicator> m_comm;
-      std::unordered_map<CredentialType, std::string> m_cred_options;
-  };
+  std::unique_ptr<ICredentials> m_sec_ctx;
+  std::unique_ptr<ICommunicator> m_comm;
+  std::unordered_map<CredentialType, std::string> m_cred_options;
+};
 
-}
+} // namespace SDMS
 #endif // AUTHZWORKER_HPP

--- a/repository/gridftp/globus5/authz/source/AuthzWorker.hpp
+++ b/repository/gridftp/globus5/authz/source/AuthzWorker.hpp
@@ -1,0 +1,65 @@
+#ifndef AUTHZWORKER_HPP
+#define AUTHZWORKER_HPP
+#pragma once
+
+// Common public includes
+#include "common/DynaLog.hpp"
+#include "common/ICommunicator.hpp"
+#include "common/ICredentials.hpp"
+
+// Standard includes
+#include <memory>
+#include <string>
+
+namespace SDMS {
+
+	/**
+	 * @class AuthzWorker
+	 * @brief Handles authorization checking, path validation, and FTP URL processing.
+	 *
+	 * The `AuthzWorker` class is responsible for handling authorization requests,
+	 * validating paths, processing FTP URLs, and interacting with a core service to
+	 * perform authorization checks. It utilizes a communicator for sending and receiving
+	 * messages and manages security credentials to perform its operations.
+	 *
+	 * The class provides various methods for:
+	 * - Checking the validity of paths and URLs.
+	 * - Verifying authorization for a client on a given path with a specified action.
+	 * - Removing the origin portion of an FTP URL to extract the path.
+	 * - Processing responses from the core service to determine authorization success or failure.
+	 * 
+	 * The class requires configuration and logging context for proper initialization.
+	 */
+  class AuthzWorker {
+    public:
+      AuthzWorker(struct Config *a_config, LogContext log_context);
+
+      ~AuthzWorker() {}
+
+      AuthzWorker &operator=(const AuthzWorker &) = delete;
+
+      int checkAuth(char *client_id, char *path, char *action);
+
+      bool isTestPath(const std::string &) const;
+      bool isURLValid(char * full_ftp_url) const;
+      bool isPathValid(const std::string & posix_path) const;
+      std::string getAuthzPath(char * full_ftp_url);
+      std::string removeOrigin(char * full_ftp_url) const;
+
+      int processResponse(ICommunicator::Response & response);
+    private:
+
+      void initCommunicator();
+      struct Config *m_config;
+      size_t m_test_path_len;
+      std::string m_test_path;
+      std::string m_local_globus_path_root;
+      LogContext m_log_context;
+
+      std::unique_ptr<ICredentials> m_sec_ctx;
+      std::unique_ptr<ICommunicator> m_comm;
+      std::unordered_map<CredentialType, std::string> m_cred_options;
+  };
+
+}
+#endif // AUTHZWORKER_HPP

--- a/repository/gridftp/globus5/authz/tests/unit/CMakeLists.txt
+++ b/repository/gridftp/globus5/authz/tests/unit/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Each test listed in Alphabetical order
 foreach(PROG
     test_getVersion
+    test_AuthzWorker
 )
 
   file(GLOB ${PROG}_SOURCES ${PROG}*.cpp)

--- a/repository/gridftp/globus5/authz/tests/unit/test_AuthzWorker.cpp
+++ b/repository/gridftp/globus5/authz/tests/unit/test_AuthzWorker.cpp
@@ -1,0 +1,409 @@
+#define BOOST_TEST_MAIN
+
+#define BOOST_TEST_MODULE AuthzWorker
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+// Private includes
+#include "AuthzWorker.hpp"
+
+// Public includes
+#include "common/DynaLog.hpp"
+#include "common/ICommunicator.hpp"
+#include "common/IMessage.hpp"
+#include "common/MessageFactory.hpp"
+#include "common/SDMS_Anon.pb.h"
+#include "common/TraceException.hpp"
+
+extern "C" {
+#include "Config.h"
+}
+
+
+class ConfigFixture {
+	public:
+		// Setup: create the object before each test case
+		ConfigFixture() {
+			std::string repo_id = "datafed-one-repo-to-rule-them-all";
+			std::string server_addr = "tcp://ruler:7513";
+			std::string pub_key = "=+r^&Qc&}f<Pho7ViJwVM5(Ze^o%UnnyA:XjF}7Q";
+			std::string priv_key = "X4y+AFXCmBoyKrc0J0V5}Z2HpCYRf3(wvhe**z))";
+			std::string server_key = "a.r)OeoL=?/rHaK1-ow<xOd7YxM/6)A&Kdu]*<)3";
+			std::string user = "vader";
+			std::string test_path = "";
+			std::string log_path = "./";
+			std::string globus_collection_path = "/globus/root";
+			//
+			std::strcpy(config.repo_id, repo_id.c_str());
+			std::strcpy(config.server_addr           , server_addr.c_str());
+			std::strcpy(config.pub_key               , pub_key.c_str());
+			std::strcpy(config.priv_key              , priv_key.c_str());
+			std::strcpy(config.server_key            , server_key.c_str());
+			std::strcpy(config.user                  , user.c_str());
+			std::strcpy(config.test_path             , test_path.c_str());
+			std::strcpy(config.log_path              , log_path.c_str());
+			std::strcpy(config.globus_collection_path, globus_collection_path.c_str()); 
+		}
+
+		// Teardown: clean up after each test case
+		~ConfigFixture() {}
+
+		// Accessor for the object
+
+		Config config;
+	private:
+};
+
+
+
+BOOST_FIXTURE_TEST_SUITE(AuthzTest, ConfigFixture)
+
+	BOOST_AUTO_TEST_CASE(test_authz) {
+		SDMS::LogContext log_context;
+		SDMS::AuthzWorker worker(&config, log_context);
+		std::cout << std::string(config.repo_id) << std::endl;	
+	}
+
+BOOST_AUTO_TEST_CASE(isTestPathValid){
+
+	SDMS::LogContext log_context;
+	std::string test_path = "/valid/test/path/";
+	std::strcpy(config.test_path, test_path.c_str());  
+	SDMS::AuthzWorker worker(&config, log_context);
+	BOOST_CHECK(worker.isTestPath(test_path));
+}
+
+BOOST_AUTO_TEST_CASE(isTestPath_InvalidTestPath)
+{
+	SDMS::LogContext log_context;
+	// Setup a valid test path
+	std::string test_path = "/valid/test/path/";
+	std::strcpy(config.test_path, test_path.c_str());  
+	SDMS::AuthzWorker worker(&config, log_context);
+
+	// Test when path does not match the test prefix
+	BOOST_CHECK(!worker.isTestPath("/invalid/path"));
+}
+
+BOOST_AUTO_TEST_CASE(TestIsTestPath_ShorterPath)
+{
+	SDMS::LogContext log_context;
+	// Setup a valid test path
+	std::string test_path = "/valid/test/path/";
+	std::strcpy(config.test_path, test_path.c_str());  
+	SDMS::AuthzWorker worker(&config, log_context);
+
+	// Test when path is shorter should be invalid 
+	BOOST_CHECK(!worker.isTestPath("/valid"));
+}
+
+BOOST_AUTO_TEST_CASE(TestIsTestPath_LongerPath)
+{
+	SDMS::LogContext log_context;
+	// Setup a valid test path
+	std::string test_path = "/valid/test/path/";
+	std::strcpy(config.test_path, test_path.c_str());  
+	SDMS::AuthzWorker worker(&config, log_context);
+
+	// Test when path is longer but aligns
+	BOOST_CHECK(worker.isTestPath("/valid/test/path/foo"));
+}
+
+BOOST_AUTO_TEST_CASE(TestIsTestPath_NoTestPath)
+{
+	SDMS::LogContext log_context;
+	// Setup a valid test path
+	SDMS::AuthzWorker worker(&config, log_context);
+
+	// Test when path is shorter should be valid 
+	BOOST_CHECK(!worker.isTestPath("/valid/test/path/foo"));
+}
+
+BOOST_AUTO_TEST_CASE(ValidPathTest) {
+	// Test a valid POSIX path
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	std::string valid_path = "/globus/root/subdir/file.txt";
+	BOOST_CHECK(worker.isPathValid(valid_path) == true);
+}
+
+BOOST_AUTO_TEST_CASE(InvalidPathTooShortTest) {
+	// Test an invalid POSIX path (too short)
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	std::string invalid_path = "/globus";
+	BOOST_CHECK(worker.isPathValid(invalid_path) == false);
+}
+
+BOOST_AUTO_TEST_CASE(InvalidPathNoPrefixTest) {
+	// Test an invalid POSIX path (wrong prefix)
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	std::string invalid_path = "/wrong/root/subdir/file.txt";
+	BOOST_CHECK(worker.isPathValid(invalid_path) == false);
+}
+
+BOOST_AUTO_TEST_CASE(ExactRootPathTest) {
+	// Test a valid path that exactly matches the root
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	std::string exact_root_path = "/globus/root";
+	BOOST_CHECK(worker.isPathValid(exact_root_path) == true);
+}
+
+BOOST_AUTO_TEST_CASE(EdgeCaseEmptyPathTest) {
+	// Test an empty path
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	std::string empty_path = "";
+	BOOST_CHECK(worker.isPathValid(empty_path) == false);
+}
+
+BOOST_AUTO_TEST_CASE(EdgeCaseTrailingSlashTest) {
+	// Test a valid path with a trailing slash
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	std::string trailing_slash_path = "/globus/root/";
+	BOOST_CHECK(worker.isPathValid(trailing_slash_path) == true);
+}
+
+BOOST_AUTO_TEST_CASE(ValidURLTest) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	// Test a valid FTP URL
+	char valid_url[] = "ftp://hostname/path/to/file.txt";
+	BOOST_CHECK(worker.isURLValid(valid_url) == true);
+}
+
+BOOST_AUTO_TEST_CASE(InvalidURLMissingSchemeTest) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	// Test an FTP URL missing the "ftp://" scheme
+	char invalid_url[] = "hostname/path/to/file.txt";
+	BOOST_CHECK(worker.isURLValid(invalid_url) == false);
+}
+
+BOOST_AUTO_TEST_CASE(InvalidURLTooFewSlashesTest) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	// Test an FTP URL with less than three '/' characters
+	char invalid_url[] = "ftp://host";
+	BOOST_CHECK(worker.isURLValid(invalid_url) == false);
+}
+
+BOOST_AUTO_TEST_CASE(EmptyURLTest) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	// Test an empty FTP URL
+	char empty_url[] = "";
+	BOOST_CHECK(worker.isURLValid(empty_url) == false);
+}
+
+BOOST_AUTO_TEST_CASE(URLWithTrailingSlashTest) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	// Test a valid FTP URL with a trailing slash
+	char trailing_slash_url[] = "ftp://hostname/path/";
+	BOOST_CHECK(worker.isURLValid(trailing_slash_url) == true);
+}
+
+BOOST_AUTO_TEST_CASE(URLWithoutHostnameTest) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	// Test an FTP URL missing the hostname but still has "ftp://"
+	char no_hostname_url[] = "ftp:///path/to/file.txt";
+	BOOST_CHECK(worker.isURLValid(no_hostname_url) == false);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginValidURLTest) {
+	// Test a valid FTP URL
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char valid_url[] = "ftp://hostname/path/to/file.txt";
+	std::string expected_result = "/path/to/file.txt";
+	BOOST_CHECK_EQUAL(worker.removeOrigin(valid_url), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginInvalidURLTest) {
+	// Test an invalid FTP URL (missing "ftp://")
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char invalid_url[] = "hostname/path/to/file.txt";
+	BOOST_CHECK_THROW(worker.removeOrigin(invalid_url), TraceException);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginEmptyURLTest) {
+	// Test an empty FTP URL
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char empty_url[] = "";
+	BOOST_CHECK_THROW(worker.removeOrigin(empty_url), TraceException);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginTrailingSlashTest) {
+	// Test a valid FTP URL with a trailing slash
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char trailing_slash_url[] = "ftp://hostname/path/";
+	std::string expected_result = "/path/";
+	BOOST_CHECK_EQUAL(worker.removeOrigin(trailing_slash_url), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginRootPathTest) {
+	// Test an FTP URL pointing to the root path
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char root_path_url[] = "ftp://hostname/";
+	std::string expected_result = "/";
+	BOOST_CHECK_EQUAL(worker.removeOrigin(root_path_url), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginDeepPathTest) {
+	// Test an FTP URL with a deep path
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char deep_path_url[] = "ftp://hostname/a/b/c/d/e.txt";
+	std::string expected_result = "/a/b/c/d/e.txt";
+	BOOST_CHECK_EQUAL(worker.removeOrigin(deep_path_url), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(GetAuthzPathValidPathTest) {
+	// Test a valid full FTP path
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char valid_path[] = "ftp://hostname/globus/root/path/to/resource.txt";
+	std::string expected_result = "/path/to/resource.txt";
+
+	BOOST_CHECK_EQUAL(worker.getAuthzPath(valid_path), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(GetAuthzPathInvalidFTPPathTest) {
+	// Test an invalid FTP path (removeOrigin will fail)
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char invalid_ftp_path[] = "http://hostname/globus/root/path/to/resource.txt";
+
+	BOOST_CHECK_THROW(worker.getAuthzPath(invalid_ftp_path), TraceException);
+}
+
+BOOST_AUTO_TEST_CASE(GetAuthzPathInvalidPOSIXPathTest) {
+	// Test an invalid POSIX path (isPathValid will fail)
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char invalid_posix_path[] = "ftp://hostname/wrong_root/path/to/resource.txt";
+
+	BOOST_CHECK_THROW(worker.getAuthzPath(invalid_posix_path), TraceException);
+}
+
+BOOST_AUTO_TEST_CASE(GetAuthzPathRootPathTest) {
+	// Test a valid full FTP path pointing to the root
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char root_path[] = "ftp://hostname/globus/root/";
+	std::string expected_result = "/";
+
+	BOOST_CHECK_EQUAL(worker.getAuthzPath(root_path), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(GetAuthzPathDeepPathTest) {
+	// Test a valid full FTP path with a deep path
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	char deep_path[] = "ftp://hostname/globus/root/a/b/c/d/e.txt";
+	std::string expected_result = "/a/b/c/d/e.txt";
+
+	BOOST_CHECK_EQUAL(worker.getAuthzPath(deep_path), expected_result);
+}
+
+BOOST_AUTO_TEST_CASE(ProcessResponseWithTimeout) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	SDMS::ICommunicator::Response response;
+	response.time_out = true;
+	BOOST_CHECK_THROW(worker.processResponse(response), TraceException);
+}
+
+BOOST_AUTO_TEST_CASE(ProcessResponseWithError) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	SDMS::ICommunicator::Response response;
+	response.error = true;
+	response.error_msg = "Sample error message";
+
+	BOOST_CHECK_EQUAL(worker.processResponse(response), 1);
+	// Verify that DL_ERROR was called with appropriate error message
+}
+
+BOOST_AUTO_TEST_CASE(ProcessResponseWithNullMessage) {
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+	SDMS::ICommunicator::Response response;
+	response.message = nullptr;
+	response.time_out = false;
+	response.error = false;
+
+	BOOST_CHECK_THROW(worker.processResponse(response), TraceException);
+	// Verify that DL_ERROR was called with the "message is not defined" error
+}
+
+BOOST_AUTO_TEST_CASE(ProcessResponseWithValidMessage) {
+
+  SDMS::MessageFactory msg_factory;
+
+	SDMS::ICommunicator::Response response;
+	response.message = msg_factory.create(SDMS::MessageType::GOOGLE_PROTOCOL_BUFFER);
+
+  std::string user_id = "hermes";
+  std::string key = "skeleton";
+  const uint16_t context = 1;
+
+  response.message->set(SDMS::MessageAttribute::ID, user_id);
+  response.message->set(SDMS::MessageAttribute::KEY, key);
+  response.message->set(SDMS::MessageAttribute::STATE, SDMS::MessageState::REQUEST);
+  response.message->set(SDMS::constants::message::google::CONTEXT, context);
+  auto auth_by_token_req = std::make_unique<SDMS::Anon::AuthenticateByTokenRequest>();
+  std::string token = "golden_chest";
+  auth_by_token_req->set_token(token);
+
+  response.message->setPayload(std::move(auth_by_token_req));
+
+  std::string route = "MtOlympia";
+  response.message->addRoute(route);
+
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+
+
+	BOOST_CHECK_EQUAL(worker.processResponse(response), 0);
+	// Verify that DL_DEBUG was called with "Received NACK reply" for NACK case
+}
+
+BOOST_AUTO_TEST_CASE(ProcessResponseWithNackReply) {
+
+  SDMS::MessageFactory msg_factory;
+
+	SDMS::ICommunicator::Response response;
+	response.message = msg_factory.create(SDMS::MessageType::GOOGLE_PROTOCOL_BUFFER);
+
+  std::string user_id = "hermes";
+  std::string key = "skeleton";
+  const uint16_t context = 1;
+
+  response.message->set(SDMS::MessageAttribute::ID, user_id);
+  response.message->set(SDMS::MessageAttribute::KEY, key);
+  response.message->set(SDMS::MessageAttribute::STATE, SDMS::MessageState::REQUEST);
+  response.message->set(SDMS::constants::message::google::CONTEXT, context);
+  auto nack = std::make_unique<SDMS::Anon::NackReply>();
+
+  response.message->setPayload(std::move(nack));
+
+  std::string route = "MtOlympia";
+  response.message->addRoute(route);
+
+	SDMS::LogContext log_context;
+	SDMS::AuthzWorker worker(&config, log_context);
+  BOOST_CHECK_EQUAL(worker.processResponse(response), 1);
+  // Verify error occurs
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/repository/gridftp/globus5/authz/tests/unit/test_AuthzWorker.cpp
+++ b/repository/gridftp/globus5/authz/tests/unit/test_AuthzWorker.cpp
@@ -19,339 +19,334 @@ extern "C" {
 #include "Config.h"
 }
 
-
 class ConfigFixture {
-	public:
-		// Setup: create the object before each test case
-		ConfigFixture() {
-			std::string repo_id = "datafed-one-repo-to-rule-them-all";
-			std::string server_addr = "tcp://ruler:7513";
-			std::string pub_key = "=+r^&Qc&}f<Pho7ViJwVM5(Ze^o%UnnyA:XjF}7Q";
-			std::string priv_key = "X4y+AFXCmBoyKrc0J0V5}Z2HpCYRf3(wvhe**z))";
-			std::string server_key = "a.r)OeoL=?/rHaK1-ow<xOd7YxM/6)A&Kdu]*<)3";
-			std::string user = "vader";
-			std::string test_path = "";
-			std::string log_path = "./";
-			std::string globus_collection_path = "/globus/root";
-			//
-			std::strcpy(config.repo_id, repo_id.c_str());
-			std::strcpy(config.server_addr           , server_addr.c_str());
-			std::strcpy(config.pub_key               , pub_key.c_str());
-			std::strcpy(config.priv_key              , priv_key.c_str());
-			std::strcpy(config.server_key            , server_key.c_str());
-			std::strcpy(config.user                  , user.c_str());
-			std::strcpy(config.test_path             , test_path.c_str());
-			std::strcpy(config.log_path              , log_path.c_str());
-			std::strcpy(config.globus_collection_path, globus_collection_path.c_str()); 
-		}
+public:
+  // Setup: create the object before each test case
+  ConfigFixture() {
+    std::string repo_id = "datafed-one-repo-to-rule-them-all";
+    std::string server_addr = "tcp://ruler:7513";
+    std::string pub_key = "=+r^&Qc&}f<Pho7ViJwVM5(Ze^o%UnnyA:XjF}7Q";
+    std::string priv_key = "X4y+AFXCmBoyKrc0J0V5}Z2HpCYRf3(wvhe**z))";
+    std::string server_key = "a.r)OeoL=?/rHaK1-ow<xOd7YxM/6)A&Kdu]*<)3";
+    std::string user = "vader";
+    std::string test_path = "";
+    std::string log_path = "./";
+    std::string globus_collection_path = "/globus/root";
+    //
+    std::strcpy(config.repo_id, repo_id.c_str());
+    std::strcpy(config.server_addr, server_addr.c_str());
+    std::strcpy(config.pub_key, pub_key.c_str());
+    std::strcpy(config.priv_key, priv_key.c_str());
+    std::strcpy(config.server_key, server_key.c_str());
+    std::strcpy(config.user, user.c_str());
+    std::strcpy(config.test_path, test_path.c_str());
+    std::strcpy(config.log_path, log_path.c_str());
+    std::strcpy(config.globus_collection_path, globus_collection_path.c_str());
+  }
 
-		// Teardown: clean up after each test case
-		~ConfigFixture() {}
+  // Teardown: clean up after each test case
+  ~ConfigFixture() {}
 
-		// Accessor for the object
+  // Accessor for the object
 
-		Config config;
-	private:
+  Config config;
+
+private:
 };
-
-
 
 BOOST_FIXTURE_TEST_SUITE(AuthzTest, ConfigFixture)
 
-	BOOST_AUTO_TEST_CASE(test_authz) {
-		SDMS::LogContext log_context;
-		SDMS::AuthzWorker worker(&config, log_context);
-		std::cout << std::string(config.repo_id) << std::endl;	
-	}
-
-BOOST_AUTO_TEST_CASE(isTestPathValid){
-
-	SDMS::LogContext log_context;
-	std::string test_path = "/valid/test/path/";
-	std::strcpy(config.test_path, test_path.c_str());  
-	SDMS::AuthzWorker worker(&config, log_context);
-	BOOST_CHECK(worker.isTestPath(test_path));
+BOOST_AUTO_TEST_CASE(test_authz) {
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::cout << std::string(config.repo_id) << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE(isTestPath_InvalidTestPath)
-{
-	SDMS::LogContext log_context;
-	// Setup a valid test path
-	std::string test_path = "/valid/test/path/";
-	std::strcpy(config.test_path, test_path.c_str());  
-	SDMS::AuthzWorker worker(&config, log_context);
+BOOST_AUTO_TEST_CASE(isTestPathValid) {
 
-	// Test when path does not match the test prefix
-	BOOST_CHECK(!worker.isTestPath("/invalid/path"));
+  SDMS::LogContext log_context;
+  std::string test_path = "/valid/test/path/";
+  std::strcpy(config.test_path, test_path.c_str());
+  SDMS::AuthzWorker worker(&config, log_context);
+  BOOST_CHECK(worker.isTestPath(test_path));
 }
 
-BOOST_AUTO_TEST_CASE(TestIsTestPath_ShorterPath)
-{
-	SDMS::LogContext log_context;
-	// Setup a valid test path
-	std::string test_path = "/valid/test/path/";
-	std::strcpy(config.test_path, test_path.c_str());  
-	SDMS::AuthzWorker worker(&config, log_context);
+BOOST_AUTO_TEST_CASE(isTestPath_InvalidTestPath) {
+  SDMS::LogContext log_context;
+  // Setup a valid test path
+  std::string test_path = "/valid/test/path/";
+  std::strcpy(config.test_path, test_path.c_str());
+  SDMS::AuthzWorker worker(&config, log_context);
 
-	// Test when path is shorter should be invalid 
-	BOOST_CHECK(!worker.isTestPath("/valid"));
+  // Test when path does not match the test prefix
+  BOOST_CHECK(!worker.isTestPath("/invalid/path"));
 }
 
-BOOST_AUTO_TEST_CASE(TestIsTestPath_LongerPath)
-{
-	SDMS::LogContext log_context;
-	// Setup a valid test path
-	std::string test_path = "/valid/test/path/";
-	std::strcpy(config.test_path, test_path.c_str());  
-	SDMS::AuthzWorker worker(&config, log_context);
+BOOST_AUTO_TEST_CASE(TestIsTestPath_ShorterPath) {
+  SDMS::LogContext log_context;
+  // Setup a valid test path
+  std::string test_path = "/valid/test/path/";
+  std::strcpy(config.test_path, test_path.c_str());
+  SDMS::AuthzWorker worker(&config, log_context);
 
-	// Test when path is longer but aligns
-	BOOST_CHECK(worker.isTestPath("/valid/test/path/foo"));
+  // Test when path is shorter should be invalid
+  BOOST_CHECK(!worker.isTestPath("/valid"));
 }
 
-BOOST_AUTO_TEST_CASE(TestIsTestPath_NoTestPath)
-{
-	SDMS::LogContext log_context;
-	// Setup a valid test path
-	SDMS::AuthzWorker worker(&config, log_context);
+BOOST_AUTO_TEST_CASE(TestIsTestPath_LongerPath) {
+  SDMS::LogContext log_context;
+  // Setup a valid test path
+  std::string test_path = "/valid/test/path/";
+  std::strcpy(config.test_path, test_path.c_str());
+  SDMS::AuthzWorker worker(&config, log_context);
 
-	// Test when path is shorter should be valid 
-	BOOST_CHECK(!worker.isTestPath("/valid/test/path/foo"));
+  // Test when path is longer but aligns
+  BOOST_CHECK(worker.isTestPath("/valid/test/path/foo"));
+}
+
+BOOST_AUTO_TEST_CASE(TestIsTestPath_NoTestPath) {
+  SDMS::LogContext log_context;
+  // Setup a valid test path
+  SDMS::AuthzWorker worker(&config, log_context);
+
+  // Test when path is shorter should be valid
+  BOOST_CHECK(!worker.isTestPath("/valid/test/path/foo"));
 }
 
 BOOST_AUTO_TEST_CASE(ValidPathTest) {
-	// Test a valid POSIX path
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	std::string valid_path = "/globus/root/subdir/file.txt";
-	BOOST_CHECK(worker.isPathValid(valid_path) == true);
+  // Test a valid POSIX path
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::string valid_path = "/globus/root/subdir/file.txt";
+  BOOST_CHECK(worker.isPathValid(valid_path) == true);
 }
 
 BOOST_AUTO_TEST_CASE(InvalidPathTooShortTest) {
-	// Test an invalid POSIX path (too short)
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	std::string invalid_path = "/globus";
-	BOOST_CHECK(worker.isPathValid(invalid_path) == false);
+  // Test an invalid POSIX path (too short)
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::string invalid_path = "/globus";
+  BOOST_CHECK(worker.isPathValid(invalid_path) == false);
 }
 
 BOOST_AUTO_TEST_CASE(InvalidPathNoPrefixTest) {
-	// Test an invalid POSIX path (wrong prefix)
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	std::string invalid_path = "/wrong/root/subdir/file.txt";
-	BOOST_CHECK(worker.isPathValid(invalid_path) == false);
+  // Test an invalid POSIX path (wrong prefix)
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::string invalid_path = "/wrong/root/subdir/file.txt";
+  BOOST_CHECK(worker.isPathValid(invalid_path) == false);
 }
 
 BOOST_AUTO_TEST_CASE(ExactRootPathTest) {
-	// Test a valid path that exactly matches the root
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	std::string exact_root_path = "/globus/root";
-	BOOST_CHECK(worker.isPathValid(exact_root_path) == true);
+  // Test a valid path that exactly matches the root
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::string exact_root_path = "/globus/root";
+  BOOST_CHECK(worker.isPathValid(exact_root_path) == true);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeCaseEmptyPathTest) {
-	// Test an empty path
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	std::string empty_path = "";
-	BOOST_CHECK(worker.isPathValid(empty_path) == false);
+  // Test an empty path
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::string empty_path = "";
+  BOOST_CHECK(worker.isPathValid(empty_path) == false);
 }
 
 BOOST_AUTO_TEST_CASE(EdgeCaseTrailingSlashTest) {
-	// Test a valid path with a trailing slash
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	std::string trailing_slash_path = "/globus/root/";
-	BOOST_CHECK(worker.isPathValid(trailing_slash_path) == true);
+  // Test a valid path with a trailing slash
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  std::string trailing_slash_path = "/globus/root/";
+  BOOST_CHECK(worker.isPathValid(trailing_slash_path) == true);
 }
 
 BOOST_AUTO_TEST_CASE(ValidURLTest) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	// Test a valid FTP URL
-	char valid_url[] = "ftp://hostname/path/to/file.txt";
-	BOOST_CHECK(worker.isURLValid(valid_url) == true);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  // Test a valid FTP URL
+  char valid_url[] = "ftp://hostname/path/to/file.txt";
+  BOOST_CHECK(worker.isURLValid(valid_url) == true);
 }
 
 BOOST_AUTO_TEST_CASE(InvalidURLMissingSchemeTest) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	// Test an FTP URL missing the "ftp://" scheme
-	char invalid_url[] = "hostname/path/to/file.txt";
-	BOOST_CHECK(worker.isURLValid(invalid_url) == false);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  // Test an FTP URL missing the "ftp://" scheme
+  char invalid_url[] = "hostname/path/to/file.txt";
+  BOOST_CHECK(worker.isURLValid(invalid_url) == false);
 }
 
 BOOST_AUTO_TEST_CASE(InvalidURLTooFewSlashesTest) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	// Test an FTP URL with less than three '/' characters
-	char invalid_url[] = "ftp://host";
-	BOOST_CHECK(worker.isURLValid(invalid_url) == false);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  // Test an FTP URL with less than three '/' characters
+  char invalid_url[] = "ftp://host";
+  BOOST_CHECK(worker.isURLValid(invalid_url) == false);
 }
 
 BOOST_AUTO_TEST_CASE(EmptyURLTest) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	// Test an empty FTP URL
-	char empty_url[] = "";
-	BOOST_CHECK(worker.isURLValid(empty_url) == false);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  // Test an empty FTP URL
+  char empty_url[] = "";
+  BOOST_CHECK(worker.isURLValid(empty_url) == false);
 }
 
 BOOST_AUTO_TEST_CASE(URLWithTrailingSlashTest) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	// Test a valid FTP URL with a trailing slash
-	char trailing_slash_url[] = "ftp://hostname/path/";
-	BOOST_CHECK(worker.isURLValid(trailing_slash_url) == true);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  // Test a valid FTP URL with a trailing slash
+  char trailing_slash_url[] = "ftp://hostname/path/";
+  BOOST_CHECK(worker.isURLValid(trailing_slash_url) == true);
 }
 
 BOOST_AUTO_TEST_CASE(URLWithoutHostnameTest) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	// Test an FTP URL missing the hostname but still has "ftp://"
-	char no_hostname_url[] = "ftp:///path/to/file.txt";
-	BOOST_CHECK(worker.isURLValid(no_hostname_url) == false);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  // Test an FTP URL missing the hostname but still has "ftp://"
+  char no_hostname_url[] = "ftp:///path/to/file.txt";
+  BOOST_CHECK(worker.isURLValid(no_hostname_url) == false);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginValidURLTest) {
-	// Test a valid FTP URL
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char valid_url[] = "ftp://hostname/path/to/file.txt";
-	std::string expected_result = "/path/to/file.txt";
-	BOOST_CHECK_EQUAL(worker.removeOrigin(valid_url), expected_result);
+  // Test a valid FTP URL
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char valid_url[] = "ftp://hostname/path/to/file.txt";
+  std::string expected_result = "/path/to/file.txt";
+  BOOST_CHECK_EQUAL(worker.removeOrigin(valid_url), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginInvalidURLTest) {
-	// Test an invalid FTP URL (missing "ftp://")
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char invalid_url[] = "hostname/path/to/file.txt";
-	BOOST_CHECK_THROW(worker.removeOrigin(invalid_url), TraceException);
+  // Test an invalid FTP URL (missing "ftp://")
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char invalid_url[] = "hostname/path/to/file.txt";
+  BOOST_CHECK_THROW(worker.removeOrigin(invalid_url), TraceException);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginEmptyURLTest) {
-	// Test an empty FTP URL
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char empty_url[] = "";
-	BOOST_CHECK_THROW(worker.removeOrigin(empty_url), TraceException);
+  // Test an empty FTP URL
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char empty_url[] = "";
+  BOOST_CHECK_THROW(worker.removeOrigin(empty_url), TraceException);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginTrailingSlashTest) {
-	// Test a valid FTP URL with a trailing slash
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char trailing_slash_url[] = "ftp://hostname/path/";
-	std::string expected_result = "/path/";
-	BOOST_CHECK_EQUAL(worker.removeOrigin(trailing_slash_url), expected_result);
+  // Test a valid FTP URL with a trailing slash
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char trailing_slash_url[] = "ftp://hostname/path/";
+  std::string expected_result = "/path/";
+  BOOST_CHECK_EQUAL(worker.removeOrigin(trailing_slash_url), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginRootPathTest) {
-	// Test an FTP URL pointing to the root path
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char root_path_url[] = "ftp://hostname/";
-	std::string expected_result = "/";
-	BOOST_CHECK_EQUAL(worker.removeOrigin(root_path_url), expected_result);
+  // Test an FTP URL pointing to the root path
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char root_path_url[] = "ftp://hostname/";
+  std::string expected_result = "/";
+  BOOST_CHECK_EQUAL(worker.removeOrigin(root_path_url), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginDeepPathTest) {
-	// Test an FTP URL with a deep path
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char deep_path_url[] = "ftp://hostname/a/b/c/d/e.txt";
-	std::string expected_result = "/a/b/c/d/e.txt";
-	BOOST_CHECK_EQUAL(worker.removeOrigin(deep_path_url), expected_result);
+  // Test an FTP URL with a deep path
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char deep_path_url[] = "ftp://hostname/a/b/c/d/e.txt";
+  std::string expected_result = "/a/b/c/d/e.txt";
+  BOOST_CHECK_EQUAL(worker.removeOrigin(deep_path_url), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(GetAuthzPathValidPathTest) {
-	// Test a valid full FTP path
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char valid_path[] = "ftp://hostname/globus/root/path/to/resource.txt";
-	std::string expected_result = "/path/to/resource.txt";
+  // Test a valid full FTP path
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char valid_path[] = "ftp://hostname/globus/root/path/to/resource.txt";
+  std::string expected_result = "/path/to/resource.txt";
 
-	BOOST_CHECK_EQUAL(worker.getAuthzPath(valid_path), expected_result);
+  BOOST_CHECK_EQUAL(worker.getAuthzPath(valid_path), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(GetAuthzPathInvalidFTPPathTest) {
-	// Test an invalid FTP path (removeOrigin will fail)
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char invalid_ftp_path[] = "http://hostname/globus/root/path/to/resource.txt";
+  // Test an invalid FTP path (removeOrigin will fail)
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char invalid_ftp_path[] = "http://hostname/globus/root/path/to/resource.txt";
 
-	BOOST_CHECK_THROW(worker.getAuthzPath(invalid_ftp_path), TraceException);
+  BOOST_CHECK_THROW(worker.getAuthzPath(invalid_ftp_path), TraceException);
 }
 
 BOOST_AUTO_TEST_CASE(GetAuthzPathInvalidPOSIXPathTest) {
-	// Test an invalid POSIX path (isPathValid will fail)
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char invalid_posix_path[] = "ftp://hostname/wrong_root/path/to/resource.txt";
+  // Test an invalid POSIX path (isPathValid will fail)
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char invalid_posix_path[] = "ftp://hostname/wrong_root/path/to/resource.txt";
 
-	BOOST_CHECK_THROW(worker.getAuthzPath(invalid_posix_path), TraceException);
+  BOOST_CHECK_THROW(worker.getAuthzPath(invalid_posix_path), TraceException);
 }
 
 BOOST_AUTO_TEST_CASE(GetAuthzPathRootPathTest) {
-	// Test a valid full FTP path pointing to the root
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char root_path[] = "ftp://hostname/globus/root/";
-	std::string expected_result = "/";
+  // Test a valid full FTP path pointing to the root
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char root_path[] = "ftp://hostname/globus/root/";
+  std::string expected_result = "/";
 
-	BOOST_CHECK_EQUAL(worker.getAuthzPath(root_path), expected_result);
+  BOOST_CHECK_EQUAL(worker.getAuthzPath(root_path), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(GetAuthzPathDeepPathTest) {
-	// Test a valid full FTP path with a deep path
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	char deep_path[] = "ftp://hostname/globus/root/a/b/c/d/e.txt";
-	std::string expected_result = "/a/b/c/d/e.txt";
+  // Test a valid full FTP path with a deep path
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  char deep_path[] = "ftp://hostname/globus/root/a/b/c/d/e.txt";
+  std::string expected_result = "/a/b/c/d/e.txt";
 
-	BOOST_CHECK_EQUAL(worker.getAuthzPath(deep_path), expected_result);
+  BOOST_CHECK_EQUAL(worker.getAuthzPath(deep_path), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessResponseWithTimeout) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	SDMS::ICommunicator::Response response;
-	response.time_out = true;
-	BOOST_CHECK_THROW(worker.processResponse(response), TraceException);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  SDMS::ICommunicator::Response response;
+  response.time_out = true;
+  BOOST_CHECK_THROW(worker.processResponse(response), TraceException);
 }
 
 BOOST_AUTO_TEST_CASE(ProcessResponseWithError) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	SDMS::ICommunicator::Response response;
-	response.error = true;
-	response.error_msg = "Sample error message";
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  SDMS::ICommunicator::Response response;
+  response.error = true;
+  response.error_msg = "Sample error message";
 
-	BOOST_CHECK_EQUAL(worker.processResponse(response), 1);
-	// Verify that DL_ERROR was called with appropriate error message
+  BOOST_CHECK_EQUAL(worker.processResponse(response), 1);
+  // Verify that DL_ERROR was called with appropriate error message
 }
 
 BOOST_AUTO_TEST_CASE(ProcessResponseWithNullMessage) {
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
-	SDMS::ICommunicator::Response response;
-	response.message = nullptr;
-	response.time_out = false;
-	response.error = false;
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
+  SDMS::ICommunicator::Response response;
+  response.message = nullptr;
+  response.time_out = false;
+  response.error = false;
 
-	BOOST_CHECK_THROW(worker.processResponse(response), TraceException);
-	// Verify that DL_ERROR was called with the "message is not defined" error
+  BOOST_CHECK_THROW(worker.processResponse(response), TraceException);
+  // Verify that DL_ERROR was called with the "message is not defined" error
 }
 
 BOOST_AUTO_TEST_CASE(ProcessResponseWithValidMessage) {
 
   SDMS::MessageFactory msg_factory;
 
-	SDMS::ICommunicator::Response response;
-	response.message = msg_factory.create(SDMS::MessageType::GOOGLE_PROTOCOL_BUFFER);
+  SDMS::ICommunicator::Response response;
+  response.message =
+      msg_factory.create(SDMS::MessageType::GOOGLE_PROTOCOL_BUFFER);
 
   std::string user_id = "hermes";
   std::string key = "skeleton";
@@ -359,9 +354,11 @@ BOOST_AUTO_TEST_CASE(ProcessResponseWithValidMessage) {
 
   response.message->set(SDMS::MessageAttribute::ID, user_id);
   response.message->set(SDMS::MessageAttribute::KEY, key);
-  response.message->set(SDMS::MessageAttribute::STATE, SDMS::MessageState::REQUEST);
+  response.message->set(SDMS::MessageAttribute::STATE,
+                        SDMS::MessageState::REQUEST);
   response.message->set(SDMS::constants::message::google::CONTEXT, context);
-  auto auth_by_token_req = std::make_unique<SDMS::Anon::AuthenticateByTokenRequest>();
+  auto auth_by_token_req =
+      std::make_unique<SDMS::Anon::AuthenticateByTokenRequest>();
   std::string token = "golden_chest";
   auth_by_token_req->set_token(token);
 
@@ -370,20 +367,20 @@ BOOST_AUTO_TEST_CASE(ProcessResponseWithValidMessage) {
   std::string route = "MtOlympia";
   response.message->addRoute(route);
 
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
 
-
-	BOOST_CHECK_EQUAL(worker.processResponse(response), 0);
-	// Verify that DL_DEBUG was called with "Received NACK reply" for NACK case
+  BOOST_CHECK_EQUAL(worker.processResponse(response), 0);
+  // Verify that DL_DEBUG was called with "Received NACK reply" for NACK case
 }
 
 BOOST_AUTO_TEST_CASE(ProcessResponseWithNackReply) {
 
   SDMS::MessageFactory msg_factory;
 
-	SDMS::ICommunicator::Response response;
-	response.message = msg_factory.create(SDMS::MessageType::GOOGLE_PROTOCOL_BUFFER);
+  SDMS::ICommunicator::Response response;
+  response.message =
+      msg_factory.create(SDMS::MessageType::GOOGLE_PROTOCOL_BUFFER);
 
   std::string user_id = "hermes";
   std::string key = "skeleton";
@@ -391,7 +388,8 @@ BOOST_AUTO_TEST_CASE(ProcessResponseWithNackReply) {
 
   response.message->set(SDMS::MessageAttribute::ID, user_id);
   response.message->set(SDMS::MessageAttribute::KEY, key);
-  response.message->set(SDMS::MessageAttribute::STATE, SDMS::MessageState::REQUEST);
+  response.message->set(SDMS::MessageAttribute::STATE,
+                        SDMS::MessageState::REQUEST);
   response.message->set(SDMS::constants::message::google::CONTEXT, context);
   auto nack = std::make_unique<SDMS::Anon::NackReply>();
 
@@ -400,8 +398,8 @@ BOOST_AUTO_TEST_CASE(ProcessResponseWithNackReply) {
   std::string route = "MtOlympia";
   response.message->addRoute(route);
 
-	SDMS::LogContext log_context;
-	SDMS::AuthzWorker worker(&config, log_context);
+  SDMS::LogContext log_context;
+  SDMS::AuthzWorker worker(&config, log_context);
   BOOST_CHECK_EQUAL(worker.processResponse(response), 1);
   // Verify error occurs
 }


### PR DESCRIPTION
#DEPENDS 

This PR should be merged first. https://github.com/ORNL/DataFed/pull/1158/files

## Summary by Sourcery

Refactor the AuthzWorker class to enhance code clarity and maintainability by modularizing functionality into specific methods. Update the build system to support building and linking tests for the AuthzWorker class, including necessary dependencies. Implement comprehensive unit tests to ensure the correctness of the AuthzWorker's functionality and the getVersion function.

Enhancements:
- Refactor the AuthzWorker class to improve code organization and readability by separating concerns into distinct methods for URL validation, path validation, and authorization checks.

Build:
- Add options to the CMake configuration to build DataFed Authz tests and include necessary libraries for GSSAPI and Globus Common.

Tests:
- Introduce unit tests for the AuthzWorker class, covering various scenarios such as path validation, URL validation, and response processing.
- Add a test suite for the getVersion function to verify version string correctness.