### PR TITLE
Remove problematic curl dump flag

### DIFF
--- a/core/database/tests/test_setup.sh
+++ b/core/database/tests/test_setup.sh
@@ -133,7 +133,7 @@ fi
 
 # We are now going to initialize the DataFed database in Arango, but only if sdms database does
 # not exist
-output=$(curl --dump - --user $local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD http://${local_DATAFED_DATABASE_HOST}:8529/_api/database/user)
+output=$(curl --user $local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD http://${local_DATAFED_DATABASE_HOST}:8529/_api/database/user)
 
 if [[ "$output" =~ .*"sdms".* ]]; then
 	echo "SDMS already exists do nothing"

--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -91,7 +91,7 @@ install_cmake() {
     # Mark cmake as installed
     touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.cmake_installed-${DATAFED_CMAKE_VERSION}"
   fi
-  export PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin:${PATH}"
+  export PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin:$PATH"
 }
 
 install_protobuf() {

--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -49,6 +49,11 @@ else
   fi
 fi
 
+# WARNING: overwriting PATH can be very dangerous
+#   In Docker builds this must follow the pattern:
+#     PATH="<desired addition to path>:$PATH"
+#     Curly braces around PATH, like ${PATH} may pull from the host's PATH
+# Please see StackOverflow answer: https://stackoverflow.com/a/38742545
 if [[ ! -v PATH ]]; then
   PATH="$DATAFED_DEPENDENCIES_INSTALL_PATH/bin"
 else
@@ -91,6 +96,11 @@ install_cmake() {
     # Mark cmake as installed
     touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/.cmake_installed-${DATAFED_CMAKE_VERSION}"
   fi
+  # WARNING: overwriting PATH can be very dangerous
+  #   In Docker builds this must follow the pattern:
+  #     PATH="<desired addition to path>:$PATH"
+  #     Curly braces around PATH, like ${PATH} may pull from the host's PATH
+  # Please see StackOverflow answer: https://stackoverflow.com/a/38742545
   export PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin:$PATH"
 }
 


### PR DESCRIPTION
# PR Description


# Tasks

* [ ] - Formatter has been run
* [x] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [x] - A user has been assigned to work on the pr

## Summary by Sourcery

Bug Fixes:
- Remove the problematic '--dump' flag from the curl command in the test setup script.