### PR TITLE
Add missing comment on env variable

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -163,6 +163,10 @@
 # DOCKER_FILE_PATH        - used to build the image
 # REGISTRY                - used for image tag and pushing to registry
 # PROJECT                 - used for image tag and pushing to registry
+#
+# Outputs
+#
+# DATAFED_HARBOR_REPOSITORY
 .build_image: &build_image |
   BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
   export DATAFED_HARBOR_REPOSITORY="${COMPONENT}-${BRANCH_LOWER}"


### PR DESCRIPTION
#1166

## Summary by Sourcery

Documentation:
- Add a comment explaining the purpose of the DATAFED_HARBOR_REPOSITORY environment variable in the GitLab CI configuration.