### PR TITLE
1219 daps bug gitlab ci gcs log

### DIFF
--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -301,7 +301,7 @@
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
     - echo "Containers are: $ANCESTOR_CONTAINERS"
-    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
+      #    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
       #    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
       #    - echo "Matching containers are: $MATCHING_CONTAINERS" 
       #    - if [ -z "$MATCHING_CONTAINERS" ]; then

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -301,10 +301,10 @@
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
     - VAR="Test"
-    - echo "This is failing: ${VAR}"
-    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
+    - echo "This is failing ${VAR}"
+    - echo "Matching against ${COMPONENT}-${BRANCH_LOWER}"
     - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
-    - echo "Matching containers are: $MATCHING_CONTAINERS" 
+    - echo "Matching containers are $MATCHING_CONTAINERS" 
     - if [ -z "$MATCHING_CONTAINERS" ]; then
         echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
       else

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -283,30 +283,28 @@
     # Needed if the harbor check script errors out.
     - if [ -f "${CI_PROJECT_DIR}/harbor_check.log" ]; then cat "${CI_PROJECT_DIR}/harbor_check.log"; fi;
 
-# It is possible to return more than one container with the same ancestor
-# for instance if two different branches have the exact same build but
-# different names. Or one image was built on top of another and share the
-# same base.
 .error_logs_client_end_to_end:
   stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
     - echo "Lower branch is $BRANCH_LOWER"
     - export FULL_IMAGE_NAME="${REGISTRY}/${PROJECT}/${COMPONENT}-${BRANCH_LOWER}"
-    - echo "Image name is $FULL_IMAGE_NAME"
+    - echo "Full image name is $FULL_IMAGE_NAME"
     - export ANCESTORS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}")
-    - echo "Ancestor output"
+    - echo "Found Ancestors"
     - echo "$ANCESTORS"
-    - echo "docker ps output"
-    - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-    - echo "ANCESTORS ${ANCESTOR_CONTAINERS}"
-    - echo "Matching against ${COMPONENT}-${BRANCH_LOWER}"
+    - echo "${ANCESTOR_CONTAINERS}"
+      # It is possible to return more than one container with the same ancestor
+      # for instance if two different branches have the exact same build but
+      # different names. Or one image was built on top of another and share the
+      # same base.
     - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
-    - echo "Matching containers are $MATCHING_CONTAINERS" 
     - if [ -z "$MATCHING_CONTAINERS" ]; then
         echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
       else
+        echo "Getting log output for the following."
+        echo "$MATCHING_CONTAINERS"
         docker logs $MATCHING_CONTAINERS;
       fi
   rules:

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -302,7 +302,7 @@
     - CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
     - echo "Containers are: $CONTAINERS"
     - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
