### PR TITLE
Fix bug where schema notification errors are not triggered when custo…

### DIFF
--- a/core/database/foxx/api/data_router.js
+++ b/core/database/foxx/api/data_router.js
@@ -105,7 +105,8 @@ function recordCreate(client, record, result) {
         obj.md = record.md;
         if (Array.isArray(obj.md)) throw [g_lib.ERR_INVALID_PARAM, "Metadata cannot be an array"];
     } else {
-        obj.md = "{}";
+        // Save it as an empty object.
+        obj.md = {};
     }
 
     if (obj.alias) {

--- a/core/database/foxx/api/data_router.js
+++ b/core/database/foxx/api/data_router.js
@@ -99,9 +99,13 @@ function recordCreate(client, record, result) {
         }
     }
 
+    // If no custom metadata is provided by the user empty curly braces should
+    // be set so as to trigger schema validation errors.
     if (record.md) {
         obj.md = record.md;
         if (Array.isArray(obj.md)) throw [g_lib.ERR_INVALID_PARAM, "Metadata cannot be an array"];
+    } else {
+        obj.md = "{}";
     }
 
     if (obj.alias) {

--- a/web/static/dlg_data_new_edit.js
+++ b/web/static/dlg_data_new_edit.js
@@ -557,11 +557,16 @@ export function show(a_mode, a_data, a_parent, a_upd_perms, a_cb) {
                     $("#sch_id", frame).val(a_data.schId);
                 }
 
+                var md;
                 if (a_data.metadata) {
-                    var md = JSON.parse(a_data.metadata);
-                    var txt = JSON.stringify(md, null, 4);
-                    jsoned.setValue(txt, -1);
+                  md = JSON.parse(a_data.metadata);
+                } else {
+                  md = {};  // Set empty metadata to an empty JSON object
                 }
+
+                var txt = JSON.stringify(md, null, 4);
+                jsoned.setValue(txt, -1); 
+
 
                 if (a_data.deps && a_data.deps.length) {
                     var i, dep, row;


### PR DESCRIPTION
…m metadata is empty

# PR Description

Fixes bug where schema notifications are not being triggered when custom metadata field has not been specified.

# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Bug Fixes:
- Fix a bug where schema notification errors were not triggered when custom metadata was empty.