### PR TITLE
Add .venv/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+.venv/
 build
 cmake/sodium_version
 cmake/curl_version


### PR DESCRIPTION
# PR Description

In the case of our deployments, at least—using the Docker Compose workflow for the repo service—part of the process is setting up a Python virtual environment, so that the Globus SDK can be installed. I noticed that the virtual environment folder, conventionally `.venv`, is not gitignored. This PR is simply to add that line to the ignorefile.

# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviewer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Chores:
- Update .gitignore to exclude the .venv/ directory.