### PR TITLE
hotfix port mapping

### DIFF
--- a/scripts/generate_repo_config.sh
+++ b/scripts/generate_repo_config.sh
@@ -30,7 +30,6 @@ Help()
   echo "-g, --globus-collection-base-path   The Globus (POSIX) Base path to the Guest Collection."
 }
 
-local_DATAFED_PORT="7512"
 if [ -z "${DATAFED_DOMAIN}" ]
 then
   local_DATAFED_DOMAIN="datafed.ornl.gov"
@@ -52,6 +51,14 @@ then
   local_DATAFED_LOG_PATH="/var/log/datafed"
 else
   local_DATAFED_LOG_PATH=$(printenv DATAFED_DEFAULT_LOG_PATH)
+fi
+
+local_DATAFED_SERVER_PORT=""
+if [ -z "${DATAFED_SERVER_PORT}" ]
+then
+    local_DATAFED_SERVER_PORT="7512"
+else
+    local_DATAFED_SERVER_PORT=$(printenv DATAFED_SERVER_PORT)
 fi
 
 local_DATAFED_CRED_DIR="${DATAFED_INSTALL_PATH}/keys/"
@@ -113,7 +120,7 @@ CONFIG_FILE_NAME="datafed-repo.cfg"
 # same port listed in the datafed-repo.cfg file.
 cat << EOF > "$PATH_TO_CONFIG_DIR/$CONFIG_FILE_NAME"
 cred-dir=$local_DATAFED_CRED_DIR
-server=tcp://$local_DATAFED_DOMAIN:${local_DATAFED_PORT}
+server=tcp://$local_DATAFED_DOMAIN:${local_DATAFED_SERVER_PORT}
 port=$local_DATAFED_REPO_PORT
 threads=$local_DATAFED_REPO_THREADS
 globus-collection-path=$local_DATAFED_GCS_COLLECTION_BASE_PATH


### PR DESCRIPTION
Accept env variable for datafed server from repo service instead of hard coding

# PR Description


# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Build:
- Make the datafed server port configurable via the `DATAFED_SERVER_PORT` environment variable. Use port 7512 as the default value if the environment variable is not set or empty.