### PR TITLE
1184 bug add set e foxx install

### DIFF
--- a/.gitlab/build/build_foxx_image.yml
+++ b/.gitlab/build/build_foxx_image.yml
@@ -21,7 +21,7 @@ build-foxx:
     - changes:
         - docker/**/*
         - scripts/**/*
-        - web/**/*
+        - core/database/**/*
         - common/proto/**/*
         - .gitlab-ci.yml
         - CMakeLists.txt
@@ -42,7 +42,7 @@ retag-image:
     - changes:
         - docker/**/*
         - scripts/**/*
-        - web/**/*
+        - core/database/**/*
         - common/proto/**/*
         - .gitlab-ci.yml
         - CMakeLists.txt

--- a/.gitlab/build/build_foxx_image.yml
+++ b/.gitlab/build/build_foxx_image.yml
@@ -24,6 +24,7 @@ build-foxx:
         - web/**/*
         - common/proto/**/*
         - .gitlab-ci.yml
+        - CMakeLists.txt
       when: on_success
 
 retag-image:
@@ -44,5 +45,6 @@ retag-image:
         - web/**/*
         - common/proto/**/*
         - .gitlab-ci.yml
+        - CMakeLists.txt
       when: never
     - when: on_success

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,14 @@ if( INSTALL_WEB_SERVER )
 endif()
 
 if( INSTALL_FOXX ) 
-  install( CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/scripts/install_foxx.sh )")
+  install(CODE "execute_process(COMMAND ${DataFed_SOURCE_DIR}/scripts/install_foxx.sh
+                                OUTPUT_VARIABLE _out
+                                ERROR_VARIABLE _err
+                                RESULT_VARIABLE _res)
+                If (NOT \${_res} EQUAL \"0\")
+                    message( FATAL_ERROR \"out: \${_out} install_foxx failed: \${_err}\")
+                endif()"
+         )
 endif()
 
 if (ENABLE_END_TO_END_TESTS)

--- a/scripts/install_foxx.sh
+++ b/scripts/install_foxx.sh
@@ -149,7 +149,7 @@ fi
 url2="http://${local_DATAFED_DATABASE_HOST}:${local_DATABASE_PORT}/_api/database"
 # We are now going to initialize the DataFed database in Arango, but only if sdms database does
 # not exist
-output=$(curl -s -i --dump - --user "$basic_auth" "$url2")
+output=$(curl -s -i --user "$basic_auth" "$url2")
 
 echo "Output: $output"
 

--- a/scripts/install_foxx.sh
+++ b/scripts/install_foxx.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-# -e has been removed so that if an error occurs the PASSWORD File is deleted and not left lying around
-# -u has been removed because we have no guarantees that the env variables are defined
-set -f -o pipefail
+# History
+#
+# -e has been added back, password file deletion should be handled by another 
+# means such as the CI after script section. If the API fails to install, it 
+# could lead to improper testing the CI env. 
+#
+# -e has been removed so that if an error occurs the PASSWORD File is deleted
+# and not left lying around
+#
+# -u has been removed because we have no guarantees that the env variables are
+# defined
+set -ef -o pipefail
 
 SCRIPT=$(realpath "$0")
 SOURCE=$(dirname "$SCRIPT")
@@ -138,7 +147,7 @@ fi
 basic_auth="$local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD"
 url="http://${local_DATAFED_DATABASE_HOST}:${local_DATABASE_PORT}/_api/database/user"
 # Do not output to /dev/null we need the output
-code=$(curl -s -o /dev/null -w "%{http_code}" --user "$basic_auth" "$url")
+code=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s -o /dev/null -w "%{http_code}" --user "$basic_auth" "$url")
 
 if [[ "$code" != "200" ]]; then
   echo "Error detected in attempting to connect to database at $url"
@@ -149,7 +158,7 @@ fi
 url2="http://${local_DATAFED_DATABASE_HOST}:${local_DATABASE_PORT}/_api/database"
 # We are now going to initialize the DataFed database in Arango, but only if sdms database does
 # not exist
-output=$(curl -s -i --user "$basic_auth" "$url2")
+output=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s -i  --user "$basic_auth" "$url2")
 
 echo "Output: $output"
 
@@ -223,7 +232,7 @@ echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
 
   echo "$FOUND_API"
 
-  RESULT=$(curl -s http://${local_DATAFED_DATABASE_HOST}:8529/_db/sdms/api/${local_FOXX_MAJOR_API_VERSION}/version)
+  RESULT=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s http://${local_DATAFED_DATABASE_HOST}:8529/_db/sdms/api/${local_FOXX_MAJOR_API_VERSION}/version)
   CODE=$(echo "${RESULT}" | jq '.code' )
   echo "Code is $CODE"
   if [ -z "${FOUND_API}" ]

--- a/scripts/install_foxx.sh
+++ b/scripts/install_foxx.sh
@@ -158,7 +158,7 @@ fi
 url2="http://${local_DATAFED_DATABASE_HOST}:${local_DATABASE_PORT}/_api/database"
 # We are now going to initialize the DataFed database in Arango, but only if sdms database does
 # not exist
-output=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s -i  --user "$basic_auth" "$url2")
+output=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s -i --user "$basic_auth" "$url2")
 
 echo "Output: $output"
 


### PR DESCRIPTION
# PR Description

This PR was about getting the install_foxx to correctly throw an error when an error was detected. That error should cause the CI job to exit with an error code. This was correctly demonstrated in comm [3ec6d53](https://github.com/ORNL/DataFed/pull/1187/commits/3ec6d533e7b2cc9c41f9ae3c6190d78e878510c5). Then the fix was merged into this branch to show how it is working and the job is now passing, this was done by removing the curl --dump flag. 

# Tasks

* [x] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [x] - Labels have been assigned to the pr
* [x] - A reviwer has been added
* [x] - A user has been assigned to work on the pr

