### PR TITLE
Parse md json strings

### DIFF
--- a/core/database/foxx/api/data_router.js
+++ b/core/database/foxx/api/data_router.js
@@ -101,7 +101,7 @@ function recordCreate(client, record, result) {
     }
 
     if (record.md) {
-        obj.md = record.md;
+        obj.md = JSON.parse(record.md); // parse escaped JSON string TODO: this could be dangerous
         if (Array.isArray(obj.md)) throw [g_lib.ERR_INVALID_PARAM, "Metadata cannot be an array"];
     }
 
@@ -463,7 +463,7 @@ function recordUpdate(client, record, result) {
         obj.md_err_msg = null;
         obj.md_err = false;
     } else if (record.md) {
-        obj.md = record.md;
+        obj.md = JSON.parse(record.md);
         if (Array.isArray(obj.md)) {
             throw [g_lib.ERR_INVALID_PARAM, "Metadata cannot be an array"];
         }

--- a/core/database/foxx/api/query_router.js
+++ b/core/database/foxx/api/query_router.js
@@ -301,10 +301,13 @@ router
     .summary("List client saved queries")
     .description("List client saved queries");
 
-function execQuery(client, mode, published, query) {
+function execQuery(client, mode, published, orig_query) {
     var col_chk = true,
         ctxt = client._id;
-
+    let query = {
+        ...orig_query,
+        params: JSON.parse(orig_query.params),
+    };
     if (!published) {
         // For searches over private data, must perform access checks based on owner field and client id
 
@@ -549,7 +552,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().optional().allow(""),
-                params: joi.object().required(),
+                params: joi.string().required(),
                 limit: joi.number().integer().required(),
             })
             .required(),

--- a/core/database/foxx/api/query_router.js
+++ b/core/database/foxx/api/query_router.js
@@ -306,7 +306,6 @@ function execQuery(client, mode, published, orig_query) {
         ctxt = client._id;
     let query = {
         ...orig_query,
-        params: JSON.parse(orig_query.params),
     };
     if (!published) {
         // For searches over private data, must perform access checks based on owner field and client id
@@ -536,7 +535,12 @@ router
         try {
             const client = g_lib.getUserFromClientID_noexcept(req.queryParams.client);
 
-            var results = execQuery(client, req.body.mode, req.body.published, req.body);
+            console.log("LOOK HERE - ", req.body);
+            const my_query = {
+                ...req.body,
+                params: JSON.parse(req.body.params),
+            };
+            var results = execQuery(client, req.body.mode, req.body.published, my_query);
 
             res.send(results);
         } catch (e) {

--- a/core/database/foxx/api/query_router.js
+++ b/core/database/foxx/api/query_router.js
@@ -535,12 +535,11 @@ router
         try {
             const client = g_lib.getUserFromClientID_noexcept(req.queryParams.client);
 
-            console.log("LOOK HERE - ", req.body);
-            const my_query = {
+            const query = {
                 ...req.body,
                 params: JSON.parse(req.body.params),
             };
-            var results = execQuery(client, req.body.mode, req.body.published, my_query);
+            var results = execQuery(client, req.body.mode, req.body.published, query);
 
             res.send(results);
         } catch (e) {

--- a/core/server/DatabaseAPI.cpp
+++ b/core/server/DatabaseAPI.cpp
@@ -1292,7 +1292,7 @@ void DatabaseAPI::generalSearch(const Auth::SearchRequest &a_request,
   payload["qry_begin"] = qry_begin;
   payload["qry_end"] = qry_end;
   payload["qry_filter"] = qry_filter;
-  payload["params"] = params;
+  payload["params"] = "{" + params + "}";
   payload["limit"] = to_string(cnt);
 
   string body = payload.dump(-1, ' ', true);


### PR DESCRIPTION
# PR Description

Fixes errors introduced by apply security patch, to json parsing.

One while adding and updating metadata, metadata was not being saved as an object as it was before.

Entering custom metadata

```
{
    "example": "bob"
}
```

Was showing escaped when trying to edit the metadata of a record after the fact

```
"{\n    \"example\": \"bob\"\n}"
```


One while using the query search 

![Screenshot (435)](https://github.com/user-attachments/assets/81833407-ef06-4998-b9a1-395970cd6b60)



# Tasks


* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Chores:
- Parses JSON strings in the 'md' field.