### PR TITLE
Add DataFed dependency paths to curl so SSL will be found

### DIFF
--- a/scripts/install_foxx.sh
+++ b/scripts/install_foxx.sh
@@ -138,7 +138,7 @@ fi
 basic_auth="$local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD"
 url="http://${local_DATAFED_DATABASE_HOST}:${local_DATABASE_PORT}/_api/database/user"
 # Do not output to /dev/null we need the output
-code=$(curl -s -o /dev/null -w "%{http_code}" --user "$basic_auth" "$url")
+code=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s -o /dev/null -w "%{http_code}" --user "$basic_auth" "$url")
 
 if [[ "$code" != "200" ]]; then
   echo "Error detected in attempting to connect to database at $url"
@@ -149,7 +149,7 @@ fi
 url2="http://${local_DATAFED_DATABASE_HOST}:${local_DATABASE_PORT}/_api/database"
 # We are now going to initialize the DataFed database in Arango, but only if sdms database does
 # not exist
-output=$(curl -s -i --dump - --user "$basic_auth" "$url2")
+output=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s -i --dump - --user "$basic_auth" "$url2")
 
 echo "Output: $output"
 
@@ -223,7 +223,7 @@ echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
 
   echo "$FOUND_API"
 
-  RESULT=$(curl -s http://${local_DATAFED_DATABASE_HOST}:8529/_db/sdms/api/${local_FOXX_MAJOR_API_VERSION}/version)
+  RESULT=$(LD_LIBRARY_PATH="${DATAFED_DEPENDENCIES_INSTALL_PATH}:$LD_LIBRARY_PATH" curl -s http://${local_DATAFED_DATABASE_HOST}:8529/_db/sdms/api/${local_FOXX_MAJOR_API_VERSION}/version)
   CODE=$(echo "${RESULT}" | jq '.code' )
   echo "Code is $CODE"
   if [ -z "${FOUND_API}" ]


### PR DESCRIPTION
# PR Description


# Tasks

* [x] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [x] - Labels have been assigned to the pr
* [x] - A reviwer has been added
* [x] - A user has been assigned to work on the pr

## Summary by Sourcery

Build:
- Update the `install_foxx.sh` script to set `LD_LIBRARY_PATH` for `curl` calls.