### PR TITLE
Add -e back to core/database/test/scripts

### DIFF
--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -78,9 +78,9 @@ end-to-end-foxx-setup:
     -     fi
     -   fi 
     - done
-    - docker logs "foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}";
     - ./scripts/ci_database_health_check.sh
   after_script:
+    - docker logs "foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}";
     - rm -rf foxx_tmp
 
 ################################################################################

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -28,7 +28,8 @@ end-to-end-foxx-setup:
     - docker
   script:
     - sudo apt-get install jq -y
-    - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
+    # Export is needed so the after_script section can use this
+    - export BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
     - mkdir -p "$HOST_LOG_FILE_PATH"
     - chmod o+w "${HOST_LOG_FILE_PATH}"
     - USER_ID=$(id -u)
@@ -41,7 +42,8 @@ end-to-end-foxx-setup:
     - if [ -f foxx_tmp/.foxx_is_installed ]; then rm foxx_tmp/.foxx_is_installed; fi
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - ./scripts/container_stop.sh -n "foxx-" -p
-    - random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
+    # Export is needed so the after_script section can use this
+    - export random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
     - CONTAINER_NAME="foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}"
     - echo "#!/bin/bash" > "${RUN_FILE}"
     - echo "docker run -d \\" >> "${RUN_FILE}"
@@ -80,6 +82,8 @@ end-to-end-foxx-setup:
     - done
     - ./scripts/ci_database_health_check.sh
   after_script:
+    # This is needed so that if there is a failure in the container we know
+    # what caused it.
     - docker logs "foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}";
     - rm -rf foxx_tmp
 

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -28,8 +28,9 @@ end-to-end-foxx-setup:
     - docker
   script:
     - sudo apt-get install jq -y
-    # Export is needed so the after_script section can use this
-    - export BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
+    - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
+    # Echo into GITLAB_ENV is needed so after_script has access
+    - echo "BRANCH_LOWER=${BRANCH_LOWER}" >> $GITLAB_ENV
     - mkdir -p "$HOST_LOG_FILE_PATH"
     - chmod o+w "${HOST_LOG_FILE_PATH}"
     - USER_ID=$(id -u)
@@ -43,7 +44,7 @@ end-to-end-foxx-setup:
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - ./scripts/container_stop.sh -n "foxx-" -p
     - random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
-    - # Echo into GITLAB_ENV is needed so after_script has access
+    # Echo into GITLAB_ENV is needed so after_script has access
     - echo "random_string=${random_string}" >> $GITLAB_ENV
     - CONTAINER_NAME="foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}"
     - echo "#!/bin/bash" > "${RUN_FILE}"

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -84,8 +84,6 @@ end-to-end-foxx-setup:
     - done
     - ./scripts/ci_database_health_check.sh
   after_script:
-    # This is needed so that if there is a failure in the container we know
-    # what caused it.
     - docker logs "foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}";
     - rm -rf foxx_tmp
 

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -42,8 +42,9 @@ end-to-end-foxx-setup:
     - if [ -f foxx_tmp/.foxx_is_installed ]; then rm foxx_tmp/.foxx_is_installed; fi
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
     - ./scripts/container_stop.sh -n "foxx-" -p
-    # Export is needed so the after_script section can use this
-    - export random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
+    - random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
+    - # Echo into GITLAB_ENV is needed so after_script has access
+    - echo "random_string=${random_string}" >> $GITLAB_ENV
     - CONTAINER_NAME="foxx-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}"
     - echo "#!/bin/bash" > "${RUN_FILE}"
     - echo "docker run -d \\" >> "${RUN_FILE}"

--- a/core/database/tests/test_foxx.sh
+++ b/core/database/tests/test_foxx.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-# -e has been removed so that if an error occurs the PASSWORD File is deleted and not left lying around
-set -uf -o pipefail
+# History
+#
+# -e added back in because CI jobs are not failing when there are problems in
+# this script. Residual password files can be removed a different way. i.e.  in
+# a cleanup script associated with a CI job.
+#
+# -e has been removed so that if an error occurs the PASSWORD File is deleted
+# and not left lying around
+set -euf -o pipefail
 
 SCRIPT=$(realpath "$BASH_SOURCE[0]")
 SOURCE=$(dirname "$SCRIPT")

