### PR TITLE
Fix edge case in GridFTP Authz where '/' is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 17. [1168] - Add authz unit testing to the CI
 18. [1200] - Add JavaScript linter (eslint) and (prettier) formatter for JavaScript
 19. [1180] - Refactor of authz foxx module, split into objects and added unit tests
+20. [1257] - Bug in authz library parsing of authz.conf file, globus paths incorrectly sanitized when using just '/'
 
 # v2024.6.17.10.40
 

--- a/core/database/foxx/api/repo.js
+++ b/core/database/foxx/api/repo.js
@@ -143,7 +143,7 @@ class Repo {
             throw [g_lib.ERR_INTERNAL_FAULT, "Repo document is missing path: " + this.#repo_id];
         }
 
-        // Get and sanitize the repo root path
+        // Get and sanitize the repo root path by removing the trailing slash if one exists
         let repo_root_path = repo.path.replace(/\/$/, "");
         let sanitized_path = a_path.replace(/\/$/, "");
 

--- a/core/database/foxx/tests/repo.test.js
+++ b/core/database/foxx/tests/repo.test.js
@@ -230,7 +230,8 @@ describe("Testing Repo class", () => {
             path: path,
         });
         const repo = new Repo("foo");
-        expect(repo.pathType("/mnt/datafed/compose-home/user/tim/1135")).to.equal(PathType.USER_RECORD_PATH);
+        expect(repo.pathType("/mnt/datafed/compose-home/user/tim/1135")).to.equal(
+            PathType.USER_RECORD_PATH,
+        );
     });
-
 });

--- a/core/database/foxx/tests/repo.test.js
+++ b/core/database/foxx/tests/repo.test.js
@@ -221,4 +221,16 @@ describe("Testing Repo class", () => {
         const repo = new Repo("foo");
         expect(repo.pathType("/mnt/repo_root/user/jane/4243")).to.equal(PathType.USER_RECORD_PATH);
     });
+
+    it("unit_repo: should handle a user record path.", () => {
+        const path = "/mnt/datafed/compose-home/";
+        g_db.repo.save({
+            _id: "repo/foo",
+            _key: "foo",
+            path: path,
+        });
+        const repo = new Repo("foo");
+        expect(repo.pathType("/mnt/datafed/compose-home/user/tim/1135")).to.equal(PathType.USER_RECORD_PATH);
+    });
+
 });

--- a/repository/gridftp/globus5/authz/source/AuthzWorker.cpp
+++ b/repository/gridftp/globus5/authz/source/AuthzWorker.cpp
@@ -413,10 +413,17 @@ std::string AuthzWorker::getAuthzPath(char *full_ftp_path) {
   std::string local_path = removeOrigin(full_ftp_path);
 
   if (isPathValid(local_path) == false) {
-    EXCEPT(1, "Invalid POSIX path.");
+    EXCEPT(1, "Invalid POSIX path: " + std::string(full_ftp_path) + " local_path: " + local_path);
   }
-  auto prefix = local_path.substr(0, m_local_globus_path_root.length());
-
+ 
+  std::string prefix = local_path.substr(0, m_local_globus_path_root.length());
+  if ( prefix.length() == 1) {
+    if (prefix.compare("/") == 0 ) {
+        return local_path;
+    }  else {
+        EXCEPT(1, "Invalid POSIX path: " + std::string(full_ftp_path) + " local_path: " + local_path + " prefix: " + prefix);
+    }
+  }
   return local_path.substr(prefix.length());
 }
 

--- a/repository/gridftp/globus5/authz/tests/unit/test_AuthzWorker.cpp
+++ b/repository/gridftp/globus5/authz/tests/unit/test_AuthzWorker.cpp
@@ -179,6 +179,18 @@ BOOST_AUTO_TEST_CASE(InvalidURLMissingSchemeTest) {
   BOOST_CHECK(worker.isURLValid(invalid_url) == false);
 }
 
+BOOST_AUTO_TEST_CASE(GetAuthzPathGlobusBaseSetToRoot) {
+  // Test a valid full FTP path when the globus_collection_path is /
+  SDMS::LogContext log_context;
+  config.globus_collection_path[0] = '/';
+  config.globus_collection_path[1] = '\0';
+  SDMS::AuthzWorker worker(&config, log_context);
+  char deep_path[] = "ftp://hostname/globus/root/a/b/c/d/e.txt";
+  std::string expected_result = "/globus/root/a/b/c/d/e.txt";
+
+  BOOST_CHECK_EQUAL(worker.getAuthzPath(deep_path), expected_result);
+}
+
 BOOST_AUTO_TEST_CASE(InvalidURLTooFewSlashesTest) {
   SDMS::LogContext log_context;
   SDMS::AuthzWorker worker(&config, log_context);
@@ -209,6 +221,18 @@ BOOST_AUTO_TEST_CASE(URLWithoutHostnameTest) {
   // Test an FTP URL missing the hostname but still has "ftp://"
   char no_hostname_url[] = "ftp:///path/to/file.txt";
   BOOST_CHECK(worker.isURLValid(no_hostname_url) == false);
+}
+
+BOOST_AUTO_TEST_CASE(RemoveOriginGlobusBaseSetToRoot) {
+  // Test a valid full FTP path when the globus_collection_path is /
+  SDMS::LogContext log_context;
+  config.globus_collection_path[0] = '/';
+  config.globus_collection_path[1] = '\0';
+  SDMS::AuthzWorker worker(&config, log_context);
+  char deep_path[] = "ftp://hostname/globus/root/a/b/c/d/e.txt";
+  std::string expected_result = "/globus/root/a/b/c/d/e.txt";
+
+  BOOST_CHECK_EQUAL(worker.removeOrigin(deep_path), expected_result);
 }
 
 BOOST_AUTO_TEST_CASE(RemoveOriginValidURLTest) {


### PR DESCRIPTION
# PR Description

Fixes bug in parsing path of globus collection in authz conf file.

# Tasks

* [x] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Fix an edge case in GridFTP authorization when the root path is used.

Bug Fixes:
- Handle the edge case where the globus_collection_path is set to the root path "/".

Tests:
- Add unit tests for the root path edge case in GridFTP authorization.