### PR TITLE
[DAPS-1283]  Add Resume Flow For Consent Reconstruct

### DIFF
--- a/web/datafed-ws.js
+++ b/web/datafed-ws.js
@@ -311,6 +311,7 @@ app.use(
 function storeCollectionId(req, res, next) {
     if (req.query.collection_id) {
         req.session.collection_id = req.query.collection_id;
+        req.session.collection_type = "mapped";
     }
     next();
 }

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -305,12 +305,16 @@ class EndpointBrowser {
             const ep_status = await new Promise((resolve) => {
                 api.epView(this.props.endpoint.id, (ok, data) => resolve(data));
             });
-            const is_mapped = ep_status.entity_type.includes("mapped");// Fetch directory listing
+            const is_mapped = ep_status.entity_type.includes("mapped"); // Fetch directory listing
             const data = await new Promise((resolve) => {
-                api.epDirList(this.props.endpoint.id, this.state.path, false,is_mapped,
+                api.epDirList(
+                    this.props.endpoint.id,
+                    this.state.path,
+                    false,
+                    is_mapped,
                     this.props.endpoint.id,
                     resolve,
-            );
+                );
             });
 
             if (data.needs_consent || data.code) {

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -1,25 +1,26 @@
 import * as util from "../../util.js";
 import * as api from "../../api.js";
+import {TransferMode} from "../../models/transfer-model.js";
 
 const CONFIG = {
-    PATH: { SEPARATOR: "/", UP: "..", CURRENT: "." },
-    UI: {
-        SIZE: { WIDTH: "500", HEIGHT: "400" },
-        DELAY: 1000,
-        ICONS: {
-            FOLDER: "ui-icon ui-icon-folder",
-            FILE: "ui-icon ui-icon-file",
-        },
+  PATH: {SEPARATOR: "/", UP: "..", CURRENT: "."},
+  UI: {
+    SIZE: {WIDTH: "500", HEIGHT: "400"},
+    DELAY: 1000,
+    ICONS: {
+      FOLDER: "ui-icon ui-icon-folder",
+      FILE: "ui-icon ui-icon-file",
     },
+  },
 };
 
 class ApiError extends Error {
-    constructor(data) {
-        super(data.message);
-        this.name = "ApiError";
-        this.data = data;
-        this.code = data.code;
-    }
+  constructor(data) {
+    super(data.message);
+    this.name = "ApiError";
+    this.data = data;
+    this.code = data.code;
+  }
 }
 
 /**
@@ -27,41 +28,61 @@ class ApiError extends Error {
  * Handles browsing and selecting files/directories from endpoints
  */
 class EndpointBrowser {
-    #controller;
-    /**
-     * @param {object} props - Browser configuration
-     * @param {object} props.controller - Yea
-     * @param {object} props.endpoint - Endpoint details
-     * @param {string} props.path - Initial path
-     * @param {string} props.mode - Browser mode ('file'/'dir')
-     * @param {Function} props.onSelect - Selection callback
-     * @param {object} props.services - The service objects to use for API and dialog operations
-     * @param {object} props.services.dialogs - Dialog service
-     * @param {Function} props.services.dialogs.dlgAlert - Alert dialog function
-     * @param {object} props.services.api - API service
-     * @param {Function} props.services.api.getGlobusConsentURL - Globus authorization URL function
-     */
-    constructor(props) {
-        const cachedComponentData = sessionStorage.getItem("resumeFlow") === true && this.loadCache();
-        this.props = cachedComponentData?.props || props;
-        this.#controller = this.props.controller;
-        this.state = {
-            path: cachedComponentData?.state?.path || props.path,
-            loading: false,
-            timer: null,
-        };
-    }
+  #controller;
 
-    /**
-     * Save component state to cache
-     * @returns {object | null} The cached component data
-     */
-    loadCache() {
-        return sessionStorage.getItem("endpointBrowserState");
-    }
+  /**
+   * @param {object} props - Browser configuration
+   * @param {object} props.controller - Yea
+   * @param {object} props.endpoint - Endpoint details
+   * @param {string} props.path - Initial path
+   * @param {TransferMode[keyof TransferMode]} props.mode - Browser mode ('file'/'dir')
+   * @param {Function} props.onSelect - Selection callback
+   * @param {object} props.services - The service objects to use for API and dialog operations
+   * @param {object} props.services.dialogs - Dialog service
+   * @param {Function} props.services.dialogs.dlgAlert - Alert dialog function
+   * @param {object} props.services.api - API service
+   * @param {Function} props.services.api.getGlobusConsentURL - Globus authorization URL function
+   */
+  constructor(props) {
+    const cachedComponentData = sessionStorage.getItem("resumeFlow") === true && this.loadCache();
+    this.props = cachedComponentData?.props ? {
+      endpoint: this.props.endpoint,
+      mode: this.props.mode,
+      onSelect: Function('return' + this.props.onSelect),
+    } : props;
+    this.#controller = this.props.controller;
+    this.state = {
+      path: cachedComponentData?.state?.path || props.path,
+      loading: false,
+      timer: null,
+    };
+  }
 
-    pathNavigator() {
-        return `
+  /**
+   * Save component state to cache
+   * @returns {object | null} The cached component data
+   */
+  loadCache() {
+    return sessionStorage.getItem("endpointBrowserState");
+  }
+
+  saveCache() {
+    sessionStorage.setItem("endpointBrowserState", JSON.stringify(
+      {
+        props: {
+          endpoint: this.props.endpoint,
+          mode: this.props.mode,
+          onSelect: String(this.props.onSelect),
+        },
+        state: {
+          path: this.state.path
+        }
+      }
+    ));
+  }
+
+  pathNavigator() {
+    return `
              <div class='endpoint-browser col-flex'>                                                                                                                  
                   <div class="path-navigator row-flex">                                                                                                               
                       <label class="path-label">Path:</label>                                                                                                         
@@ -74,10 +95,10 @@ class EndpointBrowser {
                   </div>                                                                                                                                              
               </div>                                                                                                                                              
          `;
-    }
+  }
 
-    fileTree() {
-        return `
+  fileTree() {
+    return `
              <div class="endpoint-browser file-tree-view ui-widget content">
                  <table id="file_tree">
                      <colgroup>
@@ -95,15 +116,15 @@ class EndpointBrowser {
                  </table>
              </div>
          `;
-    }
+  }
 
-    /**
-     * Renders dialog content
-     * @returns {jQuery} Dialog element
-     */
-    render() {
-        this.element =
-            $(`                                                                                                                                           
+  /**
+   * Renders dialog content
+   * @returns {jQuery} Dialog element
+   */
+  render() {
+    this.element =
+      $(`                                                                                                                                           
          <div class="endpoint-browser">                                                                                                                           
              ${this.pathNavigator()}                                                                                                                        
              <div class="spacer"></div>                                                                                                                           
@@ -111,272 +132,258 @@ class EndpointBrowser {
          </div>                                                                                                                                                   
      `);
 
-        this.initUI();
-        return this.element;
-    }
+    this.initUI();
+    return this.element;
+  }
 
-    /**
-     * Initialize UI components and event handlers
-     */
-    initUI() {
-        // Initialize buttons and inputs
-        $(".btn", this.element).button();
-        util.inputTheme($("input:text", this.element));
+  /**
+   * Initialize UI components and event handlers
+   */
+  initUI() {
+    // Initialize buttons and inputs
+    $(".btn", this.element).button();
+    util.inputTheme($("input:text", this.element));
 
-        // Attach event handlers
-        $("#up", this.element).on("click", () => this.navigate(CONFIG.PATH.UP));
-        $("#path", this.element).on("input", () => {
-            clearTimeout(this.state.timer);
-            this.state.timer = setTimeout(() => {
-                this.state.path = $("#path", this.element).val();
-                this.loadTree();
-            }, CONFIG.UI.DELAY);
-        });
-
-        // Initialize FancyTree with configuration
-        $("#file_tree", this.element).fancytree({
-            checkbox: false,
-            extensions: ["themeroller", "table"],
-            nodata: false,
-            themeroller: { activeClass: "my-fancytree-active", hoverClass: "" },
-            table: { nodeColumnIdx: 0 },
-            source: [{ title: "loading...", icon: false, is_dir: true }],
-            selectMode: 1,
-            // Render additional columns (size and date)
-            renderColumns: this.renderTreeColumns,
-            // Handle node selection
-            activate: (_, data) => {
-                data.node.setSelected(true);
-                $("#sel_btn").button(this.isValidSelection(data.node) ? "enable" : "disable");
-            },
-            // Handle double-click navigation
-            dblclick: (_, data) => {
-                if (data.node.data.is_dir && !this.state.loading) {
-                    this.navigate(data.node.key);
-                }
-            },
-        });
-
+    // Attach event handlers
+    $("#up", this.element).on("click", () => this.navigate(CONFIG.PATH.UP));
+    $("#path", this.element).on("input", () => {
+      clearTimeout(this.state.timer);
+      this.state.timer = setTimeout(() => {
+        this.state.path = $("#path", this.element).val();
         this.loadTree();
-    }
+      }, CONFIG.UI.DELAY);
+    });
 
-    renderTreeColumns(_, data) {
-        const $cols = $(data.node.tr).find(">td");
-        if (data.node.data.is_dir) {
-            $cols.eq(0).prop("colspan", 3).nextAll().remove();
-            return;
+    // Initialize FancyTree with configuration
+    $("#file_tree", this.element).fancytree({
+      checkbox: false,
+      extensions: ["themeroller", "table"],
+      nodata: false,
+      themeroller: {activeClass: "my-fancytree-active", hoverClass: ""},
+      table: {nodeColumnIdx: 0},
+      source: [{title: "loading...", icon: false, is_dir: true}],
+      selectMode: 1,
+      // Render additional columns (size and date)
+      renderColumns: this.renderTreeColumns,
+      // Handle node selection
+      activate: (_, data) => {
+        data.node.setSelected(true);
+        $("#sel_btn").button(this.isValidSelection(data.node) ? "enable" : "disable");
+      },
+      // Handle double-click navigation
+      dblclick: (_, data) => {
+        if (data.node.data.is_dir && !this.state.loading) {
+          this.navigate(data.node.key);
         }
-        $cols.eq(1).text(data.node.data.size);
-        $cols.eq(2).text(data.node.data.date);
+      },
+    });
+
+    this.loadTree();
+  }
+
+  renderTreeColumns(_, data) {
+    const $cols = $(data.node.tr).find(">td");
+    if (data.node.data.is_dir) {
+      $cols.eq(0).prop("colspan", 3).nextAll().remove();
+      return;
+    }
+    $cols.eq(1).text(data.node.data.size);
+    $cols.eq(2).text(data.node.data.date);
+  }
+
+  /**
+   * @param {object} node - Tree node
+   * @returns {boolean} Whether selection is valid
+   */
+  isValidSelection(node) {
+    const isDir = node?.data?.is_dir;
+    const notUpDirInput = node?.key !== CONFIG.PATH.UP;
+
+    const dirMode = isDir && this.props.mode === TransferMode.TT_DATA_GET;
+    const fileMode = !isDir && this.props.mode === TransferMode.TT_DATA_PUT;
+
+    return (dirMode || fileMode) && notUpDirInput;
+  }
+
+  /**
+   * Navigate to new path
+   * @param {string} newPath - Target path
+   */
+  navigate(newPath) {
+    clearTimeout(this.state.timer);
+    // Ensure path ends with separator
+    const current = this.state.path.endsWith(CONFIG.PATH.SEPARATOR)
+      ? this.state.path
+      : this.state.path + CONFIG.PATH.SEPARATOR;
+
+    let updatedPath;
+    if (newPath === CONFIG.PATH.UP) {
+      // Handle "up" navigation
+      if (current.length === 1) {
+        // Already at root
+        return;
+      }
+      const idx = current.lastIndexOf(CONFIG.PATH.SEPARATOR, current.length - 2);
+      updatedPath = idx > 0 ? current.substring(0, idx + 1) : CONFIG.PATH.SEPARATOR;
+    } else {
+      // Navigate to subdirectory
+      updatedPath = current + newPath + CONFIG.PATH.SEPARATOR;
+    }
+    // Update state and UI
+    this.state.path = updatedPath;
+    $("#path", this.element).val(updatedPath);
+    this.loadTree();
+  }
+
+  /**
+   * Load tree data from API
+   */
+  async loadTree() {
+    if (this.state.loading) {
+      return;
     }
 
-    /**
-     * @param {object} node - Tree node
-     * @returns {boolean} Whether selection is valid
-     */
-    isValidSelection(node) {
-        const isDir = node?.data?.is_dir;
-        const notUpDirInput = node?.key !== CONFIG.PATH.UP;
-        const dirMode = isDir && this.props.mode === "dir";
-        const fileMode = !isDir && this.props.mode === "file";
+    // Set loading state
+    this.state.loading = true;
+    $("#sel_btn").button("disable");
+    $("#file_tree").fancytree("disable");
 
-        return (dirMode || fileMode) && notUpDirInput;
-    }
-
-    /**
-     * Navigate to new path
-     * @param {string} newPath - Target path
-     */
-    navigate(newPath) {
-        clearTimeout(this.state.timer);
-        // Ensure path ends with separator
-        const current = this.state.path.endsWith(CONFIG.PATH.SEPARATOR)
-            ? this.state.path
-            : this.state.path + CONFIG.PATH.SEPARATOR;
-
-        let updatedPath;
-        if (newPath === CONFIG.PATH.UP) {
-            // Handle "up" navigation
-            if (current.length === 1) {
-                // Already at root
-                return;
-            }
-            const idx = current.lastIndexOf(CONFIG.PATH.SEPARATOR, current.length - 2);
-            updatedPath = idx > 0 ? current.substring(0, idx + 1) : CONFIG.PATH.SEPARATOR;
-        } else {
-            // Navigate to subdirectory
-            updatedPath = current + newPath + CONFIG.PATH.SEPARATOR;
-        }
-        // Update state and UI
-        this.state.path = updatedPath;
-        $("#path", this.element).val(updatedPath);
-        this.loadTree();
-    }
-
-    /**
-     * Load tree data from API
-     */
-    async loadTree() {
-        if (this.state.loading) {
-            return;
-        }
-
-        // Set loading state
-        this.state.loading = true;
-        $("#sel_btn").button("disable");
-        $("#file_tree").fancytree("disable");
-
-        try {
-            const ep_status = await new Promise((resolve) => {
+    try {
+      const ep_status = await new Promise((resolve) => {
                 api.epView(this.props.endpoint.id, (ok, data) => resolve(data));
             });
-            const is_mapped = ep_status.entity_type.includes("mapped");
-            // Fetch directory listing
-            const data = await new Promise((resolve) => {
-                api.epDirList(
-                    this.props.endpoint.id,
-                    this.state.path,
-                    false,
-                    is_mapped,
+            const is_mapped = ep_status.entity_type.includes("mapped");// Fetch directory listing
+      const data = await new Promise((resolve) => {
+        api.epDirList(this.props.endpoint.id, this.state.path, false,is_mapped,
                     this.props.endpoint.id,
                     resolve,
-                );
+      );
             });
 
-            if (data.needs_consent || data.code) {
+      if (data.needs_consent || data.code) {
                 // TODO: needs consent flag only works first time, if base token has consent it will no longer work.
-                throw new ApiError(data);
-            }
+        throw new ApiError(data);
+      }
 
-            const source = this.getTreeSource(data);
-            $.ui.fancytree.getTree("#file_tree").reload(source);
-        } catch (error) {
-            const errorSource = await this.createErrorSource(error);
-            $.ui.fancytree.getTree("#file_tree").reload(errorSource);
-        } finally {
-            this.state.loading = false;
-            $("#file_tree").fancytree("enable");
-        }
+      const source = this.getTreeSource(data);
+      $.ui.fancytree.getTree("#file_tree").reload(source);
+    } catch (error) {
+      const errorSource = await this.createErrorSource(error);
+      $.ui.fancytree.getTree("#file_tree").reload(errorSource);
+    } finally {
+      this.state.loading = false;
+      $("#file_tree").fancytree("enable");
     }
+  }
 
-    /**
-     * Get tree source data
-     * @param {object} data - API response data
-     * @returns {Array} Tree source data
-     */
-    getTreeSource(data) {
-        return [
-            {
-                title: CONFIG.PATH.UP,
-                icon: CONFIG.UI.ICONS.FOLDER,
-                key: CONFIG.PATH.UP,
-                is_dir: true,
-            },
-            ...data.DATA.map((entry) =>
-                entry.type === "dir"
-                    ? {
-                          title: entry.name,
-                          icon: CONFIG.UI.ICONS.FOLDER,
-                          key: entry.name,
-                          is_dir: true,
-                      }
-                    : {
-                          title: entry.name,
-                          icon: CONFIG.UI.ICONS.FILE,
-                          key: entry.name,
-                          is_dir: false,
-                          size: util.sizeToString(entry.size),
-                          date: new Date(entry.last_modified.replace(" ", "T")).toLocaleString(),
-                      },
-            ),
-        ];
-    }
+  /**
+   * Get tree source data
+   * @param {object} data - API response data
+   * @returns {Array} Tree source data
+   */
+  getTreeSource(data) {
+    return [
+      {
+        title: CONFIG.PATH.UP,
+        icon: CONFIG.UI.ICONS.FOLDER,
+        key: CONFIG.PATH.UP,
+        is_dir: true,
+      },
+      ...data.DATA.map((entry) =>
+        entry.type === "dir"
+          ? {
+            title: entry.name,
+            icon: CONFIG.UI.ICONS.FOLDER,
+            key: entry.name,
+            is_dir: true,
+          }
+          : {
+            title: entry.name,
+            icon: CONFIG.UI.ICONS.FILE,
+            key: entry.name,
+            is_dir: false,
+            size: util.sizeToString(entry.size),
+            date: new Date(entry.last_modified.replace(" ", "T")).toLocaleString(),
+          },
+      ),
+    ];
+  }
 
-    /**
-     * Handle API error responses
-     * @param {object} error - API response data
-     * @returns {Promise<Array>} Error message source
-     */
-    async createErrorSource(error) {
-        let title = "";
+  /**
+   * Handle API error responses
+   * @param {object} error - API response data
+   * @returns {Promise<Array>} Error message source
+   */
+  async createErrorSource(error) {
+    let title = "";
 
-        if (error instanceof ApiError && error.code === "ConsentRequired") {
-            // Save state only when consent is required to restore it later
+    if (error instanceof ApiError && error.code === "ConsentRequired") {
+      // Save state only when consent is required to restore it later
 
-            // Generate consent URL
-            const data = await new Promise((resolve) => {
-                api.getGlobusConsentURL(
-                    (_, data) => resolve(data),
-                    this.props.endpoint.id,
-                    error.data.required_scopes,
-                );
-            });
-            // Create a consent link with onclick handler
-            title = `<span class='ui-state-error'>Consent Required: Please provide 
+      // Generate consent URL
+      const data = await new Promise((resolve) => {
+        api.getGlobusConsentURL(
+          (_, data) => resolve(data),
+          this.props.endpoint.id,
+          error.data.required_scopes,
+        );
+      });
+      // Create a consent link with onclick handler
+      title = `<span class='ui-state-error'>Consent Required: Please provide 
                 <a href="#" id="consent-link" data-url="${data.consent_url}">consent</a>.
             </span>`;
 
-            // Add the click handler after rendering
-            setTimeout(() => {
-                const consentLink = document.getElementById("consent-link");
-                if (consentLink) {
-                    document.getElementById("consent-link").addEventListener("click", (e) => {
-                        e.preventDefault();
+      // Add the click handler after rendering
+      setTimeout(() => {
+        const consentLink = document.getElementById("consent-link");
+        if (consentLink) {
+          document.getElementById("consent-link").addEventListener("click", (e) => {
+            e.preventDefault();
 
-                        // Save state only when the link is clicked
-                        this.#controller.saveCache();
-                        this.#controller.uiManager.saveCache()
-                        this.#controller.endpointManager.saveCache()
-                        sessionStorage.setItem(
-                          "endpointBrowserState", JSON.stringify(
-                            {
-                                props: {
-                                    endpoint: this.props.endpoint,
-                                    mode: this.props.mode,
-                                    onSelect: String(this.props.onSelect)
-                                },
-                            }
-                          )
-                        );
-                        // Redirect to consent URL
-                        window.location.replace(consentLink.getAttribute("data-url"));
-                    });
-                }
-            }, 0);
-        } else {
-            title = `<span class='ui-state-error'>Error: ${error instanceof ApiError ? error.data.message : error.message}</span>`;
+            // Save state only when the link is clicked
+            this.#controller.saveCache();
+            this.#controller.uiManager.saveCache()
+            this.#controller.endpointManager.saveCache()
+            this.saveCache()
+            // Redirect to consent URL
+            window.location.replace(consentLink.getAttribute("data-url"));
+          });
         }
-
-        return [
-            {
-                title,
-                icon: false,
-                is_dir: true,
-            },
-        ];
+      }, 0);
+    } else {
+      title = `<span class='ui-state-error'>Error: ${error instanceof ApiError ? error.data.message : error.message}</span>`;
     }
 
-    /**
-     * Handle selection confirmation
-     */
-    handleSelect() {
-        const node = $.ui.fancytree.getTree("#file_tree").activeNode;
-        if (!node || !this.props.onSelect) {
-            return;
-        }
+    return [
+      {
+        title,
+        icon: false,
+        is_dir: true,
+      },
+    ];
+  }
 
-        // Construct full path for selected node
-        const path =
-            this.state.path +
-            (this.state.path.endsWith(CONFIG.PATH.SEPARATOR) ? "" : CONFIG.PATH.SEPARATOR) +
-            (node.key === CONFIG.PATH.CURRENT ? "" : node.key);
-
-        this.props.onSelect(path);
+  /**
+   * Handle selection confirmation
+   */
+  handleSelect() {
+    const node = $.ui.fancytree.getTree("#file_tree").activeNode;
+    if (!node || !this.props.onSelect) {
+      return;
     }
 
-    cleanup() {
-        clearTimeout(this.state.timer);
-    }
+    // Construct full path for selected node
+    const path =
+      this.state.path +
+      (this.state.path.endsWith(CONFIG.PATH.SEPARATOR) ? "" : CONFIG.PATH.SEPARATOR) +
+      (node.key === CONFIG.PATH.CURRENT ? "" : node.key);
+
+    this.props.onSelect(path);
+  }
+
+  cleanup() {
+    clearTimeout(this.state.timer);
+  }
 }
 
 /**
@@ -394,41 +401,41 @@ export function show(
   controller,
   callback
 ) {
-    const browser = new EndpointBrowser({
-        endpoint,
-        path,
-        mode,
-        controller,
-        onSelect: callback,
-    });
-    console.log("browser, path, mode, callback", endpoint, path, mode, callback);
-    browser.render().dialog({
-        title: `Browse End-Point ${endpoint.name}`,
-        modal: true,
-        width: CONFIG.UI.SIZE.WIDTH,
-        height: CONFIG.UI.SIZE.HEIGHT,
-        resizable: true,
-        buttons: [
-            {
-                text: "Cancel",
-                click: function () {
-                    browser.cleanup();
-                    $(this).dialog("close");
-                },
-            },
-            {
-                id: "sel_btn",
-                text: "Select",
-                click: function () {
-                    browser.handleSelect();
-                    browser.cleanup();
-                    $(this).dialog("close");
-                },
-            },
-        ],
-        close: function () {
-            browser.cleanup();
-            $(this).dialog("destroy").remove();
+  const browser = new EndpointBrowser({
+    endpoint,
+    path,
+    mode,
+    controller,
+    onSelect: callback,
+  });
+  console.log("browser, path, mode, callback", endpoint, path, mode, callback);
+  browser.render().dialog({
+    title: `Browse End-Point ${endpoint.name}`,
+    modal: true,
+    width: CONFIG.UI.SIZE.WIDTH,
+    height: CONFIG.UI.SIZE.HEIGHT,
+    resizable: true,
+    buttons: [
+      {
+        text: "Cancel",
+        click: function () {
+          browser.cleanup();
+          $(this).dialog("close");
         },
-    });
+      },
+      {
+        id: "sel_btn",
+        text: "Select",
+        click: function () {
+          browser.handleSelect();
+          browser.cleanup();
+          $(this).dialog("close");
+        },
+      },
+    ],
+    close: function () {
+      browser.cleanup();
+      $(this).dialog("destroy").remove();
+    },
+  });
 }

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -1,26 +1,27 @@
 import * as util from "../../util.js";
 import * as api from "../../api.js";
-import {TransferMode} from "../../models/transfer-model.js";
+import { TransferMode } from "../../models/transfer-model.js";
+import { AUTH_URL } from "../../../services/auth/constants.js";
 
 const CONFIG = {
-  PATH: {SEPARATOR: "/", UP: "..", CURRENT: "."},
-  UI: {
-    SIZE: {WIDTH: "500", HEIGHT: "400"},
-    DELAY: 1000,
-    ICONS: {
-      FOLDER: "ui-icon ui-icon-folder",
-      FILE: "ui-icon ui-icon-file",
+    PATH: { SEPARATOR: "/", UP: "..", CURRENT: "." },
+    UI: {
+        SIZE: { WIDTH: "500", HEIGHT: "400" },
+        DELAY: 1000,
+        ICONS: {
+            FOLDER: "ui-icon ui-icon-folder",
+            FILE: "ui-icon ui-icon-file",
+        },
     },
-  },
 };
 
 class ApiError extends Error {
-  constructor(data) {
-    super(data.message);
-    this.name = "ApiError";
-    this.data = data;
-    this.code = data.code;
-  }
+    constructor(data) {
+        super(data.message);
+        this.name = "ApiError";
+        this.data = data;
+        this.code = data.code;
+    }
 }
 
 /**
@@ -28,61 +29,65 @@ class ApiError extends Error {
  * Handles browsing and selecting files/directories from endpoints
  */
 class EndpointBrowser {
-  #controller;
+    #controller;
 
-  /**
-   * @param {object} props - Browser configuration
-   * @param {object} props.controller - Yea
-   * @param {object} props.endpoint - Endpoint details
-   * @param {string} props.path - Initial path
-   * @param {TransferMode[keyof TransferMode]} props.mode - Browser mode ('file'/'dir')
-   * @param {Function} props.onSelect - Selection callback
-   * @param {object} props.services - The service objects to use for API and dialog operations
-   * @param {object} props.services.dialogs - Dialog service
-   * @param {Function} props.services.dialogs.dlgAlert - Alert dialog function
-   * @param {object} props.services.api - API service
-   * @param {Function} props.services.api.getGlobusConsentURL - Globus authorization URL function
-   */
-  constructor(props) {
-    const cachedComponentData = sessionStorage.getItem("resumeFlow") === true && this.loadCache();
-    this.props = cachedComponentData?.props ? {
-      endpoint: this.props.endpoint,
-      mode: this.props.mode,
-      onSelect: Function('return' + this.props.onSelect),
-    } : props;
-    this.#controller = this.props.controller;
-    this.state = {
-      path: cachedComponentData?.state?.path || props.path,
-      loading: false,
-      timer: null,
-    };
-  }
+    /**
+     * @param {object} props - Browser configuration
+     * @param {object} props.controller - Yea
+     * @param {object} props.endpoint - Endpoint details
+     * @param {string} props.path - Initial path
+     * @param {TransferMode[keyof TransferMode]} props.mode - Browser mode ('file'/'dir')
+     * @param {Function} props.onSelect - Selection callback
+     * @param {object} props.services - The service objects to use for API and dialog operations
+     * @param {object} props.services.dialogs - Dialog service
+     * @param {Function} props.services.dialogs.dlgAlert - Alert dialog function
+     * @param {object} props.services.api - API service
+     * @param {Function} props.services.api.getGlobusConsentURL - Globus authorization URL function
+     */
+    constructor(props) {
+        const cachedComponentData =
+            sessionStorage.getItem("resumeFlow") === true && this.loadCache();
+        this.props = cachedComponentData?.props
+            ? {
+                  endpoint: this.props.endpoint,
+                  mode: this.props.mode,
+                  onSelect: Function("return" + this.props.onSelect),
+              }
+            : props;
+        this.#controller = this.props.controller;
+        this.state = {
+            path: cachedComponentData?.state?.path || props.path,
+            loading: false,
+            timer: null,
+        };
+    }
 
-  /**
-   * Save component state to cache
-   * @returns {object | null} The cached component data
-   */
-  loadCache() {
-    return sessionStorage.getItem("endpointBrowserState");
-  }
+    /**
+     * Save component state to cache
+     * @returns {object | null} The cached component data
+     */
+    loadCache() {
+        return sessionStorage.getItem("endpointBrowserState");
+    }
 
-  saveCache() {
-    sessionStorage.setItem("endpointBrowserState", JSON.stringify(
-      {
-        props: {
-          endpoint: this.props.endpoint,
-          mode: this.props.mode,
-          onSelect: String(this.props.onSelect),
-        },
-        state: {
-          path: this.state.path
-        }
-      }
-    ));
-  }
+    saveCache() {
+        sessionStorage.setItem(
+            "endpointBrowserState",
+            JSON.stringify({
+                props: {
+                    endpoint: this.props.endpoint,
+                    mode: this.props.mode,
+                    onSelect: String(this.props.onSelect),
+                },
+                state: {
+                    path: this.state.path,
+                },
+            }),
+        );
+    }
 
-  pathNavigator() {
-    return `
+    pathNavigator() {
+        return `
              <div class='endpoint-browser col-flex'>                                                                                                                  
                   <div class="path-navigator row-flex">                                                                                                               
                       <label class="path-label">Path:</label>                                                                                                         
@@ -95,10 +100,10 @@ class EndpointBrowser {
                   </div>                                                                                                                                              
               </div>                                                                                                                                              
          `;
-  }
+    }
 
-  fileTree() {
-    return `
+    fileTree() {
+        return `
              <div class="endpoint-browser file-tree-view ui-widget content">
                  <table id="file_tree">
                      <colgroup>
@@ -116,15 +121,15 @@ class EndpointBrowser {
                  </table>
              </div>
          `;
-  }
+    }
 
-  /**
-   * Renders dialog content
-   * @returns {jQuery} Dialog element
-   */
-  render() {
-    this.element =
-      $(`                                                                                                                                           
+    /**
+     * Renders dialog content
+     * @returns {jQuery} Dialog element
+     */
+    render() {
+        this.element =
+            $(`                                                                                                                                           
          <div class="endpoint-browser">                                                                                                                           
              ${this.pathNavigator()}                                                                                                                        
              <div class="spacer"></div>                                                                                                                           
@@ -132,258 +137,316 @@ class EndpointBrowser {
          </div>                                                                                                                                                   
      `);
 
-    this.initUI();
-    return this.element;
-  }
+        this.initUI();
+        return this.element;
+    }
 
-  /**
-   * Initialize UI components and event handlers
-   */
-  initUI() {
-    // Initialize buttons and inputs
-    $(".btn", this.element).button();
-    util.inputTheme($("input:text", this.element));
+    /**
+     * Initialize UI components and event handlers
+     */
+    initUI() {
+        // Initialize buttons and inputs
+        $(".btn", this.element).button();
+        util.inputTheme($("input:text", this.element));
 
-    // Attach event handlers
-    $("#up", this.element).on("click", () => this.navigate(CONFIG.PATH.UP));
-    $("#path", this.element).on("input", () => {
-      clearTimeout(this.state.timer);
-      this.state.timer = setTimeout(() => {
-        this.state.path = $("#path", this.element).val();
+        // Attach event handlers
+        $("#up", this.element).on("click", () => this.navigate(CONFIG.PATH.UP));
+        $("#path", this.element).on("input", () => {
+            clearTimeout(this.state.timer);
+            this.state.timer = setTimeout(() => {
+                this.state.path = $("#path", this.element).val();
+                this.loadTree();
+            }, CONFIG.UI.DELAY);
+        });
+
+        // Initialize FancyTree with configuration
+        $("#file_tree", this.element).fancytree({
+            checkbox: false,
+            extensions: ["themeroller", "table"],
+            nodata: false,
+            themeroller: { activeClass: "my-fancytree-active", hoverClass: "" },
+            table: { nodeColumnIdx: 0 },
+            source: [{ title: "loading...", icon: false, is_dir: true }],
+            selectMode: 1,
+            // Render additional columns (size and date)
+            renderColumns: this.renderTreeColumns,
+            // Handle node selection
+            activate: (_, data) => {
+                data.node.setSelected(true);
+                $("#sel_btn").button(this.isValidSelection(data.node) ? "enable" : "disable");
+            },
+            // Handle double-click navigation
+            dblclick: (_, data) => {
+                if (data.node.data.is_dir && !this.state.loading) {
+                    this.navigate(data.node.key);
+                }
+            },
+        });
+
         this.loadTree();
-      }, CONFIG.UI.DELAY);
-    });
+    }
 
-    // Initialize FancyTree with configuration
-    $("#file_tree", this.element).fancytree({
-      checkbox: false,
-      extensions: ["themeroller", "table"],
-      nodata: false,
-      themeroller: {activeClass: "my-fancytree-active", hoverClass: ""},
-      table: {nodeColumnIdx: 0},
-      source: [{title: "loading...", icon: false, is_dir: true}],
-      selectMode: 1,
-      // Render additional columns (size and date)
-      renderColumns: this.renderTreeColumns,
-      // Handle node selection
-      activate: (_, data) => {
-        data.node.setSelected(true);
-        $("#sel_btn").button(this.isValidSelection(data.node) ? "enable" : "disable");
-      },
-      // Handle double-click navigation
-      dblclick: (_, data) => {
-        if (data.node.data.is_dir && !this.state.loading) {
-          this.navigate(data.node.key);
+    renderTreeColumns(_, data) {
+        const $cols = $(data.node.tr).find(">td");
+        if (data.node.data.is_dir) {
+            $cols.eq(0).prop("colspan", 3).nextAll().remove();
+            return;
         }
-      },
-    });
-
-    this.loadTree();
-  }
-
-  renderTreeColumns(_, data) {
-    const $cols = $(data.node.tr).find(">td");
-    if (data.node.data.is_dir) {
-      $cols.eq(0).prop("colspan", 3).nextAll().remove();
-      return;
-    }
-    $cols.eq(1).text(data.node.data.size);
-    $cols.eq(2).text(data.node.data.date);
-  }
-
-  /**
-   * @param {object} node - Tree node
-   * @returns {boolean} Whether selection is valid
-   */
-  isValidSelection(node) {
-    const isDir = node?.data?.is_dir;
-    const notUpDirInput = node?.key !== CONFIG.PATH.UP;
-
-    const dirMode = isDir && this.props.mode === TransferMode.TT_DATA_GET;
-    const fileMode = !isDir && this.props.mode === TransferMode.TT_DATA_PUT;
-
-    return (dirMode || fileMode) && notUpDirInput;
-  }
-
-  /**
-   * Navigate to new path
-   * @param {string} newPath - Target path
-   */
-  navigate(newPath) {
-    clearTimeout(this.state.timer);
-    // Ensure path ends with separator
-    const current = this.state.path.endsWith(CONFIG.PATH.SEPARATOR)
-      ? this.state.path
-      : this.state.path + CONFIG.PATH.SEPARATOR;
-
-    let updatedPath;
-    if (newPath === CONFIG.PATH.UP) {
-      // Handle "up" navigation
-      if (current.length === 1) {
-        // Already at root
-        return;
-      }
-      const idx = current.lastIndexOf(CONFIG.PATH.SEPARATOR, current.length - 2);
-      updatedPath = idx > 0 ? current.substring(0, idx + 1) : CONFIG.PATH.SEPARATOR;
-    } else {
-      // Navigate to subdirectory
-      updatedPath = current + newPath + CONFIG.PATH.SEPARATOR;
-    }
-    // Update state and UI
-    this.state.path = updatedPath;
-    $("#path", this.element).val(updatedPath);
-    this.loadTree();
-  }
-
-  /**
-   * Load tree data from API
-   */
-  async loadTree() {
-    if (this.state.loading) {
-      return;
+        $cols.eq(1).text(data.node.data.size);
+        $cols.eq(2).text(data.node.data.date);
     }
 
-    // Set loading state
-    this.state.loading = true;
-    $("#sel_btn").button("disable");
-    $("#file_tree").fancytree("disable");
+    /**
+     * @param {object} node - Tree node
+     * @returns {boolean} Whether selection is valid
+     */
+    isValidSelection(node) {
+        const isDir = node?.data?.is_dir;
+        const notUpDirInput = node?.key !== CONFIG.PATH.UP;
 
-    try {
-      const ep_status = await new Promise((resolve) => {
+        const dirMode = isDir && this.props.mode === TransferMode.TT_DATA_GET;
+        const fileMode = !isDir && this.props.mode === TransferMode.TT_DATA_PUT;
+
+        return (dirMode || fileMode) && notUpDirInput;
+    }
+
+    /**
+     * Navigate to new path
+     * @param {string} newPath - Target path
+     */
+    navigate(newPath) {
+        clearTimeout(this.state.timer);
+        // Ensure path ends with separator
+        const current = this.state.path.endsWith(CONFIG.PATH.SEPARATOR)
+            ? this.state.path
+            : this.state.path + CONFIG.PATH.SEPARATOR;
+
+        let updatedPath;
+        if (newPath === CONFIG.PATH.UP) {
+            // Handle "up" navigation
+            if (current.length === 1) {
+                // Already at root
+                return;
+            }
+            const idx = current.lastIndexOf(CONFIG.PATH.SEPARATOR, current.length - 2);
+            updatedPath = idx > 0 ? current.substring(0, idx + 1) : CONFIG.PATH.SEPARATOR;
+        } else {
+            // Navigate to subdirectory
+            updatedPath = current + newPath + CONFIG.PATH.SEPARATOR;
+        }
+        // Update state and UI
+        this.state.path = updatedPath;
+        $("#path", this.element).val(updatedPath);
+        this.loadTree();
+    }
+
+    /**
+     * Load tree data from API
+     */
+    async loadTree() {
+        if (this.state.loading) {
+            return;
+        }
+
+        // Set loading state
+        this.state.loading = true;
+        $("#sel_btn").button("disable");
+        $("#file_tree").fancytree("disable");
+
+        try {
+            const ep_status = await new Promise((resolve) => {
                 api.epView(this.props.endpoint.id, (ok, data) => resolve(data));
             });
             const is_mapped = ep_status.entity_type.includes("mapped");// Fetch directory listing
-      const data = await new Promise((resolve) => {
-        api.epDirList(this.props.endpoint.id, this.state.path, false,is_mapped,
+            const data = await new Promise((resolve) => {
+                api.epDirList(this.props.endpoint.id, this.state.path, false,is_mapped,
                     this.props.endpoint.id,
                     resolve,
-      );
+            );
             });
 
-      if (data.needs_consent || data.code) {
+            if (data.needs_consent || data.code) {
                 // TODO: needs consent flag only works first time, if base token has consent it will no longer work.
-        throw new ApiError(data);
-      }
+                throw new ApiError(data);
+            }
 
-      const source = this.getTreeSource(data);
-      $.ui.fancytree.getTree("#file_tree").reload(source);
-    } catch (error) {
-      const errorSource = await this.createErrorSource(error);
-      $.ui.fancytree.getTree("#file_tree").reload(errorSource);
-    } finally {
-      this.state.loading = false;
-      $("#file_tree").fancytree("enable");
+            const source = this.getTreeSource(data);
+            $.ui.fancytree.getTree("#file_tree").reload(source);
+        } catch (error) {
+            const errorSource = await this.createErrorSource(error);
+            $.ui.fancytree.getTree("#file_tree").reload(errorSource);
+        } finally {
+            this.state.loading = false;
+            $("#file_tree").fancytree("enable");
+        }
     }
-  }
 
-  /**
-   * Get tree source data
-   * @param {object} data - API response data
-   * @returns {Array} Tree source data
-   */
-  getTreeSource(data) {
-    return [
-      {
-        title: CONFIG.PATH.UP,
-        icon: CONFIG.UI.ICONS.FOLDER,
-        key: CONFIG.PATH.UP,
-        is_dir: true,
-      },
-      ...data.DATA.map((entry) =>
-        entry.type === "dir"
-          ? {
-            title: entry.name,
-            icon: CONFIG.UI.ICONS.FOLDER,
-            key: entry.name,
-            is_dir: true,
-          }
-          : {
-            title: entry.name,
-            icon: CONFIG.UI.ICONS.FILE,
-            key: entry.name,
-            is_dir: false,
-            size: util.sizeToString(entry.size),
-            date: new Date(entry.last_modified.replace(" ", "T")).toLocaleString(),
-          },
-      ),
-    ];
-  }
+    /**
+     * Get tree source data
+     * @param {object} data - API response data
+     * @returns {Array} Tree source data
+     */
+    getTreeSource(data) {
+        return [
+            {
+                title: CONFIG.PATH.UP,
+                icon: CONFIG.UI.ICONS.FOLDER,
+                key: CONFIG.PATH.UP,
+                is_dir: true,
+            },
+            ...data.DATA.map((entry) =>
+                entry.type === "dir"
+                    ? {
+                          title: entry.name,
+                          icon: CONFIG.UI.ICONS.FOLDER,
+                          key: entry.name,
+                          is_dir: true,
+                      }
+                    : {
+                          title: entry.name,
+                          icon: CONFIG.UI.ICONS.FILE,
+                          key: entry.name,
+                          is_dir: false,
+                          size: util.sizeToString(entry.size),
+                          date: new Date(entry.last_modified.replace(" ", "T")).toLocaleString(),
+                      },
+            ),
+        ];
+    }
 
-  /**
-   * Handle API error responses
-   * @param {object} error - API response data
-   * @returns {Promise<Array>} Error message source
-   */
-  async createErrorSource(error) {
-    let title = "";
+    /**
+     * Handle API error responses
+     * @param {object} error - API response data
+     * @returns {Promise<Array>} Error message source
+     */
+    async createErrorSource(error) {
+        let title = "";
 
-    if (error instanceof ApiError && error.code === "ConsentRequired") {
-      // Save state only when consent is required to restore it later
+        if (error instanceof ApiError && error.code === "ConsentRequired") {
+            // Save state only when consent is required to restore it later
 
-      // Generate consent URL
-      const data = await new Promise((resolve) => {
-        api.getGlobusConsentURL(
-          (_, data) => resolve(data),
-          this.props.endpoint.id,
-          error.data.required_scopes,
-        );
-      });
-      // Create a consent link with onclick handler
-      title = `<span class='ui-state-error'>Consent Required: Please provide 
+            // Generate consent URL
+            const data = await new Promise((resolve) => {
+                api.getGlobusConsentURL(
+                    (_, data) => resolve(data),
+                    this.props.endpoint.id,
+                    error.data.required_scopes,
+                );
+            });
+            // Create a consent link with onclick handler
+            title = `<span class='ui-state-error'>Consent Required: Please provide 
                 <a href="#" id="consent-link" data-url="${data.consent_url}">consent</a>.
             </span>`;
 
-      // Add the click handler after rendering
-      setTimeout(() => {
-        const consentLink = document.getElementById("consent-link");
-        if (consentLink) {
-          document.getElementById("consent-link").addEventListener("click", (e) => {
-            e.preventDefault();
+            // Add the click handler after rendering
+            setTimeout(() => {
+                const consentLink = document.getElementById("consent-link");
+                if (consentLink) {
+                    document.getElementById("consent-link").addEventListener("click", (e) => {
+                        e.preventDefault();
 
-            // Save state only when the link is clicked
-            this.#controller.saveCache();
-            this.#controller.uiManager.saveCache()
-            this.#controller.endpointManager.saveCache()
-            this.saveCache()
-            // Redirect to consent URL
-            window.location.replace(consentLink.getAttribute("data-url"));
-          });
+                        // Save state only when the link is clicked
+                        // this.#controller.saveCache();
+                        // this.#controller.uiManager.saveCache();
+                        // this.#controller.endpointManager.saveCache();
+                        // this.saveCache();
+                        // Redirect to consent URL
+                        this.openConsentIframe(consentLink.getAttribute("data-url"));
+                    });
+                }
+            }, 0);
+        } else {
+            title = `<span class='ui-state-error'>Error: ${error instanceof ApiError ? error.data.message : error.message}</span>`;
         }
-      }, 0);
-    } else {
-      title = `<span class='ui-state-error'>Error: ${error instanceof ApiError ? error.data.message : error.message}</span>`;
+
+        return [
+            {
+                title,
+                icon: false,
+                is_dir: true,
+            },
+        ];
     }
 
-    return [
-      {
-        title,
-        icon: false,
-        is_dir: true,
-      },
-    ];
-  }
+    /**
+     * Opens a modal iframe for Globus consent
+     * @param {string} consentUrl - The URL for the consent page
+     */
+    openConsentIframe(consentUrl) {
+        const iframeContainer = $(`
+        <div id="consent-iframe-container" style="width:100%; height:100%;">
+          <iframe id="consent-iframe" src="${consentUrl}" style="width:100%; height:100%; border:none;"></iframe>                      
+        </div>
+        `);
 
-  /**
-   * Handle selection confirmation
-   */
-  handleSelect() {
-    const node = $.ui.fancytree.getTree("#file_tree").activeNode;
-    if (!node || !this.props.onSelect) {
-      return;
+        // Add message listener to detect when consent is complete
+        window.addEventListener("message", this.handleConsentMessage.bind(this), false);
+
+        // Show iframe in dialog
+        iframeContainer.dialog({
+            title: "Globus Authorization",
+            modal: true,
+            width: 800,
+            height: 600,
+            resizable: true,
+            buttons: [
+                {
+                    text: "Cancel",
+                    click: function () {
+                        window.removeEventListener("message", this.handleConsentMessage.bind(this));
+                        $(this).dialog("close");
+                    }.bind(this),
+                },
+            ],
+            close: function () {
+                window.removeEventListener("message", this.handleConsentMessage.bind(this));
+                $(this).dialog("destroy").remove();
+            }.bind(this),
+        });
     }
 
-    // Construct full path for selected node
-    const path =
-      this.state.path +
-      (this.state.path.endsWith(CONFIG.PATH.SEPARATOR) ? "" : CONFIG.PATH.SEPARATOR) +
-      (node.key === CONFIG.PATH.CURRENT ? "" : node.key);
+    /**
+     * Handles messages from the consent iframe
+     * @param {MessageEvent} event - The message event
+     */
+    handleConsentMessage(event) {
+        // Verify the origin for security
+        // You should replace this with your actual Globus domain
+        if (!event.origin.match(AUTH_URL)) {
+            return;
+        }
 
-    this.props.onSelect(path);
-  }
+        // Check if consent was granted
+        if (event.data && event.data.type === "globus_auth_complete") {
+            // Close the iframe dialog
+            $("#consent-iframe-container").dialog("close");
 
-  cleanup() {
-    clearTimeout(this.state.timer);
-  }
+            // Reload the tree with the new authorization
+            this.loadTree();
+        }
+    }
+
+    /**
+     * Handle selection confirmation
+     */
+    handleSelect() {
+        const node = $.ui.fancytree.getTree("#file_tree").activeNode;
+        if (!node || !this.props.onSelect) {
+            return;
+        }
+
+        // Construct full path for selected node
+        const path =
+            this.state.path +
+            (this.state.path.endsWith(CONFIG.PATH.SEPARATOR) ? "" : CONFIG.PATH.SEPARATOR) +
+            (node.key === CONFIG.PATH.CURRENT ? "" : node.key);
+
+        this.props.onSelect(path);
+    }
+
+    cleanup() {
+        clearTimeout(this.state.timer);
+    }
 }
 
 /**
@@ -394,48 +457,42 @@ class EndpointBrowser {
  * @param {Object} controller - handler
  * @param {Function} callback - Selection callback
  */
-export function show(
-  endpoint,
-  path,
-  mode,
-  controller,
-  callback
-) {
-  const browser = new EndpointBrowser({
-    endpoint,
-    path,
-    mode,
-    controller,
-    onSelect: callback,
-  });
-  console.log("browser, path, mode, callback", endpoint, path, mode, callback);
-  browser.render().dialog({
-    title: `Browse End-Point ${endpoint.name}`,
-    modal: true,
-    width: CONFIG.UI.SIZE.WIDTH,
-    height: CONFIG.UI.SIZE.HEIGHT,
-    resizable: true,
-    buttons: [
-      {
-        text: "Cancel",
-        click: function () {
-          browser.cleanup();
-          $(this).dialog("close");
+export function show(endpoint, path, mode, controller, callback) {
+    const browser = new EndpointBrowser({
+        endpoint,
+        path,
+        mode,
+        controller,
+        onSelect: callback,
+    });
+    console.log("browser, path, mode, callback", endpoint, path, mode, callback);
+    browser.render().dialog({
+        title: `Browse End-Point ${endpoint.name}`,
+        modal: true,
+        width: CONFIG.UI.SIZE.WIDTH,
+        height: CONFIG.UI.SIZE.HEIGHT,
+        resizable: true,
+        buttons: [
+            {
+                text: "Cancel",
+                click: function () {
+                    browser.cleanup();
+                    $(this).dialog("close");
+                },
+            },
+            {
+                id: "sel_btn",
+                text: "Select",
+                click: function () {
+                    browser.handleSelect();
+                    browser.cleanup();
+                    $(this).dialog("close");
+                },
+            },
+        ],
+        close: function () {
+            browser.cleanup();
+            $(this).dialog("destroy").remove();
         },
-      },
-      {
-        id: "sel_btn",
-        text: "Select",
-        click: function () {
-          browser.handleSelect();
-          browser.cleanup();
-          $(this).dialog("close");
-        },
-      },
-    ],
-    close: function () {
-      browser.cleanup();
-      $(this).dialog("destroy").remove();
-    },
-  });
+    });
 }

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -69,21 +69,9 @@ class EndpointBrowser {
      * @returns {object | null} The cached component data
      */
     loadCache() {
-        // First try to get from Redux store
         const state = transferStore.getState();
         if (state.resumeData && state.resumeData.endpointBrowserState) {
             return state.resumeData.endpointBrowserState;
-        }
-
-        // Fallback to sessionStorage for backward compatibility
-        const cachedData = sessionStorage.getItem("endpointBrowserState");
-        if (cachedData) {
-            try {
-                return JSON.parse(cachedData);
-            } catch (error) {
-                console.error("Failed to parse cached endpoint browser state:", error);
-                return null;
-            }
         }
         return null;
     }
@@ -96,7 +84,7 @@ class EndpointBrowser {
             props: {
                 endpoint: this.props.endpoint,
                 mode: this.props.mode,
-                onSelect: String(this.props.onSelect),
+                onSelect: this.props.onSelect,
             },
             state: {
                 path: this.state.path,

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -209,6 +209,15 @@ class EndpointBrowser {
 
         return (dirMode || fileMode) && notUpDirInput;
     }
+    
+    /**
+     * Save component state to redux-persist store
+     */
+    saveToStore() {
+        if (this.#controller) {
+            this.#controller.saveState();
+        }
+    }
 
     /**
      * Navigate to new path
@@ -345,11 +354,9 @@ class EndpointBrowser {
                     document.getElementById("consent-link").addEventListener("click", (e) => {
                         e.preventDefault();
 
-                        // Save state only when the link is clicked
-                        // this.#controller.saveCache();
-                        // this.#controller.uiManager.saveCache();
-                        // this.#controller.endpointManager.saveCache();
-                        // this.saveCache();
+                        // Save state to redux-persist store before redirecting
+                        this.saveToStore();
+                        
                         // Redirect to consent URL
                         this.openConsentIframe(consentLink.getAttribute("data-url"));
                     });

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -371,15 +371,7 @@ class EndpointBrowser {
             (this.state.path.endsWith(CONFIG.PATH.SEPARATOR) ? "" : CONFIG.PATH.SEPARATOR) +
             (node.key === CONFIG.PATH.CURRENT ? "" : node.key);
 
-        if (typeof this.props.onSelect === "string") {
-            // So we can't store a function in sessionStorage, however we can store it as a string
-            // https://stackoverflow.com/questions/7650071/is-there-a-way-to-create-a-function-from-a-string-with-javascript
-            const sessionStorageCallback = Function('return' + this.props.onSelect(path));
-            sessionStorageCallback();
-        } else {
-            this.props.onSelect(path);
-        }
-
+        this.props.onSelect(path);
     }
 
     cleanup() {

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -444,7 +444,7 @@ class EndpointBrowser {
  * @param {object} endpoint - Endpoint configuration
  * @param {string} path - Initial path
  * @param {string} mode - Browser mode ('file'/'dir')
- * @param {Object} controller - handler
+ * @param {object} controller - handler
  * @param {Function} callback - Selection callback
  */
 export function show(endpoint, path, mode, controller, callback) {

--- a/web/static/components/transfer/index.js
+++ b/web/static/components/transfer/index.js
@@ -8,7 +8,7 @@ export class TransferDialog {
 
     /**
      * Show transfer dialog
-     * @param {number|null} mode - Transfer mode (GET/PUT)
+     * @param {TransferMode[keyof TransferMode]} mode - Transfer mode (GET/PUT)
      * @param {Array<object>|null} records - Data records
      * @param {Function} callback - Completion callback
      */

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -13,7 +13,7 @@ import { saveTransferState, clearTransferState } from "../../store/reducers/tran
  */
 export class TransferDialogController {
     /**
-     * @param {number|TransferMode[keyof TransferMode]} mode - Transfer mode (GET/PUT)
+     * @param {TransferMode[keyof TransferMode]} mode - Transfer mode (GET/PUT)
      * @param {Array<object>} ids - Records to transfer
      * @param {Function} callback - Completion callback
      * @param {object} services - The service objects to use for API and dialog operations

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -11,7 +11,7 @@ import * as api from "../../api.js";
  */
 export class TransferDialogController {
     /**
-     * @param {number} mode - Transfer mode (GET/PUT)
+     * @param {number|TransferMode[keyof TransferMode]} mode - Transfer mode (GET/PUT)
      * @param {Array<object>} ids - Records to transfer
      * @param {Function} callback - Completion callback
      * @param {object} services - The service objects to use for API and dialog operations
@@ -32,7 +32,7 @@ export class TransferDialogController {
         const state = {
             mode: this.model.mode,
             ids: this.ids,
-            callback: this.callback,
+            callback: String(this.callback),
         };
         sessionStorage.setItem("transferDialogState", JSON.stringify(state));
         sessionStorage.setItem("resumeFlow", true);

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -28,7 +28,7 @@ export class TransferDialogController {
         this.ids = ids;
         this.callback = callback;
         this.services = services;
-        
+
         // Generate a unique ID for this transfer session
         this.transferId = Date.now().toString();
     }
@@ -40,7 +40,7 @@ export class TransferDialogController {
     addEndpointBrowserState(endpointBrowserState) {
         this.endpointBrowserState = endpointBrowserState;
     }
-    
+
     /**
      * Saves the current transfer state to the store
      */
@@ -49,18 +49,18 @@ export class TransferDialogController {
             id: this.transferId,
             mode: this.model.mode,
             ids: this.ids,
-            callback: String(this.callback),
+            callback: this.callback,
             timestamp: Date.now(),
-            endpointBrowserState: this.endpointBrowserState
+            endpointBrowserState: this.endpointBrowserState,
         };
-        
+
         // Dispatch action to save state
         transferStore.dispatch(saveTransferState(state));
-        
+
         // Log state saving for debugging
         console.debug("Transfer state saved:", state);
     }
-    
+
     /**
      * Clears the saved transfer state
      */
@@ -76,10 +76,10 @@ export class TransferDialogController {
             this.uiManager.initializeComponents();
             this.uiManager.attachMatchesHandler();
             this.endpointManager.state.initialized = true;
-            
+
             // Save state when dialog is shown
             this.saveState();
-            
+
             this.uiManager.showDialog();
         } catch (error) {
             console.error("Failed to show transfer dialog:", error);
@@ -87,7 +87,7 @@ export class TransferDialogController {
             this.clearState();
         }
     }
-    
+
     /**
      * Closes the transfer dialog and cleans up state
      */

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -28,6 +28,16 @@ export class TransferDialogController {
         this.services = services;
     }
 
+    saveCache() {
+        const state = {
+            mode: this.model.mode,
+            ids: this.ids,
+            callback: this.callback,
+        };
+        sessionStorage.setItem("transferDialogState", JSON.stringify(state));
+        sessionStorage.setItem("resumeFlow", true);
+    }
+
     show() {
         try {
             this.uiManager.initializeComponents();

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -34,6 +34,14 @@ export class TransferDialogController {
     }
 
     /**
+     * Adds endpoint browser state to be saved with transfer state
+     * @param {Object} endpointBrowserState - The endpoint browser state to save
+     */
+    addEndpointBrowserState(endpointBrowserState) {
+        this.endpointBrowserState = endpointBrowserState;
+    }
+    
+    /**
      * Saves the current transfer state to the store
      */
     saveState() {
@@ -42,7 +50,8 @@ export class TransferDialogController {
             mode: this.model.mode,
             ids: this.ids,
             callback: String(this.callback),
-            timestamp: Date.now()
+            timestamp: Date.now(),
+            endpointBrowserState: this.endpointBrowserState
         };
         
         // Dispatch action to save state

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -35,7 +35,7 @@ export class TransferDialogController {
 
     /**
      * Adds endpoint browser state to be saved with transfer state
-     * @param {Object} endpointBrowserState - The endpoint browser state to save
+     * @param {object} endpointBrowserState - The endpoint browser state to save
      */
     addEndpointBrowserState(endpointBrowserState) {
         this.endpointBrowserState = endpointBrowserState;

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -47,6 +47,9 @@ export class TransferDialogController {
         
         // Dispatch action to save state
         transferStore.dispatch(saveTransferState(state));
+        
+        // Log state saving for debugging
+        console.debug("Transfer state saved:", state);
     }
     
     /**

--- a/web/static/components/transfer/transfer-dialog-controller.js
+++ b/web/static/components/transfer/transfer-dialog-controller.js
@@ -42,7 +42,7 @@ export class TransferDialogController {
         try {
             this.uiManager.initializeComponents();
             this.uiManager.attachMatchesHandler();
-            this.endpointManager.initialized = true;
+            this.endpointManager.state.initialized = true;
             this.uiManager.showDialog();
         } catch (error) {
             console.error("Failed to show transfer dialog:", error);

--- a/web/static/components/transfer/transfer-endpoint-manager.js
+++ b/web/static/components/transfer/transfer-endpoint-manager.js
@@ -22,7 +22,7 @@ export class TransferEndpointManager {
         this.#controller = controller;
         this.api = services.api; // Dependency injection
         this.dialogs = services.dialogs; // Dependency injection
-        const cachedComponentData = this.loadCache();
+        const cachedComponentData = sessionStorage.getItem("resumeFlow") === true && this.loadCache();
         // Search tracking mechanism to prevent race conditions:
         // Without this, out-of-order API responses could update the UI with stale data
         // Example: User types "abc" then quickly types "xyz"
@@ -44,12 +44,11 @@ export class TransferEndpointManager {
      * @returns {object | null} The cached component data
      */
     loadCache() {
-        const data = sessionStorage.getItem("transferDialogEndpointManagerState");
-        return data ? JSON.parse(data) : null;
+        return sessionStorage.getItem("transferDialogEndpointManagerState");
     }
 
     saveCache() {
-        sessionStorage.setItem("transferDialogEndpointManagerState", this.state);
+        sessionStorage.setItem("transferDialogEndpointManagerState", JSON.stringify(this.state));
     }
 
     /**

--- a/web/static/components/transfer/transfer-endpoint-manager.js
+++ b/web/static/components/transfer/transfer-endpoint-manager.js
@@ -23,7 +23,7 @@ export class TransferEndpointManager {
         this.#controller = controller;
         this.api = services.api; // Dependency injection
         this.dialogs = services.dialogs; // Dependency injection
-        
+
         // Load state from Redux store
         const state = transferStore.getState();
         // Search tracking mechanism to prevent race conditions:
@@ -41,7 +41,6 @@ export class TransferEndpointManager {
             initialized: false, // Flag to indicate that the dialog is initialized
         };
     }
-
 
     /**
      * Performs autocomplete search for endpoints
@@ -183,7 +182,7 @@ export class TransferEndpointManager {
             this.searchEndpoint(endpoint, searchToken);
         }
     }
-    
+
     /**
      * Saves the current state to the Redux store
      */

--- a/web/static/components/transfer/transfer-endpoint-manager.js
+++ b/web/static/components/transfer/transfer-endpoint-manager.js
@@ -19,24 +19,37 @@ export class TransferEndpointManager {
      * @param {Function} services.api.epAutocomplete - Endpoint autocomplete API function
      */
     constructor(controller, services) {
-        this.initialized = false;
         this.#controller = controller;
         this.api = services.api; // Dependency injection
         this.dialogs = services.dialogs; // Dependency injection
-
-        this.currentEndpoint = null;
-        this.endpointManagerList = null;
+        const cachedComponentData = this.loadCache();
         // Search tracking mechanism to prevent race conditions:
-        //  * searchTokenIterator generates unique tokens for each search request
-        //  * currentSearchToken tracks the latest valid search request
         // Without this, out-of-order API responses could update the UI with stale data
         // Example: User types "abc" then quickly types "xyz"
         //  - "abc" search starts (token: 1)
         //  - "xyz" search starts (token: 2)
         //  - "abc" results return (ignored, token mismatch)
         //  - "xyz" results return (processed, matching token)
-        this.currentSearchToken = null;
-        this.searchTokenIterator = 0;
+        this.state = cachedComponentData || {
+            currentEndpoint: null,
+            endpointManagerList: null, // List of endpoint matches
+            currentSearchToken: null, // Tracks the latest valid search request
+            searchTokenIterator: 0, // Generates unique tokens for each search request
+            initialized: false, // Flag to indicate that the dialog is initialized
+        };
+    }
+
+    /**
+     * Save component state to cache
+     * @returns {object | null} The cached component data
+     */
+    loadCache() {
+        const data = sessionStorage.getItem("transferDialogEndpointManagerState");
+        return data ? JSON.parse(data) : null;
+    }
+
+    saveCache() {
+        sessionStorage.setItem("transferDialogEndpointManagerState", this.state);
     }
 
     /**
@@ -49,12 +62,12 @@ export class TransferEndpointManager {
             // Prevent race conditions by ignoring responses from outdated searches
             // Without this check, rapid typing could cause UI flickering and incorrect results
             // as slower API responses return after newer searches
-            if (searchToken !== this.currentSearchToken) {
+            if (searchToken !== this.state.currentSearchToken) {
                 return;
             }
 
             if (ok && data.DATA && data.DATA.length) {
-                this.endpointManagerList = data.DATA;
+                this.state.endpointManagerList = data.DATA;
                 // Process endpoints and update UI
                 data.DATA.forEach((ep) => {
                     ep.name = ep.canonical_name || ep.id;
@@ -62,7 +75,7 @@ export class TransferEndpointManager {
                 this.updateMatchesList(data.DATA);
             } else {
                 console.warn("No matches found");
-                this.endpointManagerList = null;
+                this.state.endpointManagerList = null;
                 this.updateMatchesList([]);
                 if (data.code) {
                     console.error("Autocomplete error:", data);
@@ -83,7 +96,7 @@ export class TransferEndpointManager {
 
         try {
             return this.api.epView(endpoint, (ok, data) => {
-                if (searchToken !== this.currentSearchToken) {
+                if (searchToken !== this.state.currentSearchToken) {
                     console.warn("Ignoring stale epView response");
                     return;
                 }
@@ -132,7 +145,7 @@ export class TransferEndpointManager {
      * @param {string} searchToken - Token to track current search request
      */
     handlePathInput(searchToken) {
-        if (!this.initialized) {
+        if (!this.state.initialized) {
             console.warn("Dialog not yet initialized - delaying path input handling");
             setTimeout(() => this.handlePathInput(searchToken), 100);
             return;
@@ -140,7 +153,7 @@ export class TransferEndpointManager {
 
         // Validate that we're processing the most recent search request
         // This prevents wasted API calls and UI updates for abandoned searches
-        if (searchToken !== this.currentSearchToken) {
+        if (searchToken !== this.state.currentSearchToken) {
             console.info("Token mismatch - ignoring stale request");
             return;
         }
@@ -151,8 +164,8 @@ export class TransferEndpointManager {
 
         // No input or set input to empty, reset state
         if (!path || !path.length) {
-            this.endpointManagerList = null;
-            this.currentEndpoint = null;
+            this.state.endpointManagerList = null;
+            this.state.currentEndpoint = null;
             this.updateMatchesList([]);
             this.#controller.uiManager.enableStartButton(false);
             this.#controller.uiManager.enableBrowseButton(false);
@@ -164,11 +177,14 @@ export class TransferEndpointManager {
             "Extracted endpoint:",
             endpoint,
             "Current endpoint:",
-            this.currentEndpoint?.name,
+            this.state.currentEndpoint?.name,
         );
 
         // Edge case: input is just a /. Ideally we have some middleware validation to avoid this
-        if (endpoint && (!this.currentEndpoint || endpoint !== this.currentEndpoint.name)) {
+        if (
+            endpoint &&
+            (!this.state.currentEndpoint || endpoint !== this.state.currentEndpoint.name)
+        ) {
             console.info("Endpoint changed or not set - searching for new endpoint");
             this.searchEndpoint(endpoint, searchToken);
         }

--- a/web/static/components/transfer/transfer-ui-manager.js
+++ b/web/static/components/transfer/transfer-ui-manager.js
@@ -3,7 +3,7 @@ import { TransferMode } from "../../models/transfer-model.js";
 import { show } from "../endpoint-browse/index.js";
 import { inputDisable, inputEnable, inputTheme, setStatusText } from "../../util.js";
 import { createMatchesHtml, formatRecordTitle, getDialogTemplate } from "./transfer-templates.js";
-import { transferStore } from "../../store/store.js"; // Import the Redux store
+import { transferStore, updateUIState } from "../../store/store.js";
 
 /**
  * @class TransferUIManager
@@ -36,24 +36,22 @@ export class TransferUIManager {
             frame: null,
             encryptRadios: null,
         };
-        
+
         // Save initial UI state to Redux
         this.saveUIState();
     }
-    
+
     /**
      * Saves the current UI state to Redux store
      */
     saveUIState() {
-        const { updateUIState } = require("../../store/store.js");
-        
         // Only save serializable parts of the state
         const stateToSave = {
             ...this.state,
             recordTree: null, // Don't try to serialize the tree object
             frame: null, // Don't try to serialize DOM elements
         };
-        
+
         updateUIState(stateToSave);
     }
 
@@ -81,7 +79,7 @@ export class TransferUIManager {
         this.initializeEndpointInput();
         this.initializeTransferOptions();
         this.initializeBrowseButton();
-        
+
         // Save UI state after initialization
         this.saveUIState();
     }
@@ -203,15 +201,16 @@ export class TransferUIManager {
         const browsePath = this.getBrowsePath(pathInput.val());
 
         show(
-          this.#controller.endpointManager.state.currentEndpoint,
-          browsePath,
-          this.#controller.model.mode,
-          this.#controller,
-          (selectedPath) => {
-            const fullPath = this.#controller.endpointManager.state.currentEndpoint.name + selectedPath;
-            pathInput.val(fullPath);
-            this.enableStartButton(true);
-          }
+            this.#controller.endpointManager.state.currentEndpoint,
+            browsePath,
+            this.#controller.model.mode,
+            this.#controller,
+            (selectedPath) => {
+                const fullPath =
+                    this.#controller.endpointManager.state.currentEndpoint.name + selectedPath;
+                pathInput.val(fullPath);
+                this.enableStartButton(true);
+            },
         );
     }
 
@@ -338,12 +337,6 @@ export class TransferUIManager {
         matches.prop("disabled", false);
         this.enableBrowseButton(true);
         this.updateEndpointOptions(endpoint);
-        
-        // Update endpoint state in Redux store
-        const { updateEndpointState } = require("../../store/store.js");
-        updateEndpointState(this.#controller.endpointManager.state);
-        
-        // Save UI state after endpoint selection
         this.saveUIState();
     }
 

--- a/web/static/components/transfer/transfer-ui-manager.js
+++ b/web/static/components/transfer/transfer-ui-manager.js
@@ -31,11 +31,30 @@ export class TransferUIManager {
         // Load state from Redux store
         const state = transferStore.getState();
         this.inputTimer = null;
-        this.state = state.transferUIState || {
+        this.state = state.uiState || {
             recordTree: null,
             frame: null,
             encryptRadios: null,
         };
+        
+        // Save initial UI state to Redux
+        this.saveUIState();
+    }
+    
+    /**
+     * Saves the current UI state to Redux store
+     */
+    saveUIState() {
+        const { updateUIState } = require("../../store/store.js");
+        
+        // Only save serializable parts of the state
+        const stateToSave = {
+            ...this.state,
+            recordTree: null, // Don't try to serialize the tree object
+            frame: null, // Don't try to serialize DOM elements
+        };
+        
+        updateUIState(stateToSave);
     }
 
     /**
@@ -62,6 +81,9 @@ export class TransferUIManager {
         this.initializeEndpointInput();
         this.initializeTransferOptions();
         this.initializeBrowseButton();
+        
+        // Save UI state after initialization
+        this.saveUIState();
     }
 
     initializeButtons() {
@@ -316,6 +338,13 @@ export class TransferUIManager {
         matches.prop("disabled", false);
         this.enableBrowseButton(true);
         this.updateEndpointOptions(endpoint);
+        
+        // Update endpoint state in Redux store
+        const { updateEndpointState } = require("../../store/store.js");
+        updateEndpointState(this.#controller.endpointManager.state);
+        
+        // Save UI state after endpoint selection
+        this.saveUIState();
     }
 
     updateEndpointOptions(endpoint) {

--- a/web/static/components/transfer/transfer-ui-manager.js
+++ b/web/static/components/transfer/transfer-ui-manager.js
@@ -192,13 +192,11 @@ export class TransferUIManager {
 
     showBrowseDialog(pathInput) {
         const browsePath = this.getBrowsePath(pathInput.val());
-        const mode = this.#controller.model.mode === TransferMode.TT_DATA_GET ? "dir" : "file";
-        // On dialog view, cache necessary data for view reconstruction
 
         show(
           this.#controller.endpointManager.state.currentEndpoint,
           browsePath,
-          mode,
+          this.#controller.model.mode,
           this.#controller,
           (selectedPath) => {
             const fullPath = this.#controller.endpointManager.state.currentEndpoint.name + selectedPath;

--- a/web/static/dlg_data_new_edit.js
+++ b/web/static/dlg_data_new_edit.js
@@ -5,6 +5,7 @@ import * as settings from "./settings.js";
 import * as dialogs from "./dialogs.js";
 import { transferDialog } from "./components/transfer/index.js";
 import * as dlgSchList from "./dlg_schema_list.js";
+import {TransferMode} from "./models/transfer-model.js";
 
 export var DLG_DATA_MODE_NEW = 0;
 export var DLG_DATA_MODE_EDIT = 1;
@@ -100,7 +101,7 @@ export function show(a_mode, a_data, a_parent, a_upd_perms, a_cb) {
         extern = $("#external", frame);
 
     $("#pick_source", frame).on("click", function () {
-        transferDialog.show(null, null, function (a_path, a_encrypt_mode) {
+        transferDialog.show(TransferMode.TT_DATA_PUT, null, function (a_path, a_encrypt_mode) {
             $("#source_file", frame).val(a_path);
             encrypt_mode = a_encrypt_mode;
             if (ext_auto.prop("checked")) updateAutoExt();

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -5,7 +5,8 @@ import * as settings from "/settings.js";
 import * as dialogs from "/dialogs.js";
 import { TransferDialogController } from "./components/transfer/transfer-dialog-controller.js";
 import { TransferMode } from "./models/transfer-model.js";
-import { transferStore, loadTransferState, clearTransferState } from "./store/store.js";
+import { transferStore, persistor, loadTransferState, clearTransferState } from "./store/store.js";
+import { PersistGate } from "redux-persist/integration/react";
 
 $(".btn-help").on("click", function () {
     window.open("https://ornl.github.io/DataFed/", "datafed-docs");
@@ -74,30 +75,39 @@ $(document).ready(function () {
 });
 
 /**
- * Resumes the transfer flow using the Redux store
+ * Resumes the transfer flow using the Redux store with redux-persist
  * Retrieves the saved state and initializes the TransferDialogController
  * with the saved state values.
  */
 const resumeTransferFlow = () => {
-    const savedState = loadTransferState();
-    
-    if (savedState) {
-        console.info("Resuming transfer flow with saved state:", savedState);
-        
-        try {
-            // Convert the callback string back to a function
-            const sessionStorageCallback = new Function('return ' + savedState.callback)();
+    // Wait for rehydration to complete before accessing the state
+    const unsubscribe = persistor.subscribe(() => {
+        const { bootstrapped } = persistor.getState();
+        if (bootstrapped) {
+            unsubscribe();
             
-            const transferDialogController = new TransferDialogController(
-                TransferMode[savedState.mode] || savedState.mode,
-                savedState.ids || [],
-                sessionStorageCallback
-            );
+            const savedState = loadTransferState();
+            
+            if (savedState) {
+                console.info("Resuming transfer flow with persisted state:", savedState);
+                
+                try {
+                    // Convert the callback string back to a function
+                    const sessionStorageCallback = new Function('return ' + savedState.callback)();
+                    
+                    const transferDialogController = new TransferDialogController(
+                        TransferMode[savedState.mode] || savedState.mode,
+                        savedState.ids || [],
+                        sessionStorageCallback,
+                        { dialogs, api }
+                    );
 
-            transferDialogController.show();
-        } catch (error) {
-            console.error("Failed to resume transfer flow:", error);
-            clearTransferState();
+                    transferDialogController.show();
+                } catch (error) {
+                    console.error("Failed to resume transfer flow:", error);
+                    clearTransferState();
+                }
+            }
         }
-    }
+    });
 };

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -76,8 +76,7 @@ $(document).ready(function () {
  * with the saved state values. Removes the 'resumeFlow' flag from sessionStorage after resuming.
  */
 const resumeTransferFlow = () => {
-    const resumeFlow = sessionStorage.getItem("resumeFlow");
-    if (resumeFlow === "true") {
+    if (sessionStorage.getItem("resumeFlow") === true) {
         const savedState = sessionStorage.getItem("transferDialogState");
         if (savedState) {
             const state = JSON.parse(savedState);

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -86,6 +86,8 @@ const resumeTransferFlow = () => {
         if (bootstrapped) {
             unsubscribe();
             
+            // Check if resumeFlow flag is set in sessionStorage
+            const shouldResumeFlow = sessionStorage.getItem('resumeFlow') === 'true';
             const savedState = loadTransferState();
             
             if (savedState) {
@@ -103,10 +105,20 @@ const resumeTransferFlow = () => {
                     );
 
                     transferDialogController.show();
+                    
+                    // Clear the resumeFlow flag after successful restoration
+                    if (shouldResumeFlow) {
+                        sessionStorage.removeItem('resumeFlow');
+                    }
                 } catch (error) {
                     console.error("Failed to resume transfer flow:", error);
                     clearTransferState();
+                    sessionStorage.removeItem('resumeFlow');
                 }
+            } else if (shouldResumeFlow) {
+                // If we have the flag but no state, clear the flag
+                console.warn("Resume flow flag was set but no state was found");
+                sessionStorage.removeItem('resumeFlow');
             }
         }
     });

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -3,6 +3,7 @@ import * as util from "/util.js";
 import * as api from "/api.js";
 import * as settings from "/settings.js";
 import * as dialogs from "/dialogs.js";
+import { TransferDialogController } from "./components/transfer/transfer-dialog-controller.js";
 
 $(".btn-help").on("click", function () {
     window.open("https://ornl.github.io/DataFed/", "datafed-docs");
@@ -42,6 +43,7 @@ $(document).ready(function () {
     }
 
     resizeUI();
+    resumeTransferFlow();
 
     api.userView(tmpl_data.user_uid, true, function (ok, user) {
         if (ok && user) {
@@ -67,3 +69,28 @@ $(document).ready(function () {
         }
     });
 });
+
+/**
+ * Resumes the transfer flow if the 'resumeFlow' flag is set in sessionStorage.
+ * Retrieves the saved state from sessionStorage and initializes the TransferDialogController
+ * with the saved state values. Removes the 'resumeFlow' flag from sessionStorage after resuming.
+ */
+const resumeTransferFlow = () => {
+    const resumeFlow = sessionStorage.getItem("resumeFlow");
+    if (resumeFlow === "true") {
+        const savedState = sessionStorage.getItem("transferDialogState");
+        if (savedState) {
+            const state = JSON.parse(savedState);
+
+            const transferDialogController = new TransferDialogController(
+                state.mode,
+                state.ids,
+                state.callback,
+            );
+
+            transferDialogController.show();
+        }
+
+        sessionStorage.removeItem("resumeFlow");
+    }
+};

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -80,11 +80,14 @@ const resumeTransferFlow = () => {
         const savedState = sessionStorage.getItem("transferDialogState");
         if (savedState) {
             const state = JSON.parse(savedState);
+            // So we can't store a function in sessionStorage, however we can store it as a string
+            // https://stackoverflow.com/questions/7650071/is-there-a-way-to-create-a-function-from-a-string-with-javascript
+            const sessionStorageCallback = Function('return' + state.callback);
 
             const transferDialogController = new TransferDialogController(
                 state.mode,
                 state.ids,
-                state.callback,
+                sessionStorageCallback(),
             );
 
             transferDialogController.show();

--- a/web/static/main.js
+++ b/web/static/main.js
@@ -4,6 +4,7 @@ import * as api from "/api.js";
 import * as settings from "/settings.js";
 import * as dialogs from "/dialogs.js";
 import { TransferDialogController } from "./components/transfer/transfer-dialog-controller.js";
+import {TransferMode} from "./models/transfer-model.js";
 
 $(".btn-help").on("click", function () {
     window.open("https://ornl.github.io/DataFed/", "datafed-docs");
@@ -42,8 +43,9 @@ $(document).ready(function () {
         $("#devmode").show();
     }
 
-    resizeUI();
     resumeTransferFlow();
+    resizeUI();
+
 
     api.userView(tmpl_data.user_uid, true, function (ok, user) {
         if (ok && user) {
@@ -76,18 +78,20 @@ $(document).ready(function () {
  * with the saved state values. Removes the 'resumeFlow' flag from sessionStorage after resuming.
  */
 const resumeTransferFlow = () => {
-    if (sessionStorage.getItem("resumeFlow") === true) {
+    if (sessionStorage.getItem("resumeFlow") === "true") {
         const savedState = sessionStorage.getItem("transferDialogState");
         if (savedState) {
             const state = JSON.parse(savedState);
+            console.log("transferDialogState", state)
             // So we can't store a function in sessionStorage, however we can store it as a string
             // https://stackoverflow.com/questions/7650071/is-there-a-way-to-create-a-function-from-a-string-with-javascript
-            const sessionStorageCallback = Function('return' + state.callback);
+            const sessionStorageCallback = new Function('return' + state.callback)();
+            console.log("check it out,", sessionStorageCallback);
 
             const transferDialogController = new TransferDialogController(
-                state.mode,
+                TransferMode[state.mode],
                 state.ids,
-                sessionStorageCallback(),
+                sessionStorageCallback,
             );
 
             transferDialogController.show();

--- a/web/static/package.json
+++ b/web/static/package.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "redux": "^4.2.1",
+    "redux-persist": "^6.0.0"
+  }
+}

--- a/web/static/store/index.js
+++ b/web/static/store/index.js
@@ -6,8 +6,8 @@
 /**
  * Creates a Redux-like store
  * @param {Function} reducer - The reducer function
- * @param {Object} initialState - The initial state
- * @returns {Object} Store object with getState, dispatch, and subscribe methods
+ * @param {object} initialState - The initial state
+ * @returns {object} Store object with getState, dispatch, and subscribe methods
  */
 export const createStore = (reducer, initialState) => {
     let state = initialState;
@@ -15,7 +15,7 @@ export const createStore = (reducer, initialState) => {
 
     /**
      * Gets the current state
-     * @returns {Object} The current state
+     * @returns {object} The current state
      */
     function getState() {
         return state;
@@ -23,8 +23,8 @@ export const createStore = (reducer, initialState) => {
 
     /**
      * Dispatches an action to update state
-     * @param {Object} action - The action object with type and payload
-     * @returns {Object} The action object
+     * @param {object} action - The action object with type and payload
+     * @returns {object} The action object
      */
     function dispatch(action) {
         state = reducer(state, action);

--- a/web/static/store/index.js
+++ b/web/static/store/index.js
@@ -9,7 +9,7 @@
  * @param {Object} initialState - The initial state
  * @returns {Object} Store object with getState, dispatch, and subscribe methods
  */
-export function createStore(reducer, initialState) {
+export const createStore = (reducer, initialState) => {
     let state = initialState;
     let listeners = [];
 
@@ -28,7 +28,7 @@ export function createStore(reducer, initialState) {
      */
     function dispatch(action) {
         state = reducer(state, action);
-        listeners.forEach(listener => listener());
+        listeners.forEach((listener) => listener());
         return action;
     }
 
@@ -40,16 +40,16 @@ export function createStore(reducer, initialState) {
     function subscribe(listener) {
         listeners.push(listener);
         return function unsubscribe() {
-            listeners = listeners.filter(l => l !== listener);
+            listeners = listeners.filter((l) => l !== listener);
         };
     }
 
     // Initialize the state
-    dispatch({ type: '@@INIT' });
+    dispatch({ type: "@@INIT" });
 
     return {
         getState,
         dispatch,
-        subscribe
+        subscribe,
     };
-}
+};

--- a/web/static/store/index.js
+++ b/web/static/store/index.js
@@ -1,0 +1,55 @@
+/**
+ * @module Store
+ * @description A simple Redux-like state management implementation
+ */
+
+/**
+ * Creates a Redux-like store
+ * @param {Function} reducer - The reducer function
+ * @param {Object} initialState - The initial state
+ * @returns {Object} Store object with getState, dispatch, and subscribe methods
+ */
+export function createStore(reducer, initialState) {
+    let state = initialState;
+    let listeners = [];
+
+    /**
+     * Gets the current state
+     * @returns {Object} The current state
+     */
+    function getState() {
+        return state;
+    }
+
+    /**
+     * Dispatches an action to update state
+     * @param {Object} action - The action object with type and payload
+     * @returns {Object} The action object
+     */
+    function dispatch(action) {
+        state = reducer(state, action);
+        listeners.forEach(listener => listener());
+        return action;
+    }
+
+    /**
+     * Subscribes to state changes
+     * @param {Function} listener - The listener function
+     * @returns {Function} Unsubscribe function
+     */
+    function subscribe(listener) {
+        listeners.push(listener);
+        return function unsubscribe() {
+            listeners = listeners.filter(l => l !== listener);
+        };
+    }
+
+    // Initialize the state
+    dispatch({ type: '@@INIT' });
+
+    return {
+        getState,
+        dispatch,
+        subscribe
+    };
+}

--- a/web/static/store/reducers/transfer-reducer.js
+++ b/web/static/store/reducers/transfer-reducer.js
@@ -1,0 +1,116 @@
+import { TransferMode } from "../../models/transfer-model.js";
+
+/**
+ * @module TransferReducer
+ * @description Reducer for transfer-related state
+ */
+
+/**
+ * Initial state for transfer reducer
+ */
+export const initialState = {
+    transfers: [],
+    currentTransfer: null,
+    resumeData: null
+};
+
+/**
+ * Action types for transfer reducer
+ */
+export const ActionTypes = {
+    SAVE_TRANSFER_STATE: 'SAVE_TRANSFER_STATE',
+    CLEAR_TRANSFER_STATE: 'CLEAR_TRANSFER_STATE',
+    ADD_TRANSFER: 'ADD_TRANSFER',
+    UPDATE_TRANSFER: 'UPDATE_TRANSFER'
+};
+
+/**
+ * Reducer function for transfer state
+ * @param {Object} state - Current state
+ * @param {Object} action - Action object with type and payload
+ * @returns {Object} New state
+ */
+export function transferReducer(state = initialState, action) {
+    switch (action.type) {
+        case ActionTypes.SAVE_TRANSFER_STATE:
+            return { 
+                ...state, 
+                resumeData: action.payload 
+            };
+            
+        case ActionTypes.CLEAR_TRANSFER_STATE:
+            return { 
+                ...state, 
+                resumeData: null 
+            };
+            
+        case ActionTypes.ADD_TRANSFER:
+            return { 
+                ...state, 
+                transfers: [...state.transfers, action.payload],
+                currentTransfer: action.payload
+            };
+            
+        case ActionTypes.UPDATE_TRANSFER:
+            return {
+                ...state,
+                transfers: state.transfers.map(transfer => 
+                    transfer.id === action.payload.id 
+                        ? { ...transfer, ...action.payload } 
+                        : transfer
+                ),
+                currentTransfer: state.currentTransfer?.id === action.payload.id 
+                    ? { ...state.currentTransfer, ...action.payload } 
+                    : state.currentTransfer
+            };
+            
+        default:
+            return state;
+    }
+}
+
+/**
+ * Action creator for saving transfer state
+ * @param {Object} transferData - Transfer data to save
+ * @returns {Object} Action object
+ */
+export function saveTransferState(transferData) {
+    return {
+        type: ActionTypes.SAVE_TRANSFER_STATE,
+        payload: transferData
+    };
+}
+
+/**
+ * Action creator for clearing transfer state
+ * @returns {Object} Action object
+ */
+export function clearTransferState() {
+    return {
+        type: ActionTypes.CLEAR_TRANSFER_STATE
+    };
+}
+
+/**
+ * Action creator for adding a transfer
+ * @param {Object} transfer - Transfer object to add
+ * @returns {Object} Action object
+ */
+export function addTransfer(transfer) {
+    return {
+        type: ActionTypes.ADD_TRANSFER,
+        payload: transfer
+    };
+}
+
+/**
+ * Action creator for updating a transfer
+ * @param {Object} transfer - Transfer object with updates
+ * @returns {Object} Action object
+ */
+export function updateTransfer(transfer) {
+    return {
+        type: ActionTypes.UPDATE_TRANSFER,
+        payload: transfer
+    };
+}

--- a/web/static/store/reducers/transfer-reducer.js
+++ b/web/static/store/reducers/transfer-reducer.js
@@ -11,7 +11,9 @@ import { TransferMode } from "../../models/transfer-model.js";
 export const initialState = {
     transfers: [],
     currentTransfer: null,
-    resumeData: null
+    resumeData: null,
+    uiState: null,
+    endpointState: null
 };
 
 /**
@@ -22,7 +24,9 @@ export const ActionTypes = {
     CLEAR_TRANSFER_STATE: 'CLEAR_TRANSFER_STATE',
     ADD_TRANSFER: 'ADD_TRANSFER',
     UPDATE_TRANSFER: 'UPDATE_TRANSFER',
-    SAVE_ENDPOINT_BROWSER_STATE: 'SAVE_ENDPOINT_BROWSER_STATE'
+    SAVE_ENDPOINT_BROWSER_STATE: 'SAVE_ENDPOINT_BROWSER_STATE',
+    UPDATE_UI_STATE: 'UPDATE_UI_STATE',
+    UPDATE_ENDPOINT_STATE: 'UPDATE_ENDPOINT_STATE'
 };
 
 /**
@@ -42,7 +46,9 @@ export function transferReducer(state = initialState, action) {
         case ActionTypes.CLEAR_TRANSFER_STATE:
             return { 
                 ...state, 
-                resumeData: null 
+                resumeData: null,
+                uiState: null,
+                endpointState: null
             };
             
         case ActionTypes.ADD_TRANSFER:
@@ -75,6 +81,18 @@ export function transferReducer(state = initialState, action) {
                     timestamp: Date.now(),
                     endpointBrowserState: action.payload
                 }
+            };
+            
+        case ActionTypes.UPDATE_UI_STATE:
+            return {
+                ...state,
+                uiState: action.payload
+            };
+            
+        case ActionTypes.UPDATE_ENDPOINT_STATE:
+            return {
+                ...state,
+                endpointState: action.payload
             };
             
         default:
@@ -136,6 +154,30 @@ export function updateTransfer(transfer) {
 export function saveEndpointBrowserState(state) {
     return {
         type: ActionTypes.SAVE_ENDPOINT_BROWSER_STATE,
+        payload: state
+    };
+}
+
+/**
+ * Action creator for updating UI state
+ * @param {Object} state - UI state to save
+ * @returns {Object} Action object
+ */
+export function updateUIState(state) {
+    return {
+        type: ActionTypes.UPDATE_UI_STATE,
+        payload: state
+    };
+}
+
+/**
+ * Action creator for updating endpoint state
+ * @param {Object} state - Endpoint state to save
+ * @returns {Object} Action object
+ */
+export function updateEndpointState(state) {
+    return {
+        type: ActionTypes.UPDATE_ENDPOINT_STATE,
         payload: state
     };
 }

--- a/web/static/store/reducers/transfer-reducer.js
+++ b/web/static/store/reducers/transfer-reducer.js
@@ -31,9 +31,9 @@ export const ActionTypes = {
 
 /**
  * Reducer function for transfer state
- * @param {Object} state - Current state
- * @param {Object} action - Action object with type and payload
- * @returns {Object} New state
+ * @param {object} state - Current state
+ * @param {object} action - Action object with type and payload
+ * @returns {object} New state
  */
 export function transferReducer(state = initialState, action) {
     switch (action.type) {
@@ -102,8 +102,8 @@ export function transferReducer(state = initialState, action) {
 
 /**
  * Action creator for saving transfer state
- * @param {Object} transferData - Transfer data to save
- * @returns {Object} Action object
+ * @param {object} transferData - Transfer data to save
+ * @returns {object} Action object
  */
 export function saveTransferState(transferData) {
     return {
@@ -114,7 +114,7 @@ export function saveTransferState(transferData) {
 
 /**
  * Action creator for clearing transfer state
- * @returns {Object} Action object
+ * @returns {object} Action object
  */
 export function clearTransferState() {
     return {
@@ -124,8 +124,8 @@ export function clearTransferState() {
 
 /**
  * Action creator for adding a transfer
- * @param {Object} transfer - Transfer object to add
- * @returns {Object} Action object
+ * @param {object} transfer - Transfer object to add
+ * @returns {object} Action object
  */
 export function addTransfer(transfer) {
     return {
@@ -136,8 +136,8 @@ export function addTransfer(transfer) {
 
 /**
  * Action creator for updating a transfer
- * @param {Object} transfer - Transfer object with updates
- * @returns {Object} Action object
+ * @param {object} transfer - Transfer object with updates
+ * @returns {object} Action object
  */
 export function updateTransfer(transfer) {
     return {
@@ -148,8 +148,8 @@ export function updateTransfer(transfer) {
 
 /**
  * Action creator for saving endpoint browser state
- * @param {Object} state - The endpoint browser state to save
- * @returns {Object} Action object
+ * @param {object} state - The endpoint browser state to save
+ * @returns {object} Action object
  */
 export function saveEndpointBrowserState(state) {
     return {
@@ -160,8 +160,8 @@ export function saveEndpointBrowserState(state) {
 
 /**
  * Action creator for updating UI state
- * @param {Object} state - UI state to save
- * @returns {Object} Action object
+ * @param {object} state - UI state to save
+ * @returns {object} Action object
  */
 export function updateUIState(state) {
     return {
@@ -172,8 +172,8 @@ export function updateUIState(state) {
 
 /**
  * Action creator for updating endpoint state
- * @param {Object} state - Endpoint state to save
- * @returns {Object} Action object
+ * @param {object} state - Endpoint state to save
+ * @returns {object} Action object
  */
 export function updateEndpointState(state) {
     return {

--- a/web/static/store/reducers/transfer-reducer.js
+++ b/web/static/store/reducers/transfer-reducer.js
@@ -21,7 +21,8 @@ export const ActionTypes = {
     SAVE_TRANSFER_STATE: 'SAVE_TRANSFER_STATE',
     CLEAR_TRANSFER_STATE: 'CLEAR_TRANSFER_STATE',
     ADD_TRANSFER: 'ADD_TRANSFER',
-    UPDATE_TRANSFER: 'UPDATE_TRANSFER'
+    UPDATE_TRANSFER: 'UPDATE_TRANSFER',
+    SAVE_ENDPOINT_BROWSER_STATE: 'SAVE_ENDPOINT_BROWSER_STATE'
 };
 
 /**
@@ -62,6 +63,18 @@ export function transferReducer(state = initialState, action) {
                 currentTransfer: state.currentTransfer?.id === action.payload.id 
                     ? { ...state.currentTransfer, ...action.payload } 
                     : state.currentTransfer
+            };
+            
+        case ActionTypes.SAVE_ENDPOINT_BROWSER_STATE:
+            return {
+                ...state,
+                resumeData: state.resumeData ? {
+                    ...state.resumeData,
+                    endpointBrowserState: action.payload
+                } : {
+                    timestamp: Date.now(),
+                    endpointBrowserState: action.payload
+                }
             };
             
         default:
@@ -112,5 +125,17 @@ export function updateTransfer(transfer) {
     return {
         type: ActionTypes.UPDATE_TRANSFER,
         payload: transfer
+    };
+}
+
+/**
+ * Action creator for saving endpoint browser state
+ * @param {Object} state - The endpoint browser state to save
+ * @returns {Object} Action object
+ */
+export function saveEndpointBrowserState(state) {
+    return {
+        type: ActionTypes.SAVE_ENDPOINT_BROWSER_STATE,
+        payload: state
     };
 }

--- a/web/static/store/reducers/transfer-reducer.js
+++ b/web/static/store/reducers/transfer-reducer.js
@@ -13,20 +13,20 @@ export const initialState = {
     currentTransfer: null,
     resumeData: null,
     uiState: null,
-    endpointState: null
+    endpointState: null,
 };
 
 /**
  * Action types for transfer reducer
  */
 export const ActionTypes = {
-    SAVE_TRANSFER_STATE: 'SAVE_TRANSFER_STATE',
-    CLEAR_TRANSFER_STATE: 'CLEAR_TRANSFER_STATE',
-    ADD_TRANSFER: 'ADD_TRANSFER',
-    UPDATE_TRANSFER: 'UPDATE_TRANSFER',
-    SAVE_ENDPOINT_BROWSER_STATE: 'SAVE_ENDPOINT_BROWSER_STATE',
-    UPDATE_UI_STATE: 'UPDATE_UI_STATE',
-    UPDATE_ENDPOINT_STATE: 'UPDATE_ENDPOINT_STATE'
+    SAVE_TRANSFER_STATE: "SAVE_TRANSFER_STATE",
+    CLEAR_TRANSFER_STATE: "CLEAR_TRANSFER_STATE",
+    ADD_TRANSFER: "ADD_TRANSFER",
+    UPDATE_TRANSFER: "UPDATE_TRANSFER",
+    SAVE_ENDPOINT_BROWSER_STATE: "SAVE_ENDPOINT_BROWSER_STATE",
+    UPDATE_UI_STATE: "UPDATE_UI_STATE",
+    UPDATE_ENDPOINT_STATE: "UPDATE_ENDPOINT_STATE",
 };
 
 /**
@@ -38,63 +38,66 @@ export const ActionTypes = {
 export function transferReducer(state = initialState, action) {
     switch (action.type) {
         case ActionTypes.SAVE_TRANSFER_STATE:
-            return { 
-                ...state, 
-                resumeData: action.payload 
+            return {
+                ...state,
+                resumeData: action.payload,
             };
-            
+
         case ActionTypes.CLEAR_TRANSFER_STATE:
-            return { 
-                ...state, 
+            return {
+                ...state,
                 resumeData: null,
                 uiState: null,
-                endpointState: null
+                endpointState: null,
             };
-            
+
         case ActionTypes.ADD_TRANSFER:
-            return { 
-                ...state, 
+            return {
+                ...state,
                 transfers: [...state.transfers, action.payload],
-                currentTransfer: action.payload
+                currentTransfer: action.payload,
             };
-            
+
         case ActionTypes.UPDATE_TRANSFER:
             return {
                 ...state,
-                transfers: state.transfers.map(transfer => 
-                    transfer.id === action.payload.id 
-                        ? { ...transfer, ...action.payload } 
-                        : transfer
+                transfers: state.transfers.map((transfer) =>
+                    transfer.id === action.payload.id
+                        ? { ...transfer, ...action.payload }
+                        : transfer,
                 ),
-                currentTransfer: state.currentTransfer?.id === action.payload.id 
-                    ? { ...state.currentTransfer, ...action.payload } 
-                    : state.currentTransfer
+                currentTransfer:
+                    state.currentTransfer?.id === action.payload.id
+                        ? { ...state.currentTransfer, ...action.payload }
+                        : state.currentTransfer,
             };
-            
+
         case ActionTypes.SAVE_ENDPOINT_BROWSER_STATE:
             return {
                 ...state,
-                resumeData: state.resumeData ? {
-                    ...state.resumeData,
-                    endpointBrowserState: action.payload
-                } : {
-                    timestamp: Date.now(),
-                    endpointBrowserState: action.payload
-                }
+                resumeData: state.resumeData
+                    ? {
+                          ...state.resumeData,
+                          endpointBrowserState: action.payload,
+                      }
+                    : {
+                          timestamp: Date.now(),
+                          endpointBrowserState: action.payload,
+                      },
             };
-            
+
         case ActionTypes.UPDATE_UI_STATE:
             return {
                 ...state,
-                uiState: action.payload
+                uiState: action.payload,
             };
-            
+
         case ActionTypes.UPDATE_ENDPOINT_STATE:
             return {
                 ...state,
-                endpointState: action.payload
+                endpointState: action.payload,
             };
-            
+
         default:
             return state;
     }
@@ -108,7 +111,7 @@ export function transferReducer(state = initialState, action) {
 export function saveTransferState(transferData) {
     return {
         type: ActionTypes.SAVE_TRANSFER_STATE,
-        payload: transferData
+        payload: transferData,
     };
 }
 
@@ -118,7 +121,7 @@ export function saveTransferState(transferData) {
  */
 export function clearTransferState() {
     return {
-        type: ActionTypes.CLEAR_TRANSFER_STATE
+        type: ActionTypes.CLEAR_TRANSFER_STATE,
     };
 }
 
@@ -130,7 +133,7 @@ export function clearTransferState() {
 export function addTransfer(transfer) {
     return {
         type: ActionTypes.ADD_TRANSFER,
-        payload: transfer
+        payload: transfer,
     };
 }
 
@@ -142,7 +145,7 @@ export function addTransfer(transfer) {
 export function updateTransfer(transfer) {
     return {
         type: ActionTypes.UPDATE_TRANSFER,
-        payload: transfer
+        payload: transfer,
     };
 }
 
@@ -154,7 +157,7 @@ export function updateTransfer(transfer) {
 export function saveEndpointBrowserState(state) {
     return {
         type: ActionTypes.SAVE_ENDPOINT_BROWSER_STATE,
-        payload: state
+        payload: state,
     };
 }
 
@@ -166,7 +169,7 @@ export function saveEndpointBrowserState(state) {
 export function updateUIState(state) {
     return {
         type: ActionTypes.UPDATE_UI_STATE,
-        payload: state
+        payload: state,
     };
 }
 
@@ -178,6 +181,6 @@ export function updateUIState(state) {
 export function updateEndpointState(state) {
     return {
         type: ActionTypes.UPDATE_ENDPOINT_STATE,
-        payload: state
+        payload: state,
     };
 }

--- a/web/static/store/store.js
+++ b/web/static/store/store.js
@@ -1,10 +1,10 @@
 import { createStore } from "./index.js";
 import { persistStore, persistReducer } from "redux-persist";
-import sessionStorage from "redux-persist/lib/storage/session"; // Use sessionStorage
+import sessionStorage from "redux-persist/lib/storage/session";
 import {
     transferReducer,
     initialState as transferInitialState,
-    ActionTypes
+    ActionTypes,
 } from "./reducers/transfer-reducer.js";
 
 /**
@@ -12,21 +12,18 @@ import {
  * @description Application store configuration with redux-persist
  */
 
-// Configuration for redux-persist
+// Redux-persist
 const persistConfig = {
     key: "transfer",
     storage: sessionStorage,
     whitelist: ["resumeData", "uiState", "endpointState", "transfers", "currentTransfer"], // Persist all relevant state
-    timeout: 2000 // Increase timeout for larger state objects
+    debug: process.env.NODE_ENV !== "production", // Enable debug in non-production environments
+    serialize: true,
+    deserialize: true,
 };
 
-// Create a persisted reducer
 const persistedReducer = persistReducer(persistConfig, transferReducer);
-
-// Create and export the transfer store with the persisted reducer
 export const transferStore = createStore(persistedReducer, transferInitialState);
-
-// Create and export the persistor
 export const persistor = persistStore(transferStore);
 
 /**
@@ -51,7 +48,7 @@ export const saveTransferState = (data) => {
     try {
         transferStore.dispatch({
             type: ActionTypes.SAVE_TRANSFER_STATE,
-            payload: data
+            payload: data,
         });
     } catch (error) {
         console.error("Failed to save transfer state:", error);
@@ -66,7 +63,7 @@ export const updateUIState = (state) => {
     try {
         transferStore.dispatch({
             type: ActionTypes.UPDATE_UI_STATE,
-            payload: state
+            payload: state,
         });
     } catch (error) {
         console.error("Failed to update UI state:", error);
@@ -81,7 +78,7 @@ export const updateEndpointState = (state) => {
     try {
         transferStore.dispatch({
             type: ActionTypes.UPDATE_ENDPOINT_STATE,
-            payload: state
+            payload: state,
         });
     } catch (error) {
         console.error("Failed to update endpoint state:", error);
@@ -95,9 +92,48 @@ export const clearTransferState = () => {
     try {
         transferStore.dispatch({ type: ActionTypes.CLEAR_TRANSFER_STATE });
         persistor.purge(); // Clear persisted state
+
+        // Additional cleanup for any related storage items
+        const storageKeys = Object.keys(sessionStorage);
+        storageKeys.forEach((key) => {
+            if (key.startsWith("persist:") || key.includes("transfer")) {
+                sessionStorage.removeItem(key);
+            }
+        });
     } catch (error) {
         console.error("Failed to clear transfer state:", error);
         // Attempt a more aggressive cleanup if the dispatch fails
         sessionStorage.removeItem(`persist:${persistConfig.key}`);
+        sessionStorage.clear(); // Last resort: clear all session storage
+    }
+};
+
+/**
+ * Checks if the persisted state is valid and usable
+ * @returns {boolean} Whether the state is valid
+ */
+export const isPersistedStateValid = () => {
+    try {
+        const state = transferStore.getState();
+
+        // Basic validation checks
+        if (!state || typeof state !== "object") return false;
+
+        // Check if resumeData exists and has required properties
+        if (state.resumeData) {
+            const { id, mode, timestamp } = state.resumeData;
+
+            // Validate required fields exist
+            if (!id || !mode || !timestamp) return false;
+
+            // Check if state is too old (older than 24 hours)
+            const maxAge = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+            if (Date.now() - timestamp > maxAge) return false;
+        }
+
+        return true;
+    } catch (error) {
+        console.error("Error validating persisted state:", error);
+        return false;
     }
 };

--- a/web/static/store/store.js
+++ b/web/static/store/store.js
@@ -1,0 +1,46 @@
+import { createStore } from "./index.js";
+import { transferReducer, initialState as transferInitialState } from "./reducers/transfer-reducer.js";
+
+/**
+ * @module AppStore
+ * @description Application store configuration
+ */
+
+// Create and export the transfer store
+export const transferStore = createStore(transferReducer, transferInitialState);
+
+/**
+ * Persists transfer state to session storage
+ * @param {Object} state - State to persist
+ */
+export function persistTransferState(state) {
+    if (state) {
+        sessionStorage.setItem("transferState", JSON.stringify(state));
+    }
+}
+
+/**
+ * Loads transfer state from session storage
+ * @returns {Object|null} Loaded state or null
+ */
+export function loadTransferState() {
+    const savedState = sessionStorage.getItem("transferState");
+    return savedState ? JSON.parse(savedState) : null;
+}
+
+/**
+ * Clears transfer state from session storage
+ */
+export function clearTransferState() {
+    sessionStorage.removeItem("transferState");
+}
+
+// Subscribe to store changes to persist state
+transferStore.subscribe(() => {
+    const state = transferStore.getState();
+    if (state.resumeData) {
+        persistTransferState(state.resumeData);
+    } else {
+        clearTransferState();
+    }
+});

--- a/web/static/store/store.js
+++ b/web/static/store/store.js
@@ -1,7 +1,10 @@
 import { createStore } from "./index.js";
 import { persistStore, persistReducer } from "redux-persist";
 import sessionStorage from "redux-persist/lib/storage/session"; // Use sessionStorage
-import { transferReducer, initialState as transferInitialState } from "./reducers/transfer-reducer.js";
+import {
+    transferReducer,
+    initialState as transferInitialState,
+} from "./reducers/transfer-reducer.js";
 
 /**
  * @module AppStore
@@ -10,9 +13,9 @@ import { transferReducer, initialState as transferInitialState } from "./reducer
 
 // Configuration for redux-persist
 const persistConfig = {
-    key: 'transfer',
+    key: "transfer",
     storage: sessionStorage,
-    whitelist: ['resumeData', 'transferUIState'] // Persist both resumeData and transferUIState
+    whitelist: ["resumeData", "transferUIState"], // Persist both resumeData and transferUIState
 };
 
 // Create a persisted reducer
@@ -28,15 +31,15 @@ export const persistor = persistStore(transferStore);
  * Loads transfer state from the persisted store
  * @returns {Object|null} Loaded state or null
  */
-export function loadTransferState() {
+export const loadTransferState = () => {
     const state = transferStore.getState();
     return state.resumeData || null;
-}
+};
 
 /**
  * Clears transfer state from the store and persistence
  */
-export function clearTransferState() {
-    transferStore.dispatch({ type: 'CLEAR_TRANSFER_STATE' });
+export const clearTransferState = () => {
+    transferStore.dispatch({ type: "CLEAR_TRANSFER_STATE" });
     persistor.purge(); // Clear persisted state
-}
+};

--- a/web/static/store/store.js
+++ b/web/static/store/store.js
@@ -74,6 +74,21 @@ export const updateUIState = (state) => {
 };
 
 /**
+ * Updates the endpoint state in the store
+ * @param {Object} state - The endpoint state to save
+ */
+export const updateEndpointState = (state) => {
+    try {
+        transferStore.dispatch({
+            type: ActionTypes.UPDATE_ENDPOINT_STATE,
+            payload: state
+        });
+    } catch (error) {
+        console.error("Failed to update endpoint state:", error);
+    }
+};
+
+/**
  * Clears transfer state from the store and persistence
  */
 export const clearTransferState = () => {

--- a/web/static/store/store.js
+++ b/web/static/store/store.js
@@ -28,7 +28,7 @@ export const persistor = persistStore(transferStore);
 
 /**
  * Loads transfer state from the persisted store
- * @returns {Object|null} Loaded state or null
+ * @returns {object | null} Loaded state or null
  */
 export const loadTransferState = () => {
     try {
@@ -42,7 +42,7 @@ export const loadTransferState = () => {
 
 /**
  * Saves the current transfer state
- * @param {Object} data - The transfer data to save
+ * @param {object} data - The transfer data to save
  */
 export const saveTransferState = (data) => {
     try {
@@ -57,7 +57,7 @@ export const saveTransferState = (data) => {
 
 /**
  * Updates the UI state in the store
- * @param {Object} state - The UI state to save
+ * @param {object} state - The UI state to save
  */
 export const updateUIState = (state) => {
     try {
@@ -72,7 +72,7 @@ export const updateUIState = (state) => {
 
 /**
  * Updates the endpoint state in the store
- * @param {Object} state - The endpoint state to save
+ * @param {object} state - The endpoint state to save
  */
 export const updateEndpointState = (state) => {
     try {

--- a/web/static/store/store.js
+++ b/web/static/store/store.js
@@ -12,7 +12,7 @@ import { transferReducer, initialState as transferInitialState } from "./reducer
 const persistConfig = {
     key: 'transfer',
     storage: sessionStorage,
-    whitelist: ['resumeData'] // Only persist resumeData slice
+    whitelist: ['resumeData', 'transferUIState'] // Persist both resumeData and transferUIState
 };
 
 // Create a persisted reducer

--- a/web/views/main.ect
+++ b/web/views/main.ect
@@ -53,6 +53,9 @@
         <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/panel_graph.js"></script>
         <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/panel_item_info.js"></script>
         <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/main_browse_tab.js"></script>
+        <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/store/index.js"></script>
+        <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/store/reducers/transfer-reducer.js"></script>
+        <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/store/store.js"></script>
         <script nonce="<%= @nonce %>" type="module" charset="utf-8" src="/main.js"></script>
         <title>DataFed Main</title>
     </head>


### PR DESCRIPTION
# PR Description

This pr:
* Utilizes sessionStorage
* Has components independently manage their sessionStorage
* Adds `resumeTransferFlow` check to `web/static/main.js`

Addressesd [[Web, UI] Manage Consent Redirect](https://github.com/ORNL/DataFed/issues/1283) 

# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

This pull request introduces the ability to resume the transfer flow after a consent redirect. It leverages sessionStorage to persist the state of the transfer dialog and endpoint browser, allowing users to continue their transfer process seamlessly after granting consent. It also adds a check for `resumeTransferFlow` to `web/static/main.js` to handle the resumption of the transfer flow.

New Features:
- Implements a mechanism to resume the transfer flow after a consent redirect, preserving the state of the transfer dialog and endpoint browser using sessionStorage.

Enhancements:
- The transfer UI manager, endpoint manager, and endpoint browser components now independently manage their state using sessionStorage, allowing the application to restore the UI to its previous state after a redirect or page reload.
- The endpoint browser now caches its state when consent is required, allowing the application to restore the browser to its previous state after the user grants consent.