### PR TITLE
[DAPS-1388] Add GCP Support

### DIFF
--- a/web/static/api.js
+++ b/web/static/api.js
@@ -97,7 +97,7 @@ export function setDefaultAlloc(a_repo, a_subject, a_cb) {
 
 export function xfrStart(a_ids, a_mode, a_path, a_ext, a_encrypt_mode, a_orig_fname, a_cb) {
     const search_path = a_path.substring(0, a_path.indexOf("/"));
-    epView(search_path, (ok, ep_data ) => {
+    epView(search_path, (ok, ep_data) => {
         const ep = new EndpointModel(ep_data);
         let url = "/api/dat/";
 
@@ -117,7 +117,9 @@ export function xfrStart(a_ids, a_mode, a_path, a_ext, a_encrypt_mode, a_orig_fn
         }
 
         // Make the API request with proper consent parameters if needed
-        const requestData = ep.requiresConsent ? { collection_id: ep.id, collection_type: "mapped" } : null;
+        const requestData = ep.requiresConsent
+            ? { collection_id: ep.id, collection_type: "mapped" }
+            : null;
 
         _asyncGet(url, requestData, (ok, data) => {
             if (ok) {

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -1,7 +1,7 @@
 import * as util from "../../util.js";
 import * as api from "../../api.js";
 import { TransferMode } from "../../models/transfer-model.js";
-import { EndpointModel, EndpointEntityType } from "../../models/endpoint-model.js";
+import { EndpointModel } from "../../models/endpoint-model.js";
 
 const CONFIG = {
     PATH: { SEPARATOR: "/", UP: "..", CURRENT: "." },
@@ -224,7 +224,8 @@ class EndpointBrowser {
             if (ep_status?.code) {
                 throw new ApiError({
                     code: ep_status.code,
-                    message: ep_status.message || `Error accessing endpoint: ${this.props.endpoint.id}`
+                    message:
+                        ep_status.message || `Error accessing endpoint: ${this.props.endpoint.id}`,
                 });
             }
 
@@ -304,14 +305,13 @@ class EndpointBrowser {
             if (error.code === "ConsentRequired" || error.data?.needs_consent === true) {
                 const data = await new Promise((resolve) => {
                     api.getGlobusConsentURL(
-                      (_, data) => resolve(data),
-                      this.props.endpoint.id,
-                      error.data.required_scopes
+                        (_, data) => resolve(data),
+                        this.props.endpoint.id,
+                        error.data.required_scopes,
                     );
                 });
                 title = `<span class='ui-state-error'>Consent Required: Please provide <a href="${data.consent_url}">consent</a>.</span>`;
-            }
-            else {
+            } else {
                 title = `<span class='ui-state-error'>Error: ${error.data.message || "Unknown API error"}</span>`;
             }
         } else {
@@ -352,9 +352,8 @@ class EndpointBrowser {
  * @param {Function} callback - Selection callback
  */
 export function show(endpoint, path, mode, callback) {
-    const endpointModel = endpoint instanceof EndpointModel
-      ? endpoint
-      : new EndpointModel(endpoint);
+    const endpointModel =
+        endpoint instanceof EndpointModel ? endpoint : new EndpointModel(endpoint);
 
     const browser = new EndpointBrowser({
         endpoint: endpointModel,

--- a/web/static/components/endpoint-browse/index.js
+++ b/web/static/components/endpoint-browse/index.js
@@ -230,7 +230,7 @@ class EndpointBrowser {
             }
 
             // Only GCSv5_mapped_collections require consent for data access
-            const requiresConsent = this.props.endpoint.requiresConsent;
+            const { requiresConsent } = this.props.endpoint;
 
             // Fetch directory listing
             const data = await new Promise((resolve) => {
@@ -312,10 +312,14 @@ class EndpointBrowser {
                 });
                 title = `<span class='ui-state-error'>Consent Required: Please provide <a href="${data.consent_url}">consent</a>.</span>`;
             } else {
-                title = `<span class='ui-state-error'>Error: ${error.data.message || "Unknown API error"}</span>`;
+                title = `<span class='ui-state-error'>Error: ${
+                    error.data.message || "Unknown API error"
+                }</span>`;
             }
         } else {
-            title = `<span class='ui-state-error'>Error: ${error.message || "Unknown error"}</span>`;
+            title = `<span class='ui-state-error'>Error: ${
+                error.message || "Unknown error"
+            }</span>`;
         }
 
         return [{ title, icon: false, is_dir: true }];

--- a/web/static/components/transfer/transfer-endpoint-manager.js
+++ b/web/static/components/transfer/transfer-endpoint-manager.js
@@ -41,6 +41,75 @@ export class TransferEndpointManager {
     }
 
     /**
+     * ------------UI UPDATE HELPERS------------
+     */
+
+    #resetUIForSearch() {
+        console.debug("Resetting UI for search.");
+        this.state.currentEndpoint = null;
+        this.state.endpointManagerList = null;
+        this.#updateMatchesList([]);
+        // Also disable start button as no endpoint is confirmed yet
+        this.#controller.uiManager.enableBrowseButton(false);
+        this.#controller.uiManager.enableStartButton(false);
+    }
+
+    #updateMatchesList(endpoints = []) {
+        const matches = $("#matches", this.#controller.uiManager.state.frame);
+        if (!endpoints || !endpoints.length) {
+            matches.html("<option disabled selected>No Matches</option>");
+            matches.prop("disabled", true);
+        } else {
+            const html = createMatchesHtml(endpoints);
+            matches.html(html);
+            matches.prop("disabled", false);
+        }
+    }
+
+    #updateUIForEndpointFound(endpointData) {
+        console.info("Updating UI for directly found endpoint:", endpointData);
+        this.#updateMatchesList(endpointData);
+        this.#controller.uiManager.handleSelectedEndpoint(endpointData);
+        this.#controller.uiManager.enableBrowseButton(true);
+        this.#controller.uiManager.handleSelectionChange();
+    }
+
+    #updateUIWithMatches(endpoints) {
+        console.debug("Updating UI with autocomplete matches.");
+        this.state.endpointManagerList = endpoints;
+        endpoints.forEach((ep) => {
+            ep.name = ep.canonical_name || ep.id;
+        });
+        this.#updateMatchesList(endpoints);
+        // Buttons remain disabled until a selection is made from the list
+        this.#controller.uiManager.enableBrowseButton(false);
+        this.#controller.uiManager.enableStartButton(false);
+    }
+
+    #updateUIForNoMatches() {
+        console.warn("Updating UI for no matches found.");
+        this.state.endpointManagerList = null;
+        // Don't clear currentEndpoint here, as it might be valid from a previous selection
+        this.#updateMatchesList([]);
+        this.#controller.uiManager.enableBrowseButton(false);
+        this.#controller.uiManager.enableStartButton(false);
+    }
+
+    #updateUIForAutocompleteFailure(data) {
+        console.error("Autocomplete error:", data);
+        this.#updateUIForNoMatches();
+        if (data?.code) {
+            this.dialogs.dlgAlert("Globus Error", `Autocomplete failed: ${data.code}`);
+        } else {
+            this.dialogs.dlgAlert("Globus Error", "Autocomplete failed due to an unknown error.");
+        }
+    }
+
+    /**
+     * ------------SEARCH LOGIC------------
+     */
+
+    /**
      * Performs autocomplete search for endpoints
      * @param {string} endpoint - The endpoint search term
      * @param {string} searchToken - Token to track current search request
@@ -51,95 +120,50 @@ export class TransferEndpointManager {
             // Without this check, rapid typing could cause UI flickering and incorrect results
             // as slower API responses return after newer searches
             if (searchToken !== this.state.currentSearchToken) {
+                console.debug("Ignoring stale autocomplete response.");
                 return;
             }
 
-            if (ok && data.DATA && data.DATA.length) {
-                this.state.endpointManagerList = data.DATA;
-                // Process endpoints and update UI
-                data.DATA.forEach((ep) => {
-                    ep.name = ep.canonical_name || ep.id;
-                });
-                this.updateMatchesList(data.DATA);
-                // Ensure browse button is disabled until a selection is made from matches
-                this.#controller.uiManager.enableBrowseButton(false);
-                // Also disable start button as no endpoint is confirmed yet
-                this.#controller.uiManager.enableStartButton(false);
+            if (ok && data?.DATA?.length) {
+                this.#updateUIWithMatches(data.DATA);
             } else {
-                console.warn("No matches found via autocomplete");
-                this.state.endpointManagerList = null;
-                this.updateMatchesList([]);
-                // Disable browse/start buttons as no endpoint could be resolved
-                this.#controller.uiManager.enableBrowseButton(false);
-                this.#controller.uiManager.enableStartButton(false);
-                if (data.code) {
-                    console.error("Autocomplete error:", data);
-                    // Optionally show an alert, but often just showing "No Matches" is enough
-                    this.dialogs.dlgAlert("Globus Error", data.code);
+                if (!ok || data?.code) {
+                    this.#updateUIForAutocompleteFailure(data);
+                } else {
+                    this.#updateUIForNoMatches();
                 }
             }
         });
     }
 
     /**
-     * Searches for a specific endpoint by trying epView first, then falling back to autocomplete.
-     * @param {string} endpoint - The endpoint identifier (UUID, canonical name, display name, etc.)
+     * Searches for a specific endpoint
+     * @param {string} endpoint - The endpoint to search for
      * @param {string} searchToken - Token to track current search request
+     * @returns {Promise|undefined} API response promise if available
      */
     searchEndpoint(endpoint, searchToken) {
-        console.info("Searching for endpoint:", endpoint);
-        // Reset matches list and disable buttons initially for the new search
-        this.updateMatchesList([]);
-        this.#controller.uiManager.enableBrowseButton(false);
-        this.#controller.uiManager.enableStartButton(false);
-        this.state.currentEndpoint = null; // Clear current endpoint until resolved
+        console.info(`Searching for endpoint: "${endpoint}" (Token: ${searchToken})`);
+        // Reset UI for the new search immediately
+        this.#resetUIForSearch();
 
-        // 1. Try direct epView first (handles UUIDs, canonical names)
-        this.api.epView(endpoint, (ok, data) => {
-            if (searchToken !== this.state.currentSearchToken) {
-                console.warn("Ignoring stale epView response (direct attempt)");
-                return;
-            }
+        try {
+            return this.api.epView(endpoint, (ok, data) => {
+                if (searchToken !== this.state.currentSearchToken) {
+                    console.warn("Ignoring stale epView response");
+                    return;
+                }
 
-            if (ok && !data.code) {
-                // Exact match found via epView
-                console.info("Direct endpoint match found via epView:", data);
-                // Update UI immediately with the single, confirmed match
-                this.#controller.uiManager.handleSelectedEndpoint(data);
-                // Enable browse button now that we have a valid endpoint
-                this.#controller.uiManager.enableBrowseButton(true);
-                // Trigger selection change check which might enable the start button
-                this.#controller.uiManager.handleSelectionChange();
-            } else {
-                // epView failed, likely not a UUID/canonical name. Try autocomplete.
-                console.warn("Direct epView failed for '"+ endpoint +"', trying autocomplete. Error:", data?.code || "N/A");
-                this.searchEndpointAutocomplete(endpoint, searchToken);
-            }
-        });
-    }
-
-    /**
-     * ------------UPDATE------------
-     */
-
-    /**
-     * Updates the list of endpoint matches in the UI
-     * @param {Array<object>} [endpoints=[]] - Array of endpoint objects
-     */
-    updateMatchesList(endpoints = []) {
-        const matches = $("#matches", this.#controller.uiManager.state.frame);
-        // Ensure matches element exists before proceeding
-        if (!matches.length) {
-            console.warn("Matches dropdown element not found in UI.");
-            return;
-        }
-        if (!endpoints.length) {
-            matches.html("<option disabled selected>No Matches</option>");
-            matches.prop("disabled", true);
-        } else {
-            const html = createMatchesHtml(endpoints);
-            matches.html(html);
-            matches.prop("disabled", false);
+                if (ok && !data.code) {
+                    console.info("Direct endpoint match found:", data.id);
+                    this.#updateUIForEndpointFound(data);
+                } else {
+                    console.warn("No direct match, trying autocomplete");
+                    this.searchEndpointAutocomplete(endpoint, searchToken);
+                }
+            });
+        } catch (error) {
+            this.dialogs.dlgAlert("Globus Error", error);
         }
     }
 
@@ -155,7 +179,6 @@ export class TransferEndpointManager {
         // Check initialization state using the manager's own state
         if (!this.state.initialized) {
             console.warn("Dialog not yet initialized - delaying path input handling");
-            // Ensure 'this' context is preserved in setTimeout
             setTimeout(() => this.handlePathInput(searchToken), 100);
             return;
         }
@@ -172,12 +195,8 @@ export class TransferEndpointManager {
         // Handle empty input
         if (!path) {
             console.info("Path input cleared.");
-            this.state.endpointManagerList = null;
-            this.state.currentEndpoint = null;
-            this.updateMatchesList([]);
-            this.#controller.uiManager.enableStartButton(false);
-            this.#controller.uiManager.enableBrowseButton(false);
-            // Clear the matches dropdown explicitly
+            this.#resetUIForSearch();
+            // Explicitly set placeholder for matches dropdown when input is empty
             const matches = $("#matches", this.#controller.uiManager.state.frame);
             if (matches.length) {
                 matches.html("<option disabled selected>Enter Endpoint</option>");
@@ -186,29 +205,39 @@ export class TransferEndpointManager {
             return;
         }
 
+        // Extract potential endpoint identifier (part before the first '/')
         const endpoint = path.split("/")[0];
+        const currentEndpointName =
+            this.state.currentEndpoint?.name || this.state.currentEndpoint?.id;
+
         console.info(
-            "Extracted endpoint:", endpoint,
-            "Current endpoint name:", this.state.currentEndpoint?.name || "None"
+            `Path input: "${path}", Extracted endpoint: "${endpoint}", Current endpoint name: "${
+                currentEndpointName || "None"
+            }"`,
         );
 
         // Trigger search if endpoint identifier is present and differs from current
         // or if there's no current endpoint selected yet.
-        if (endpoint && (!this.state.currentEndpoint || endpoint !== this.state.currentEndpoint.name)) {
+        // Edge case: input is just a /. Ideally we have some middleware validation to avoid this
+        if (
+            endpoint &&
+            (!this.state.currentEndpoint || endpoint !== this.state.currentEndpoint.name)
+        ) {
             console.info("Endpoint identifier changed or not set - searching for:", endpoint);
             this.searchEndpoint(endpoint, searchToken);
-        } else if (endpoint && this.state.currentEndpoint && endpoint === this.state.currentEndpoint.name) {
+        } else if (endpoint && this.state.currentEndpoint && endpoint === currentEndpointName) {
             // Endpoint name hasn't changed, but path might have.
             // Ensure buttons reflect current state (e.g., if path became valid/invalid)
-            console.info("Endpoint name unchanged, re-evaluating selection state.");
+            console.debug("Endpoint name unchanged, re-evaluating selection state.");
             this.#controller.uiManager.handleSelectionChange();
         } else if (!endpoint) {
-             // This case should be caught by the `!path` check earlier, but added for robustness.
-             console.warn("Path input resulted in empty endpoint identifier.");
-             this.state.currentEndpoint = null;
-             this.updateMatchesList([]);
-             this.#controller.uiManager.enableStartButton(false);
-             this.#controller.uiManager.enableBrowseButton(false);
+            // This case should be caught by the `!path` check earlier, but added for robustness.
+            console.warn("Path input resulted in empty endpoint identifier.");
+            console.warn("Path input resulted in empty endpoint identifier.");
+            this.#resetUIForSearch();
         }
+        // If the endpoint identifier *is* the same as current, and non-empty, we do nothing here,
+        // assuming the user is just editing the path part after the endpoint.
+        // handleSelectionChange called above covers path validity checks.
     }
 }

--- a/web/static/components/transfer/transfer-endpoint-manager.js
+++ b/web/static/components/transfer/transfer-endpoint-manager.js
@@ -233,7 +233,6 @@ export class TransferEndpointManager {
         } else if (!endpoint) {
             // This case should be caught by the `!path` check earlier, but added for robustness.
             console.warn("Path input resulted in empty endpoint identifier.");
-            console.warn("Path input resulted in empty endpoint identifier.");
             this.#resetUIForSearch();
         }
         // If the endpoint identifier *is* the same as current, and non-empty, we do nothing here,

--- a/web/static/models/endpoint-model.js
+++ b/web/static/models/endpoint-model.js
@@ -1,0 +1,112 @@
+/**
+ * Enum for Globus endpoint entity types
+ * @readonly
+ * @enum {string}
+ */
+const EndpointEntityType = Object.freeze({
+  GCP_MAPPED_COLLECTION: 'GCP_mapped_collection',
+  GCP_GUEST_COLLECTION: 'GCP_guest_collection',
+  GCSV5_ENDPOINT: 'GCSv5_endpoint',
+  GCSV5_MAPPED_COLLECTION: 'GCSv5_mapped_collection',
+  GCSV5_GUEST_COLLECTION: 'GCSv5_guest_collection',
+  GCSV4_HOST: 'GCSv4_host',
+  GCSV4_SHARE: 'GCSv4_share',
+
+  /**
+   * Check if entity type is a mapped collection
+   * @param {string} type - Entity type to check
+   * @returns {boolean} True if the entity type is a mapped collection
+   */
+  isMappedCollection(type) {
+    return type === this.GCP_MAPPED_COLLECTION ||
+      type === this.GCSV5_MAPPED_COLLECTION;
+  },
+
+  /**
+   * Check if entity type is a guest collection
+   * @param {string} type - Entity type to check
+   * @returns {boolean} True if the entity type is a guest collection
+   */
+  isGuestCollection(type) {
+    return type === this.GCP_GUEST_COLLECTION ||
+      type === this.GCSV5_GUEST_COLLECTION;
+  },
+
+  /**
+   * Check if entity requires consent
+   * According to docs, only GCSv5 mapped collections require consent
+   * @param {string} type - Entity type to check
+   * @returns {boolean} True if the entity type requires consent
+   */
+  requiresConsent(type) {
+    return type === this.GCSV5_MAPPED_COLLECTION;
+  }
+});
+
+/**
+ * Model class for Globus endpoint data and operations
+ */
+class EndpointModel {
+  #endpoint;
+  #displayName;
+  #entityType;
+  #collections;
+  #ownerString;
+  #isConnected;
+  #isBusy;
+
+  /**
+   * @param {object} endpointData - Endpoint data from Globus API
+   */
+  constructor(endpointData = {}) {
+    this.#endpoint = endpointData;
+    this.#displayName = endpointData.display_name || endpointData.canonical_name || "Unknown Endpoint";
+    this.#entityType = endpointData.entity_type || null;
+    this.#collections = endpointData.collections || [];
+    this.#ownerString = this.#formatOwnerString(endpointData);
+    this.#isConnected = endpointData.is_connected === true;
+    this.#isBusy = endpointData.in_use === true;
+  }
+
+  /**
+   * Format owner information as a display string
+   * @param {object} endpointData - Endpoint data
+   * @returns {string} Formatted owner string
+   */
+  #formatOwnerString(endpointData) {
+    if (endpointData.owner_string) return endpointData.owner_string;
+
+    return endpointData.owner_id ?
+      `${endpointData.username || 'User'}#${endpointData.owner_id}` :
+      'Unknown owner';
+  }
+
+  get id() { return this.#endpoint.id || ''; }
+  get displayName() { return this.#displayName; }
+  get entityType() { return this.#entityType; }
+  get requiresConsent() { return EndpointEntityType.requiresConsent(this.#entityType); }
+  get isMappedCollection() { return EndpointEntityType.isMappedCollection(this.#entityType); }
+  get isGuestCollection() { return EndpointEntityType.isGuestCollection(this.#entityType); }
+  get isConnected() { return this.#isConnected; }
+  get isBusy() { return this.#isBusy; }
+  get rawData() { return { ...this.#endpoint }; }
+  get ownerString() { return this.#ownerString; }
+  get collections() { return [...this.#collections]; }
+
+  canTransfer() { return this.#isConnected && !this.#isBusy; }
+
+  getSearchAttributes() {
+    return {
+      id: this.id,
+      displayName: this.#displayName,
+      owner: this.#ownerString,
+      status: this.#isConnected ? 'Connected' : 'Disconnected',
+      entityType: this.#entityType
+    };
+  }
+}
+
+export {
+  EndpointEntityType,
+  EndpointModel
+}

--- a/web/static/models/endpoint-model.js
+++ b/web/static/models/endpoint-model.js
@@ -1,112 +1,158 @@
 /**
  * Enum for Globus endpoint entity types
+ * Derived from https://docs.globus.org/api/transfer/endpoints_and_collections/#entity_types
  * @readonly
  * @enum {string}
  */
 const EndpointEntityType = Object.freeze({
-  GCP_MAPPED_COLLECTION: 'GCP_mapped_collection',
-  GCP_GUEST_COLLECTION: 'GCP_guest_collection',
-  GCSV5_ENDPOINT: 'GCSv5_endpoint',
-  GCSV5_MAPPED_COLLECTION: 'GCSv5_mapped_collection',
-  GCSV5_GUEST_COLLECTION: 'GCSv5_guest_collection',
-  GCSV4_HOST: 'GCSv4_host',
-  GCSV4_SHARE: 'GCSv4_share',
+    GCP_MAPPED_COLLECTION: "GCP_mapped_collection",
+    GCP_GUEST_COLLECTION: "GCP_guest_collection",
+    GCSV5_ENDPOINT: "GCSv5_endpoint",
+    GCSV5_MAPPED_COLLECTION: "GCSv5_mapped_collection",
+    GCSV5_GUEST_COLLECTION: "GCSv5_guest_collection",
+    GCSV4_HOST: "GCSv4_host",
+    GCSV4_SHARE: "GCSv4_share",
 
-  /**
-   * Check if entity type is a mapped collection
-   * @param {string} type - Entity type to check
-   * @returns {boolean} True if the entity type is a mapped collection
-   */
-  isMappedCollection(type) {
-    return type === this.GCP_MAPPED_COLLECTION ||
-      type === this.GCSV5_MAPPED_COLLECTION;
-  },
+    /**
+     * Check if a string is a valid defined entity type.
+     * @param {string} type - Entity type string to check.
+     * @returns {boolean} True if the type is a valid enum value.
+     */
+    isValid(type) {
+        return typeof type === "string" && Object.values(this).includes(type);
+    },
 
-  /**
-   * Check if entity type is a guest collection
-   * @param {string} type - Entity type to check
-   * @returns {boolean} True if the entity type is a guest collection
-   */
-  isGuestCollection(type) {
-    return type === this.GCP_GUEST_COLLECTION ||
-      type === this.GCSV5_GUEST_COLLECTION;
-  },
+    /**
+     * Check if entity type is a mapped collection
+     * @param {string} type - Entity type to check
+     * @returns {boolean} True if the entity type is a mapped collection
+     */
+    isMappedCollection(type) {
+        if (!this.isValid(type)) throw new TypeError(`Invalid entity type provided: ${type}`);
+        return type === this.GCP_MAPPED_COLLECTION || type === this.GCSV5_MAPPED_COLLECTION;
+    },
 
-  /**
-   * Check if entity requires consent
-   * According to docs, only GCSv5 mapped collections require consent
-   * @param {string} type - Entity type to check
-   * @returns {boolean} True if the entity type requires consent
-   */
-  requiresConsent(type) {
-    return type === this.GCSV5_MAPPED_COLLECTION;
-  }
+    /**
+     * Check if entity type is a guest collection
+     * @param {string} type - Entity type to check
+     * @returns {boolean} True if the entity type is a guest collection
+     */
+    isGuestCollection(type) {
+        if (!this.isValid(type)) throw new TypeError(`Invalid entity type provided: ${type}`);
+        return type === this.GCP_GUEST_COLLECTION || type === this.GCSV5_GUEST_COLLECTION;
+    },
+
+    /**
+     * Check if entity requires consent
+     * According to docs, only GCSv5 mapped collections require consent
+     * @param {string} type - Entity type to check
+     * @returns {boolean} True if the entity type requires consent
+     */
+    requiresConsent(type) {
+        if (!this.isValid(type)) throw new TypeError(`Invalid entity type provided: ${type}`);
+        return type === this.GCSV5_MAPPED_COLLECTION;
+    },
 });
 
 /**
- * Model class for Globus endpoint data and operations
+ * https://docs.globus.org/api/transfer/endpoints_and_collections/
+ * Derived from https://docs.globus.org/api/transfer/endpoints_and_collections/
  */
 class EndpointModel {
-  #endpoint;
-  #displayName;
-  #entityType;
-  #collections;
-  #ownerString;
-  #isConnected;
-  #isBusy;
+    #endpoint;
+    #displayName;
+    #entityType;
+    #collections;
+    #ownerString;
+    #isConnected;
+    #isBusy;
 
-  /**
-   * @param {object} endpointData - Endpoint data from Globus API
-   */
-  constructor(endpointData = {}) {
-    this.#endpoint = endpointData;
-    this.#displayName = endpointData.display_name || endpointData.canonical_name || "Unknown Endpoint";
-    this.#entityType = endpointData.entity_type || null;
-    this.#collections = endpointData.collections || [];
-    this.#ownerString = this.#formatOwnerString(endpointData);
-    this.#isConnected = endpointData.is_connected === true;
-    this.#isBusy = endpointData.in_use === true;
-  }
+    /**
+     * @param {object} endpointData - Endpoint data from Globus API
+     */
+    constructor(endpointData = {}) {
+        if (!endpointData || typeof endpointData !== "object") {
+            throw new TypeError("Endpoint data must be an object.");
+        }
+        if (!endpointData.id) {
+            throw new TypeError("Endpoint data must include an 'id'.");
+        }
+        if (!EndpointEntityType.isValid(endpointData.entity_type)) {
+            throw new TypeError(
+                `Endpoint data must include a valid 'entity_type'. Received: ${endpointData.entity_type}`,
+            );
+        }
 
-  /**
-   * Format owner information as a display string
-   * @param {object} endpointData - Endpoint data
-   * @returns {string} Formatted owner string
-   */
-  #formatOwnerString(endpointData) {
-    if (endpointData.owner_string) return endpointData.owner_string;
+        this.#endpoint = endpointData;
+        this.#displayName =
+            endpointData.display_name || endpointData.canonical_name || "Unknown Endpoint";
+        this.#entityType = endpointData.entity_type;
+        this.#collections = endpointData.collections || [];
+        this.#ownerString = this.#formatOwnerString(endpointData);
+        this.#isConnected = endpointData.is_connected === true;
+        this.#isBusy = endpointData.in_use === true;
+    }
 
-    return endpointData.owner_id ?
-      `${endpointData.username || 'User'}#${endpointData.owner_id}` :
-      'Unknown owner';
-  }
+    /**
+     * Format owner information as a display string
+     * @param {object} endpointData - Endpoint data
+     * @returns {string} Formatted owner string
+     */
+    #formatOwnerString(endpointData) {
+        if (endpointData.owner_string) {
+            return endpointData.owner_string;
+        } else if (endpointData.owner_id) {
+            return `${endpointData.username || "User"}#${endpointData.owner_id}`;
+        }
+    }
 
-  get id() { return this.#endpoint.id || ''; }
-  get displayName() { return this.#displayName; }
-  get entityType() { return this.#entityType; }
-  get requiresConsent() { return EndpointEntityType.requiresConsent(this.#entityType); }
-  get isMappedCollection() { return EndpointEntityType.isMappedCollection(this.#entityType); }
-  get isGuestCollection() { return EndpointEntityType.isGuestCollection(this.#entityType); }
-  get isConnected() { return this.#isConnected; }
-  get isBusy() { return this.#isBusy; }
-  get rawData() { return { ...this.#endpoint }; }
-  get ownerString() { return this.#ownerString; }
-  get collections() { return [...this.#collections]; }
+    get id() {
+        return this.#endpoint.id;
+    }
+    get displayName() {
+        return this.#displayName;
+    }
+    get entityType() {
+        return this.#entityType;
+    }
+    get requiresConsent() {
+        return EndpointEntityType.requiresConsent(this.#entityType);
+    }
+    get isMappedCollection() {
+        return EndpointEntityType.isMappedCollection(this.#entityType);
+    }
+    get isGuestCollection() {
+        return EndpointEntityType.isGuestCollection(this.#entityType);
+    }
+    get isConnected() {
+        return this.#isConnected;
+    }
+    get isBusy() {
+        return this.#isBusy;
+    }
+    get rawData() {
+        return { ...this.#endpoint };
+    }
+    get ownerString() {
+        return this.#ownerString;
+    }
+    get collections() {
+        return [...this.#collections];
+    }
 
-  canTransfer() { return this.#isConnected && !this.#isBusy; }
+    canTransfer() {
+        return this.#isConnected && !this.#isBusy;
+    }
 
-  getSearchAttributes() {
-    return {
-      id: this.id,
-      displayName: this.#displayName,
-      owner: this.#ownerString,
-      status: this.#isConnected ? 'Connected' : 'Disconnected',
-      entityType: this.#entityType
-    };
-  }
+    getSearchAttributes() {
+        return {
+            id: this.id,
+            displayName: this.#displayName,
+            owner: this.#ownerString,
+            status: this.#isConnected ? "Connected" : "Disconnected",
+            entityType: this.#entityType,
+        };
+    }
 }
 
-export {
-  EndpointEntityType,
-  EndpointModel
-}
+export { EndpointEntityType, EndpointModel };

--- a/web/test/endpoint-model.test.js
+++ b/web/test/endpoint-model.test.js
@@ -13,6 +13,21 @@ describe("EndpointEntityType", () => {
         expect(EndpointEntityType.GCSV4_SHARE).to.equal("GCSv4_share");
     });
 
+    describe("isValid", () => {
+        it("should return true for valid entity type strings", () => {
+            expect(EndpointEntityType.isValid(EndpointEntityType.GCP_MAPPED_COLLECTION)).to.be.true;
+            expect(EndpointEntityType.isValid(EndpointEntityType.GCSV5_ENDPOINT)).to.be.true;
+            expect(EndpointEntityType.isValid("GCSv4_host")).to.be.true;
+        });
+
+        it("should return false for invalid or non-string types", () => {
+            expect(EndpointEntityType.isValid("invalid_type_string")).to.be.false;
+            expect(EndpointEntityType.isValid(null)).to.be.false;
+            expect(EndpointEntityType.isValid(undefined)).to.be.false;
+            expect(EndpointEntityType.isValid(123)).to.be.false;
+            expect(EndpointEntityType.isValid({})).to.be.false;
+        });
+    });
     describe("isMappedCollection", () => {
         it("should return true for mapped collection types", () => {
             expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCP_MAPPED_COLLECTION))
@@ -22,23 +37,14 @@ describe("EndpointEntityType", () => {
             ).to.be.true;
         });
 
-        it("should return false for non-mapped collection types", () => {
-            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCP_GUEST_COLLECTION))
-                .to.be.false;
-            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV5_ENDPOINT)).to.be
-                .false;
-            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV5_GUEST_COLLECTION))
-                .to.be.false;
-            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV4_HOST)).to.be
-                .false;
-            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV4_SHARE)).to.be
-                .false;
-            expect(EndpointEntityType.isMappedCollection("some_other_type")).to.be.false;
-            expect(EndpointEntityType.isMappedCollection(null)).to.be.false;
-            expect(EndpointEntityType.isMappedCollection(undefined)).to.be.false;
+        it("should throw TypeError for invalid types", () => {
+            expect(() => EndpointEntityType.isMappedCollection("some_other_type")).to.throw(
+                TypeError,
+            );
+            expect(() => EndpointEntityType.isMappedCollection(null)).to.throw(TypeError);
+            expect(() => EndpointEntityType.isMappedCollection(undefined)).to.throw(TypeError);
         });
     });
-
     describe("isGuestCollection", () => {
         it("should return true for guest collection types", () => {
             expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCP_GUEST_COLLECTION)).to
@@ -47,42 +53,24 @@ describe("EndpointEntityType", () => {
                 .to.be.true;
         });
 
-        it("should return false for non-guest collection types", () => {
-            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCP_MAPPED_COLLECTION))
-                .to.be.false;
-            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV5_ENDPOINT)).to.be
-                .false;
-            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV5_MAPPED_COLLECTION))
-                .to.be.false;
-            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV4_HOST)).to.be.false;
-            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV4_SHARE)).to.be
-                .false;
-            expect(EndpointEntityType.isGuestCollection("some_other_type")).to.be.false;
-            expect(EndpointEntityType.isGuestCollection(null)).to.be.false;
-            expect(EndpointEntityType.isGuestCollection(undefined)).to.be.false;
+        it("should throw TypeError for invalid types", () => {
+            expect(() => EndpointEntityType.isGuestCollection("some_other_type")).to.throw(
+                TypeError,
+            );
+            expect(() => EndpointEntityType.isGuestCollection(null)).to.throw(TypeError);
+            expect(() => EndpointEntityType.isGuestCollection(undefined)).to.throw(TypeError);
         });
     });
-
     describe("requiresConsent", () => {
         it("should return true only for GCSv5 mapped collection type", () => {
             expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV5_MAPPED_COLLECTION))
                 .to.be.true;
         });
 
-        it("should return false for other types", () => {
-            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCP_MAPPED_COLLECTION)).to
-                .be.false;
-            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCP_GUEST_COLLECTION)).to
-                .be.false;
-            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV5_ENDPOINT)).to.be
-                .false;
-            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV5_GUEST_COLLECTION)).to
-                .be.false;
-            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV4_HOST)).to.be.false;
-            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV4_SHARE)).to.be.false;
-            expect(EndpointEntityType.requiresConsent("some_other_type")).to.be.false;
-            expect(EndpointEntityType.requiresConsent(null)).to.be.false;
-            expect(EndpointEntityType.requiresConsent(undefined)).to.be.false;
+        it("should throw TypeError for invalid types", () => {
+            expect(() => EndpointEntityType.requiresConsent("some_other_type")).to.throw(TypeError);
+            expect(() => EndpointEntityType.requiresConsent(null)).to.throw(TypeError);
+            expect(() => EndpointEntityType.requiresConsent(undefined)).to.throw(TypeError);
         });
     });
 });
@@ -93,18 +81,55 @@ describe("EndpointModel", () => {
     });
 
     describe("Constructor and Basic Getters", () => {
-        it("should initialize with default values when no data is provided", () => {
-            const endpointData = {};
-            const model = new EndpointModel(endpointData);
+        it("should throw TypeError if endpointData is not an object", () => {
+            expect(() => new EndpointModel(null)).to.throw(
+                TypeError,
+                "Endpoint data must be an object.",
+            );
+            expect(() => new EndpointModel("string")).to.throw(
+                TypeError,
+                "Endpoint data must be an object.",
+            );
+            expect(() => new EndpointModel(123)).to.throw(
+                TypeError,
+                "Endpoint data must be an object.",
+            );
+        });
 
-            expect(model.id).to.equal("");
-            expect(model.displayName).to.equal("Unknown Endpoint");
-            expect(model.entityType).to.be.null;
-            expect(model.collections).to.deep.equal([]);
-            expect(model.ownerString).to.equal("Unknown owner");
-            expect(model.isConnected).to.be.false;
-            expect(model.isBusy).to.be.false;
-            expect(model.rawData).to.deep.equal({});
+        it("should throw TypeError if id is missing", () => {
+            const endpointData = { entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
+            expect(() => new EndpointModel(endpointData)).to.throw(
+                TypeError,
+                "Endpoint data must include an 'id'.",
+            );
+            expect(() => new EndpointModel({})).to.throw(
+                TypeError,
+                "Endpoint data must include an 'id'.",
+            );
+        });
+
+        it("should throw TypeError if entity_type is missing", () => {
+            const endpointData = { id: "ep123" };
+            expect(() => new EndpointModel(endpointData)).to.throw(
+                TypeError,
+                /must include a valid 'entity_type'/,
+            );
+        });
+
+        it("should throw TypeError if entity_type is invalid", () => {
+            const endpointData = { id: "ep123", entity_type: "invalid_type" };
+            expect(() => new EndpointModel(endpointData)).to.throw(
+                TypeError,
+                /must include a valid 'entity_type'/,
+            );
+        });
+
+        it("should NOT throw if only optional fields are missing", () => {
+            const minimalData = {
+                id: "ep123",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            };
+            expect(() => new EndpointModel(minimalData)).to.not.throw();
         });
 
         it("should initialize correctly with typical endpoint data", () => {
@@ -131,10 +156,26 @@ describe("EndpointModel", () => {
         });
 
         it("should handle display name fallback logic", () => {
-            const dataWithName = { display_name: "Display Name" };
-            const dataWithCanonical = { canonical_name: "Canonical Name" };
-            const dataWithBoth = { display_name: "Display Name", canonical_name: "Canonical Name" };
-            const dataWithNeither = {};
+            const dataWithName = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                display_name: "Display Name",
+            };
+            const dataWithCanonical = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                canonical_name: "Canonical Name",
+            };
+            const dataWithBoth = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                display_name: "Display Name",
+                canonical_name: "Canonical Name",
+            };
+            const dataWithNeither = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            };
 
             expect(new EndpointModel(dataWithName).displayName).to.equal("Display Name");
             expect(new EndpointModel(dataWithCanonical).displayName).to.equal("Canonical Name");
@@ -143,10 +184,12 @@ describe("EndpointModel", () => {
         });
 
         it("should handle owner string fallback logic", () => {
-            const dataWithOwnerString = { owner_string: "owner@domain.org" };
-            const dataWithOwnerId = { owner_id: "owner123" };
-            const dataWithOwnerIdAndUser = { owner_id: "owner123", username: "testuser" };
+            const base = { id: "ep1", entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
+            const dataWithOwnerString = { ...base, owner_string: "owner@domain.org" };
+            const dataWithOwnerId = { ...base, owner_id: "owner123" };
+            const dataWithOwnerIdAndUser = { ...base, owner_id: "owner123", username: "testuser" };
             const dataWithAll = {
+                ...base,
                 owner_string: "owner@domain.org",
                 owner_id: "owner123",
                 username: "testuser",
@@ -159,15 +202,16 @@ describe("EndpointModel", () => {
                 "testuser#owner123",
             );
             expect(new EndpointModel(dataWithAll).ownerString).to.equal("owner@domain.org");
-            expect(new EndpointModel(dataWithNeither).ownerString).to.equal("Unknown owner");
         });
+        // expect(new EndpointModel(dataWithNeither).ownerString).to.equal("Unknown owner");
 
         it("should correctly map is_connected and in_use to isConnected and isBusy", () => {
-            const dataConnectedNotBusy = { is_connected: true, in_use: false };
-            const dataDisconnectedNotBusy = { is_connected: false, in_use: false };
-            const dataConnectedBusy = { is_connected: true, in_use: true };
-            const dataDisconnectedBusy = { is_connected: false, in_use: true };
-            const dataMissing = {};
+            const base = { id: "ep1", entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
+            const dataConnectedNotBusy = { ...base, is_connected: true, in_use: false };
+            const dataDisconnectedNotBusy = { ...base, is_connected: false, in_use: false };
+            const dataConnectedBusy = { ...base, is_connected: true, in_use: true };
+            const dataDisconnectedBusy = { ...base, is_connected: false, in_use: true };
+            const dataMissing = { ...base };
 
             let model = new EndpointModel(dataConnectedNotBusy);
             expect(model.isConnected).to.be.true;
@@ -193,47 +237,68 @@ describe("EndpointModel", () => {
 
     describe("Derived Getters (requiresConsent, isMappedCollection, isGuestCollection)", () => {
         it("should correctly determine requiresConsent based on entityType", () => {
-            const dataRequiresConsent = { entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION };
+            const dataRequiresConsent = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION,
+            };
             const dataDoesNotRequireConsent = {
+                id: "ep2",
                 entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
             };
-            const dataNoType = {};
 
             expect(new EndpointModel(dataRequiresConsent).requiresConsent).to.be.true;
             expect(new EndpointModel(dataDoesNotRequireConsent).requiresConsent).to.be.false;
-            expect(new EndpointModel(dataNoType).requiresConsent).to.be.false;
         });
 
         it("should correctly determine isMappedCollection based on entityType", () => {
-            const dataIsMapped1 = { entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
-            const dataIsMapped2 = { entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION };
-            const dataIsNotMapped = { entity_type: EndpointEntityType.GCP_GUEST_COLLECTION };
-            const dataNoType = {};
+            const dataIsMapped1 = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            };
+            const dataIsMapped2 = {
+                id: "ep2",
+                entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION,
+            };
+            const dataIsNotMapped = {
+                id: "ep3",
+                entity_type: EndpointEntityType.GCP_GUEST_COLLECTION,
+            };
 
             expect(new EndpointModel(dataIsMapped1).isMappedCollection).to.be.true;
             expect(new EndpointModel(dataIsMapped2).isMappedCollection).to.be.true;
             expect(new EndpointModel(dataIsNotMapped).isMappedCollection).to.be.false;
-            expect(new EndpointModel(dataNoType).isMappedCollection).to.be.false;
         });
 
         it("should correctly determine isGuestCollection based on entityType", () => {
-            const dataIsGuest1 = { entity_type: EndpointEntityType.GCP_GUEST_COLLECTION };
-            const dataIsGuest2 = { entity_type: EndpointEntityType.GCSV5_GUEST_COLLECTION };
-            const dataIsNotGuest = { entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
-            const dataNoType = {};
+            const dataIsGuest1 = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_GUEST_COLLECTION,
+            };
+            const dataIsGuest2 = {
+                id: "ep2",
+                entity_type: EndpointEntityType.GCSV5_GUEST_COLLECTION,
+            };
+            const dataIsNotGuest = {
+                id: "ep3",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            };
 
             expect(new EndpointModel(dataIsGuest1).isGuestCollection).to.be.true;
             expect(new EndpointModel(dataIsGuest2).isGuestCollection).to.be.true;
             expect(new EndpointModel(dataIsNotGuest).isGuestCollection).to.be.false;
-            expect(new EndpointModel(dataNoType).isGuestCollection).to.be.false;
         });
     });
 
     describe("rawData", () => {
         it("should return a shallow copy of the original endpoint data", () => {
-            const originalData = { id: "ep1", name: "test", nested: { key: "value" } };
+            const originalData = {
+                id: "ep1",
+                name: "test",
+                entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION,
+                nested: { key: "value" },
+            };
             const model = new EndpointModel(originalData);
-            const rawData = model.rawData;
+            const { rawData } = model;
 
             expect(rawData).to.deep.equal(originalData);
             expect(rawData).to.not.equal(originalData);
@@ -244,7 +309,11 @@ describe("EndpointModel", () => {
     describe("collections Getter", () => {
         it("should return a shallow copy of the internal collections array", () => {
             const originalCollections = [{ id: "coll1" }, { id: "coll2" }];
-            const endpointData = { collections: originalCollections };
+            const endpointData = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                collections: originalCollections,
+            };
             const model = new EndpointModel(endpointData);
             const collectionsCopy = model.collections;
 
@@ -256,7 +325,10 @@ describe("EndpointModel", () => {
         });
 
         it("should return an empty array if original data had no collections", () => {
-            const endpointData = {};
+            const endpointData = {
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            };
             const model = new EndpointModel(endpointData);
             const collectionsCopy = model.collections;
 
@@ -266,27 +338,50 @@ describe("EndpointModel", () => {
 
     describe("canTransfer", () => {
         it("should return true if connected and not busy", () => {
-            const model = new EndpointModel({ is_connected: true, in_use: false });
+            const model = new EndpointModel({
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                is_connected: true,
+                in_use: false,
+            });
             expect(model.canTransfer()).to.be.true;
         });
 
         it("should return false if not connected", () => {
-            const model = new EndpointModel({ is_connected: false, in_use: false });
+            const model = new EndpointModel({
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                is_connected: false,
+                in_use: false,
+            });
             expect(model.canTransfer()).to.be.false;
         });
 
         it("should return false if busy", () => {
-            const model = new EndpointModel({ is_connected: true, in_use: true });
+            const model = new EndpointModel({
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                is_connected: true,
+                in_use: true,
+            });
             expect(model.canTransfer()).to.be.false;
         });
 
         it("should return false if not connected and busy", () => {
-            const model = new EndpointModel({ is_connected: false, in_use: true });
+            const model = new EndpointModel({
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+                is_connected: false,
+                in_use: true,
+            });
             expect(model.canTransfer()).to.be.false;
         });
 
         it("should return false if connection/busy status is unknown (default)", () => {
-            const model = new EndpointModel({});
+            const model = new EndpointModel({
+                id: "ep1",
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            });
             expect(model.canTransfer()).to.be.false;
         });
     });
@@ -332,19 +427,6 @@ describe("EndpointModel", () => {
                 owner: "offline@owner.com",
                 status: "Disconnected",
                 entityType: EndpointEntityType.GCSV5_ENDPOINT,
-            });
-        });
-
-        it("should handle default/missing values gracefully", () => {
-            const model = new EndpointModel({});
-            const attributes = model.getSearchAttributes();
-
-            expect(attributes).to.deep.equal({
-                id: "",
-                displayName: "Unknown Endpoint",
-                owner: "Unknown owner",
-                status: "Disconnected",
-                entityType: null,
             });
         });
     });

--- a/web/test/endpoint-model.test.js
+++ b/web/test/endpoint-model.test.js
@@ -1,0 +1,351 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { EndpointEntityType, EndpointModel } from "../static/models/endpoint-model.js";
+
+describe("EndpointEntityType", () => {
+    it("should contain the correct enum string values", () => {
+        expect(EndpointEntityType.GCP_MAPPED_COLLECTION).to.equal("GCP_mapped_collection");
+        expect(EndpointEntityType.GCP_GUEST_COLLECTION).to.equal("GCP_guest_collection");
+        expect(EndpointEntityType.GCSV5_ENDPOINT).to.equal("GCSv5_endpoint");
+        expect(EndpointEntityType.GCSV5_MAPPED_COLLECTION).to.equal("GCSv5_mapped_collection");
+        expect(EndpointEntityType.GCSV5_GUEST_COLLECTION).to.equal("GCSv5_guest_collection");
+        expect(EndpointEntityType.GCSV4_HOST).to.equal("GCSv4_host");
+        expect(EndpointEntityType.GCSV4_SHARE).to.equal("GCSv4_share");
+    });
+
+    describe("isMappedCollection", () => {
+        it("should return true for mapped collection types", () => {
+            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCP_MAPPED_COLLECTION))
+                .to.be.true;
+            expect(
+                EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV5_MAPPED_COLLECTION),
+            ).to.be.true;
+        });
+
+        it("should return false for non-mapped collection types", () => {
+            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCP_GUEST_COLLECTION))
+                .to.be.false;
+            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV5_ENDPOINT)).to.be
+                .false;
+            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV5_GUEST_COLLECTION))
+                .to.be.false;
+            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV4_HOST)).to.be
+                .false;
+            expect(EndpointEntityType.isMappedCollection(EndpointEntityType.GCSV4_SHARE)).to.be
+                .false;
+            expect(EndpointEntityType.isMappedCollection("some_other_type")).to.be.false;
+            expect(EndpointEntityType.isMappedCollection(null)).to.be.false;
+            expect(EndpointEntityType.isMappedCollection(undefined)).to.be.false;
+        });
+    });
+
+    describe("isGuestCollection", () => {
+        it("should return true for guest collection types", () => {
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCP_GUEST_COLLECTION)).to
+                .be.true;
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV5_GUEST_COLLECTION))
+                .to.be.true;
+        });
+
+        it("should return false for non-guest collection types", () => {
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCP_MAPPED_COLLECTION))
+                .to.be.false;
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV5_ENDPOINT)).to.be
+                .false;
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV5_MAPPED_COLLECTION))
+                .to.be.false;
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV4_HOST)).to.be.false;
+            expect(EndpointEntityType.isGuestCollection(EndpointEntityType.GCSV4_SHARE)).to.be
+                .false;
+            expect(EndpointEntityType.isGuestCollection("some_other_type")).to.be.false;
+            expect(EndpointEntityType.isGuestCollection(null)).to.be.false;
+            expect(EndpointEntityType.isGuestCollection(undefined)).to.be.false;
+        });
+    });
+
+    describe("requiresConsent", () => {
+        it("should return true only for GCSv5 mapped collection type", () => {
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV5_MAPPED_COLLECTION))
+                .to.be.true;
+        });
+
+        it("should return false for other types", () => {
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCP_MAPPED_COLLECTION)).to
+                .be.false;
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCP_GUEST_COLLECTION)).to
+                .be.false;
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV5_ENDPOINT)).to.be
+                .false;
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV5_GUEST_COLLECTION)).to
+                .be.false;
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV4_HOST)).to.be.false;
+            expect(EndpointEntityType.requiresConsent(EndpointEntityType.GCSV4_SHARE)).to.be.false;
+            expect(EndpointEntityType.requiresConsent("some_other_type")).to.be.false;
+            expect(EndpointEntityType.requiresConsent(null)).to.be.false;
+            expect(EndpointEntityType.requiresConsent(undefined)).to.be.false;
+        });
+    });
+});
+
+describe("EndpointModel", () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe("Constructor and Basic Getters", () => {
+        it("should initialize with default values when no data is provided", () => {
+            const endpointData = {};
+            const model = new EndpointModel(endpointData);
+
+            expect(model.id).to.equal("");
+            expect(model.displayName).to.equal("Unknown Endpoint");
+            expect(model.entityType).to.be.null;
+            expect(model.collections).to.deep.equal([]);
+            expect(model.ownerString).to.equal("Unknown owner");
+            expect(model.isConnected).to.be.false;
+            expect(model.isBusy).to.be.false;
+            expect(model.rawData).to.deep.equal({});
+        });
+
+        it("should initialize correctly with typical endpoint data", () => {
+            const endpointData = {
+                id: "ep123",
+                display_name: "My Test Endpoint",
+                entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION,
+                collections: [{ id: "coll1" }, { id: "coll2" }],
+                owner_string: "testuser#globusid",
+                is_connected: true,
+                in_use: false,
+                other_prop: "value",
+            };
+            const model = new EndpointModel(endpointData);
+
+            expect(model.id).to.equal("ep123");
+            expect(model.displayName).to.equal("My Test Endpoint");
+            expect(model.entityType).to.equal(EndpointEntityType.GCSV5_MAPPED_COLLECTION);
+            expect(model.collections).to.deep.equal([{ id: "coll1" }, { id: "coll2" }]);
+            expect(model.ownerString).to.equal("testuser#globusid");
+            expect(model.isConnected).to.be.true;
+            expect(model.isBusy).to.be.false;
+            expect(model.rawData).to.deep.equal(endpointData);
+        });
+
+        it("should handle display name fallback logic", () => {
+            const dataWithName = { display_name: "Display Name" };
+            const dataWithCanonical = { canonical_name: "Canonical Name" };
+            const dataWithBoth = { display_name: "Display Name", canonical_name: "Canonical Name" };
+            const dataWithNeither = {};
+
+            expect(new EndpointModel(dataWithName).displayName).to.equal("Display Name");
+            expect(new EndpointModel(dataWithCanonical).displayName).to.equal("Canonical Name");
+            expect(new EndpointModel(dataWithBoth).displayName).to.equal("Display Name");
+            expect(new EndpointModel(dataWithNeither).displayName).to.equal("Unknown Endpoint");
+        });
+
+        it("should handle owner string fallback logic", () => {
+            const dataWithOwnerString = { owner_string: "owner@domain.org" };
+            const dataWithOwnerId = { owner_id: "owner123" };
+            const dataWithOwnerIdAndUser = { owner_id: "owner123", username: "testuser" };
+            const dataWithAll = {
+                owner_string: "owner@domain.org",
+                owner_id: "owner123",
+                username: "testuser",
+            };
+            const dataWithNeither = {};
+
+            expect(new EndpointModel(dataWithOwnerString).ownerString).to.equal("owner@domain.org");
+            expect(new EndpointModel(dataWithOwnerId).ownerString).to.equal("User#owner123");
+            expect(new EndpointModel(dataWithOwnerIdAndUser).ownerString).to.equal(
+                "testuser#owner123",
+            );
+            expect(new EndpointModel(dataWithAll).ownerString).to.equal("owner@domain.org");
+            expect(new EndpointModel(dataWithNeither).ownerString).to.equal("Unknown owner");
+        });
+
+        it("should correctly map is_connected and in_use to isConnected and isBusy", () => {
+            const dataConnectedNotBusy = { is_connected: true, in_use: false };
+            const dataDisconnectedNotBusy = { is_connected: false, in_use: false };
+            const dataConnectedBusy = { is_connected: true, in_use: true };
+            const dataDisconnectedBusy = { is_connected: false, in_use: true };
+            const dataMissing = {};
+
+            let model = new EndpointModel(dataConnectedNotBusy);
+            expect(model.isConnected).to.be.true;
+            expect(model.isBusy).to.be.false;
+
+            model = new EndpointModel(dataDisconnectedNotBusy);
+            expect(model.isConnected).to.be.false;
+            expect(model.isBusy).to.be.false;
+
+            model = new EndpointModel(dataConnectedBusy);
+            expect(model.isConnected).to.be.true;
+            expect(model.isBusy).to.be.true;
+
+            model = new EndpointModel(dataDisconnectedBusy);
+            expect(model.isConnected).to.be.false;
+            expect(model.isBusy).to.be.true;
+
+            model = new EndpointModel(dataMissing);
+            expect(model.isConnected).to.be.false;
+            expect(model.isBusy).to.be.false;
+        });
+    });
+
+    describe("Derived Getters (requiresConsent, isMappedCollection, isGuestCollection)", () => {
+        it("should correctly determine requiresConsent based on entityType", () => {
+            const dataRequiresConsent = { entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION };
+            const dataDoesNotRequireConsent = {
+                entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION,
+            };
+            const dataNoType = {};
+
+            expect(new EndpointModel(dataRequiresConsent).requiresConsent).to.be.true;
+            expect(new EndpointModel(dataDoesNotRequireConsent).requiresConsent).to.be.false;
+            expect(new EndpointModel(dataNoType).requiresConsent).to.be.false;
+        });
+
+        it("should correctly determine isMappedCollection based on entityType", () => {
+            const dataIsMapped1 = { entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
+            const dataIsMapped2 = { entity_type: EndpointEntityType.GCSV5_MAPPED_COLLECTION };
+            const dataIsNotMapped = { entity_type: EndpointEntityType.GCP_GUEST_COLLECTION };
+            const dataNoType = {};
+
+            expect(new EndpointModel(dataIsMapped1).isMappedCollection).to.be.true;
+            expect(new EndpointModel(dataIsMapped2).isMappedCollection).to.be.true;
+            expect(new EndpointModel(dataIsNotMapped).isMappedCollection).to.be.false;
+            expect(new EndpointModel(dataNoType).isMappedCollection).to.be.false;
+        });
+
+        it("should correctly determine isGuestCollection based on entityType", () => {
+            const dataIsGuest1 = { entity_type: EndpointEntityType.GCP_GUEST_COLLECTION };
+            const dataIsGuest2 = { entity_type: EndpointEntityType.GCSV5_GUEST_COLLECTION };
+            const dataIsNotGuest = { entity_type: EndpointEntityType.GCP_MAPPED_COLLECTION };
+            const dataNoType = {};
+
+            expect(new EndpointModel(dataIsGuest1).isGuestCollection).to.be.true;
+            expect(new EndpointModel(dataIsGuest2).isGuestCollection).to.be.true;
+            expect(new EndpointModel(dataIsNotGuest).isGuestCollection).to.be.false;
+            expect(new EndpointModel(dataNoType).isGuestCollection).to.be.false;
+        });
+    });
+
+    describe("rawData", () => {
+        it("should return a shallow copy of the original endpoint data", () => {
+            const originalData = { id: "ep1", name: "test", nested: { key: "value" } };
+            const model = new EndpointModel(originalData);
+            const rawData = model.rawData;
+
+            expect(rawData).to.deep.equal(originalData);
+            expect(rawData).to.not.equal(originalData);
+            expect(rawData.nested).to.equal(originalData.nested);
+        });
+    });
+
+    describe("collections Getter", () => {
+        it("should return a shallow copy of the internal collections array", () => {
+            const originalCollections = [{ id: "coll1" }, { id: "coll2" }];
+            const endpointData = { collections: originalCollections };
+            const model = new EndpointModel(endpointData);
+            const collectionsCopy = model.collections;
+
+            expect(collectionsCopy).to.deep.equal(originalCollections);
+            expect(collectionsCopy).to.not.equal(originalCollections);
+            if (collectionsCopy.length > 0) {
+                expect(collectionsCopy[0]).to.equal(originalCollections[0]);
+            }
+        });
+
+        it("should return an empty array if original data had no collections", () => {
+            const endpointData = {};
+            const model = new EndpointModel(endpointData);
+            const collectionsCopy = model.collections;
+
+            expect(collectionsCopy).to.deep.equal([]);
+        });
+    });
+
+    describe("canTransfer", () => {
+        it("should return true if connected and not busy", () => {
+            const model = new EndpointModel({ is_connected: true, in_use: false });
+            expect(model.canTransfer()).to.be.true;
+        });
+
+        it("should return false if not connected", () => {
+            const model = new EndpointModel({ is_connected: false, in_use: false });
+            expect(model.canTransfer()).to.be.false;
+        });
+
+        it("should return false if busy", () => {
+            const model = new EndpointModel({ is_connected: true, in_use: true });
+            expect(model.canTransfer()).to.be.false;
+        });
+
+        it("should return false if not connected and busy", () => {
+            const model = new EndpointModel({ is_connected: false, in_use: true });
+            expect(model.canTransfer()).to.be.false;
+        });
+
+        it("should return false if connection/busy status is unknown (default)", () => {
+            const model = new EndpointModel({});
+            expect(model.canTransfer()).to.be.false;
+        });
+    });
+
+    describe("getSearchAttributes", () => {
+        it("should return the correct attributes object based on model state", () => {
+            const endpointData = {
+                id: "ep999",
+                display_name: "Searchable Endpoint",
+                entity_type: EndpointEntityType.GCSV4_HOST,
+                owner_id: "owner999",
+                username: "searchuser",
+                is_connected: true,
+                in_use: false,
+            };
+            const model = new EndpointModel(endpointData);
+            const attributes = model.getSearchAttributes();
+
+            expect(attributes).to.deep.equal({
+                id: "ep999",
+                displayName: "Searchable Endpoint",
+                owner: "searchuser#owner999",
+                status: "Connected",
+                entityType: EndpointEntityType.GCSV4_HOST,
+            });
+        });
+
+        it("should reflect disconnected status correctly", () => {
+            const endpointData = {
+                id: "ep000",
+                display_name: "Offline Endpoint",
+                entity_type: EndpointEntityType.GCSV5_ENDPOINT,
+                owner_string: "offline@owner.com",
+                is_connected: false,
+                in_use: false,
+            };
+            const model = new EndpointModel(endpointData);
+            const attributes = model.getSearchAttributes();
+
+            expect(attributes).to.deep.equal({
+                id: "ep000",
+                displayName: "Offline Endpoint",
+                owner: "offline@owner.com",
+                status: "Disconnected",
+                entityType: EndpointEntityType.GCSV5_ENDPOINT,
+            });
+        });
+
+        it("should handle default/missing values gracefully", () => {
+            const model = new EndpointModel({});
+            const attributes = model.getSearchAttributes();
+
+            expect(attributes).to.deep.equal({
+                id: "",
+                displayName: "Unknown Endpoint",
+                owner: "Unknown owner",
+                status: "Disconnected",
+                entityType: null,
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Ticket  

[DAPS-1388](https://github.com/ORNL/DataFed/issues/1388)

## Description 

We were evaluating if a collection was mapped on the frontend by if endpoint data had `entity_type.includes("mapped")`.

Due to [Globus Connect Personal collections not needing consent](https://docs.globus.org/api/transfer/endpoints_and_collections/#:~:text=document%20refers%20to.-,GCP_mapped_collection,-These%20entities%20represent), we needed to add an entity type checker that can encapsulate the logic.


[Source](https://docs.globus.org/api/transfer/endpoints_and_collections/#:~:text=document%20refers%20to.-,GCP_mapped_collection,-These%20entities%20represent)
> These entities represent top level installs of Globus Connect Personal. They are managed in Transfer and do not require additional consent for data access. The gcp_connected field can be used to determine if the Globus Connect Personal client is currently running and connected to Globus.

## How Has This Been Tested?  

### Manually
1. Go to DataFed
2. Login
3. Go to the dashboard
4. Create a data record
5. Ensure it has data from the source
6. Right-click the data record
7. Select the download option from the menu
8. Ensure the data record selected has its radio box checked
9. Input Globus Endpoint UUID (???)
10. Press the browse button
11. Select directory to download file to
12. Press Submit CTA
13. Check GCP location

## Artifacts (if appropriate):  

### Download File to Globus Connect Personal

https://github.com/user-attachments/assets/9fe88940-2d2f-409b-b65f-f1e3fae0df7f

### Globus Connect Personal Disconnect

https://github.com/user-attachments/assets/21b61196-18ec-4636-b42e-9fdf3edf81f0

### Tests
<img width="963" alt="Screenshot 2025-04-23 at 11 29 05 PM" src="https://github.com/user-attachments/assets/a199dbd4-a329-48f5-90d4-9f07e1c19c8c" />

## Summary by Sourcery

Add comprehensive support for Globus Connect Personal (GCP) endpoints by introducing an EndpointModel to handle endpoint type detection and consent requirements

New Features:
- Introduced EndpointModel to encapsulate Globus endpoint metadata and type checking
- Added support for detecting different Globus endpoint entity types
- Implemented consent requirement detection for different endpoint types

Enhancements:
- Improved endpoint search and selection logic in transfer endpoint manager
- Enhanced error handling for endpoint browsing and transfers
- Added more robust type checking for Globus endpoint collections

Tests:
- Added unit test file for EndpointModel to validate endpoint type and consent logic