--- a/core/database/tests/test_setup.sh
+++ b/core/database/tests/test_setup.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-# -e has been removed so that if an error occurs the PASSWORD File is deleted and not left lying around
-set -uf -o pipefail
+# History
+#
+# -e added back in because CI jobs are not failing when there are problems in
+# this script. Residual password files can be removed a different way. i.e.  in
+# a cleanup script associated with a CI job.
+#
+# -e has been removed so that if an error occurs the PASSWORD File is deleted
+# and not left lying around
+
+set -uef -o pipefail
 
 SCRIPT=$(realpath "$BASH_SOURCE[0]")
 SOURCE=$(dirname "$SCRIPT")
@@ -143,31 +151,24 @@ fi
 # Using the Arango web ui 
 # Using node module
 #
-# The web deployment requires manual interaction, and I could not figure out the 
-# syntax for the REST http endpoints with curl so we are going to try the node module
-
-## Will create the zip file in the build directory to keep datafed source code clean
-#cd ../../build
-## Zip up the api
-#zip datafed.zip ../core/database/foxx/api/* 
-#
-## Get the size of the file in bytes
-#bytes=$(wc -c < datafed.zip)
+# The web deployment requires manual interaction, and I could not figure out
+# the syntax for the REST http endpoints with curl so we are going to try the
+# node module
 
 # Will only install if it is not already installed
 install_nvm
 install_node
 
-PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
 # Install foxx service node module
 $NVM_DIR/nvm-exec npm install --global foxx-cli
-echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
 
 FOXX_PREFIX=""
 if ! command -v foxx > /dev/null 2>&1; then
     FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
 fi
 
+PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
+echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
 # Check if database foxx services have already been installed
 # WARNING Foxx and arangosh arguments differ --server is used for Foxx not --server.endpoint
 existing_services=$("${FOXX_PREFIX}foxx" list -a -u "$local_DATABASE_USER" -p "${PATH_TO_PASSWD_FILE}"  --server "tcp://${local_DATAFED_DATABASE_HOST}:8529"  --database "$local_DATABASE_NAME")

--- a/core/database/tests/test_setup.sh
+++ b/core/database/tests/test_setup.sh
@@ -133,7 +133,7 @@ fi
 
 # We are now going to initialize the DataFed database in Arango, but only if sdms database does
 # not exist
-output=$(curl --dump - --user $local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD http://${local_DATAFED_DATABASE_HOST}:8529/_api/database/user)
+output=$(curl --user $local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD http://${local_DATAFED_DATABASE_HOST}:8529/_api/database/user)
 
 if [[ "$output" =~ .*"sdms".* ]]; then
 	echo "SDMS already exists do nothing"

--- a/core/database/tests/test_teardown.sh
+++ b/core/database/tests/test_teardown.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-# -e has been removed so that if an error occurs the PASSWORD File is deleted and not left lying around
-set -uf -o pipefail
+# History
+#
+# -e added back in because CI jobs are not failing when there are problems in
+# this script. Residual password files can be removed a different way. i.e.  in
+# a cleanup script associated with a CI job.
+#
+# -e has been removed so that if an error occurs the PASSWORD File is deleted
+# and not left lying around
+set -euf -o pipefail
 
 SCRIPT=$(realpath "$0")
 SOURCE=$(dirname "$SCRIPT")

--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -49,6 +49,11 @@ else
   fi
 fi
 
+# WARNING: overwriting PATH can be very dangerous
+#   In Docker builds this must follow the pattern:
+#     PATH="<desired addition to path>:$PATH"
+#     Curly braces around PATH, like ${PATH} may pull from the host's PATH
+# Please see StackOverflow answer: https://stackoverflow.com/a/38742545
 if [[ ! -v PATH ]]; then
   PATH="$DATAFED_DEPENDENCIES_INSTALL_PATH/bin"
 else
@@ -91,7 +96,12 @@ install_cmake() {
     # Mark cmake as installed
     touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.cmake_installed-${DATAFED_CMAKE_VERSION}"
   fi
-  export PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin:${PATH}"
+  # WARNING: overwriting PATH can be very dangerous
+  #   In Docker builds this must follow the pattern:
+  #     PATH="<desired addition to path>:$PATH"
+  #     Curly braces around PATH, like ${PATH} may pull from the host's PATH
+  # Please see StackOverflow answer: https://stackoverflow.com/a/38742545
+  export PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin:$PATH"
 }
 
 install_protobuf() {


### PR DESCRIPTION
# PR Description


# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [x] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [x] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Enhancements:
- Reintroduce the '-e' option in test scripts to ensure CI jobs fail when there are script errors, with a plan to handle residual password files through a separate cleanup script.