-    - MATCHING_CONTAINERS=( echo "$CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - MATCHING_CONTAINERS=$( echo "$CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
     - echo "Matching containers are: $MATCHING_CONTAINERS" 
     - if [ -z "$MATCHING_CONTAINERS" ]; then
         echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -300,8 +300,8 @@
     - echo "docker ps output"
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-      #    - echo "Containers are: $ANCESTOR_CONTAINERS"
-      #    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
+    - echo "Containers are: $ANCESTOR_CONTAINERS"
+    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
       #    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
       #    - echo "Matching containers are: $MATCHING_CONTAINERS" 
       #    - if [ -z "$MATCHING_CONTAINERS" ]; then

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -301,7 +301,7 @@
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
     - echo "Containers are ${ANCESTOR_CONTAINERS}"
-      #    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
+    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
       #    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
       #    - echo "Matching containers are: $MATCHING_CONTAINERS" 
       #    - if [ -z "$MATCHING_CONTAINERS" ]; then

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -283,6 +283,10 @@
     # Needed if the harbor check script errors out.
     - if [ -f "${CI_PROJECT_DIR}/harbor_check.log" ]; then cat "${CI_PROJECT_DIR}/harbor_check.log"; fi;
 
+# It is possible to return more than one container with the same ancestor
+# for instance if two different branches have the exact same build but
+# different names. Or one image was built on top of another and share the
+# same base.
 .error_logs_client_end_to_end:
   stage: log
   script:
@@ -295,14 +299,10 @@
     - echo "$ANCESTORS"
     - echo "docker ps output"
     - docker ps
-      # It is possible to return more than one container with the same ancestor
-      # for instance if two different branches have the exact same build but
-      # different names. Or one image was built on top of another and share the
-      # same base.
-    - CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-    - echo "Containers are: $CONTAINERS"
+    - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
+    - echo "Containers are: $ANCESTOR_CONTAINERS"
     - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
-    - MATCHING_CONTAINERS=$( echo "$CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
     - echo "Matching containers are: $MATCHING_CONTAINERS" 
     - if [ -z "$MATCHING_CONTAINERS" ]; then
         echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -299,7 +299,11 @@
       # for instance if two different branches have the exact same build but
       # different names. Or one image was built on top of another and share the
       # same base.
-    - MATCHING_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
+    - echo "Containers are: $CONTAINERS"
+    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
+    - MATCHING_CONTAINERS=( echo "$CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - echo "Matching containers are: $MATCHING_CONTAINERS" 
     - if [ -z "$MATCHING_CONTAINERS" ]; then
         echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
       else

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -295,7 +295,11 @@
     - echo "$ANCESTORS"
     - echo "docker ps output"
     - docker ps
-    - docker logs $(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}")
+      # It is possible to return more than one container with the same ancestor
+      # for instance if two different branches have the exact same build but
+      # different names. Or one image was built on top of another and share the
+      # same base.
+    - docker logs $(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}" | grep "${COMPONENT}-${BRANCH_LOWER}" )
   rules:
     - when: always
 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -300,8 +300,7 @@
     - echo "docker ps output"
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-    - VAR="Test"
-    - echo "This is failing ${VAR}"
+    - echo "ANCESTORS ${ANCESTOR_CONTAINERS}"
     - echo "Matching against ${COMPONENT}-${BRANCH_LOWER}"
     - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
     - echo "Matching containers are $MATCHING_CONTAINERS" 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -287,12 +287,8 @@
   stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
-    - echo "Lower branch is $BRANCH_LOWER"
     - export FULL_IMAGE_NAME="${REGISTRY}/${PROJECT}/${COMPONENT}-${BRANCH_LOWER}"
     - echo "Full image name is $FULL_IMAGE_NAME"
-    - export ANCESTORS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}")
-    - echo "Found Ancestors"
-    - echo "$ANCESTORS"
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
     - echo "${ANCESTOR_CONTAINERS}"
       # It is possible to return more than one container with the same ancestor

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -287,7 +287,15 @@
   stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
-    - docker logs $(docker ps -a --filter "ancestor=${REGISTRY}/${PROJECT}/${COMPONENT}-${BRANCH_LOWER}" --format "{{.Names}}")
+    - echo "Lower branch is $BRANCH_LOWER"
+    - export FULL_IMAGE_NAME="${REGISTRY}/${PROJECT}/${COMPONENT}-${BRANCH_LOWER}"
+    - echo "Image name is $FULL_IMAGE_NAME"
+    - export ANCESTORS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}")
+    - echo "Ancestor output"
+    - echo "$ANCESTORS"
+    - echo "docker ps output"
+    - docker ps
+    - docker logs $(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}")
   rules:
     - when: always
 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -300,17 +300,18 @@
     - echo "docker ps output"
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-    - echo "Containers are ${ANCESTOR_CONTAINERS}"
+    - VAR="Test"
+    - echo "This is failing: ${VAR}"
     - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
-      #    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
-      #    - echo "Matching containers are: $MATCHING_CONTAINERS" 
-      #    - if [ -z "$MATCHING_CONTAINERS" ]; then
-      #        echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
-      #      else
-      #        docker logs $MATCHING_CONTAINERS;
-      #      fi
-      #  rules:
-      #    - when: always
+    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - echo "Matching containers are: $MATCHING_CONTAINERS" 
+    - if [ -z "$MATCHING_CONTAINERS" ]; then
+        echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
+      else
+        docker logs $MATCHING_CONTAINERS;
+      fi
+  rules:
+    - when: always
 
 # In the case that we are not needing to actually rebuild the image we want to
 # retag the image that already exists in harbor with the current commit, this

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -300,7 +300,7 @@
     - echo "docker ps output"
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-    - echo "Containers are: $ANCESTOR_CONTAINERS"
+    - echo "Containers are ${ANCESTOR_CONTAINERS}"
       #    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
       #    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
       #    - echo "Matching containers are: $MATCHING_CONTAINERS" 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -287,15 +287,15 @@
   stage: log
   script:
     - BRANCH_LOWER=$(echo "$CI_COMMIT_REF_NAME" | tr '[:upper:]' '[:lower:]')
-    - export FULL_IMAGE_NAME="${REGISTRY}/${PROJECT}/${COMPONENT}-${BRANCH_LOWER}"
+    - FULL_IMAGE_NAME="${REGISTRY}/${PROJECT}/${COMPONENT}-${BRANCH_LOWER}"
     - echo "Full image name is $FULL_IMAGE_NAME"
-    - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
+    - ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
     - echo "${ANCESTOR_CONTAINERS}"
       # It is possible to return more than one container with the same ancestor
       # for instance if two different branches have the exact same build but
       # different names. Or one image was built on top of another and share the
       # same base.
-    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
     - if [ -z "$MATCHING_CONTAINERS" ]; then
         echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
       else

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -299,7 +299,12 @@
       # for instance if two different branches have the exact same build but
       # different names. Or one image was built on top of another and share the
       # same base.
-    - docker logs $(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}" | grep "${COMPONENT}-${BRANCH_LOWER}" )
+    - MATCHING_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+    - if [ -z "$MATCHING_CONTAINERS" ]; then
+        echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
+      else
+        docker logs $MATCHING_CONTAINERS;
+      fi
   rules:
     - when: always
 

--- a/.gitlab/common.yml
+++ b/.gitlab/common.yml
@@ -300,17 +300,17 @@
     - echo "docker ps output"
     - docker ps
     - export ANCESTOR_CONTAINERS=$(docker ps -a --filter "ancestor=${FULL_IMAGE_NAME}" --format "{{.Names}}") 
-    - echo "Containers are: $ANCESTOR_CONTAINERS"
-    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
-    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
-    - echo "Matching containers are: $MATCHING_CONTAINERS" 
-    - if [ -z "$MATCHING_CONTAINERS" ]; then
-        echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
-      else
-        docker logs $MATCHING_CONTAINERS;
-      fi
-  rules:
-    - when: always
+      #    - echo "Containers are: $ANCESTOR_CONTAINERS"
+      #    - echo "Matching against: ${COMPONENT}-${BRANCH_LOWER}"
+      #    - export MATCHING_CONTAINERS=$( echo "$ANCESTOR_CONTAINERS" | grep "${COMPONENT}-${BRANCH_LOWER}" || echo "")
+      #    - echo "Matching containers are: $MATCHING_CONTAINERS" 
+      #    - if [ -z "$MATCHING_CONTAINERS" ]; then
+      #        echo "No matching containers found for image ${FULL_IMAGE_NAME} and component ${COMPONENT}-${BRANCH_LOWER}";
+      #      else
+      #        docker logs $MATCHING_CONTAINERS;
+      #      fi
+      #  rules:
+      #    - when: always
 
 # In the case that we are not needing to actually rebuild the image we want to
 # retag the image that already exists in harbor with the current commit, this

--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -280,7 +280,7 @@ end-to-end-repo-setup:
 
 # Requires setting up Globus Connect Server, requires firewall exceptions on
 # the machine running this.
-# Note we need the certificates to be available on the gcs-authz container
+# Note we need the certificates to be available on the gcs container
 # if it is meant to be run on the same machine as the metadata services
 # because the Apache web server can then route traffic appropriately, if 
 # run separate from the metadata services it should not be needed.
@@ -312,13 +312,13 @@ end-to-end-gcs-authz-setup:
     - chown gitlab-runner "$HOST_LOG_FILE_PATH"
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
-    - ./scripts/container_stop.sh -n "gcs-authz" -p
+    - ./scripts/container_stop.sh -n "${COMPONENT}" -p
     - random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
     - cat $CI_DATAFED_CORE_PUB_KEY > /shared/datafed-repo-key.pub
     - cat $CI_DATAFED_CORE_PRIV_KEY > /shared/datafed-repo-key.priv
     - echo "#!/bin/bash" > run_globus.sh
     - echo "docker run -d \\" >> run_globus.sh
-    - echo "--name \"gcs-authz-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}\" \\" >> run_globus.sh
+    - echo "--name \"${COMPONENT}-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}\" \\" >> run_globus.sh
     - echo "--network host \\" >> run_globus.sh
     - echo "-e DATAFED_GLOBUS_APP_SECRET=\"$CI_DATAFED_GLOBUS_APP_SECRET\" \\" >> run_globus.sh
     - echo "-e DATAFED_GLOBUS_APP_ID=\"$CI_DATAFED_GLOBUS_APP_ID\" \\" >> run_globus.sh

--- a/.gitlab/stage_unit.yml
+++ b/.gitlab/stage_unit.yml
@@ -94,11 +94,11 @@ run-authz-unit-job:
     - chown gitlab-runner "$HOST_LOG_FILE_PATH"
     - ./scripts/generate_datafed.sh
     - docker login "${REGISTRY}" -u "${HARBOR_USER}" -p "${HARBOR_DATAFED_GITLAB_CI_REGISTRY_TOKEN}"
-    - ./scripts/container_stop.sh -n "gcs-authz" -p
+    - ./scripts/container_stop.sh -n "${COMPONENT}" -p
     - random_string=$(bash -c "cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "10" | head -n 1")
     - echo "#!/bin/bash" > run_globus.sh
     - echo "docker run \\" >> run_globus.sh
-    - echo "--name \"gcs-authz-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}\" \\" >> run_globus.sh
+    - echo "--name \"${COMPONENT}-${BRANCH_LOWER}-${CI_COMMIT_SHORT_SHA}-${random_string}\" \\" >> run_globus.sh
     - echo "--network host \\" >> run_globus.sh
     - echo "-e DATAFED_GLOBUS_APP_SECRET=\"$CI_DATAFED_GLOBUS_APP_SECRET\" \\" >> run_globus.sh
     - echo "-e DATAFED_GLOBUS_APP_ID=\"$CI_DATAFED_GLOBUS_APP_ID\" \\" >> run_globus.sh


### PR DESCRIPTION
# PR Description

* Using filter with ancestor can return more than one container name, this causes problems when running with docker logs command which expects a single argument.
* Bug was also found to be a difference in container names when building the images vs when testing them and calling the logs. Container names when building where called gcs and when testing were called gcs-authz. 

# Tasks

* [x] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [x] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [x] - Labels have been assigned to the pr
* [x] - A reviwer has been added
* [x] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

CI:
- Fix a bug in the log command where filtering by ancestor could return multiple container names.