### PR TITLE
Set reasonable default that will help filling in repo form for core t…

### DIFF
--- a/compose/all/compose.yml
+++ b/compose/all/compose.yml
@@ -117,6 +117,8 @@ services:
       - ${DATAFED_HOST_COLLECTION_MOUNT}:${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}
     ports:
       - 9000:9000 # Communication core server
+    networks:
+      - datafed-internal
 
 # Needs host port 80 for apache
 # Needs ports 50000 - 51000 for GridFTP

--- a/scripts/compose_generate_env.sh
+++ b/scripts/compose_generate_env.sh
@@ -113,9 +113,16 @@ fi
 
 if [ -z "${DATAFED_COMPOSE_REPO_DOMAIN}" ]
 then
-  # Make the repo domain equivalent to the COMPOSE DOMAIN unless it is specified
-  # explicitly
-  local_DATAFED_COMPOSE_REPO_DOMAIN="${local_DATAFED_COMPOSE_DOMAIN}"
+
+  # Make the repo domain equivalent to the COMPOSE DOMAIN unless REPO_DOMAIN is
+  # specified explicitly, and it is not localhost, communication between the
+  # core container and the repo container will not resolve using localhost.
+  if [ "${local_DATAFED_COMPOSE_DOMAIN}" == "localhost" ]
+  then
+    local_DATAFED_COMPOSE_REPO_DOMAIN=""
+  else
+    local_DATAFED_COMPOSE_REPO_DOMAIN="${local_DATAFED_COMPOSE_DOMAIN}"
+  fi
 else
   local_DATAFED_COMPOSE_REPO_DOMAIN=$(printenv DATAFED_COMPOSE_REPO_DOMAIN)
 fi


### PR DESCRIPTION
# PR Description

This PR helps mitigate problems with core and repo communication. The REPO_DOMAIN is used to create the repo form to register a repo with the core service. The default localhost that was being used causes problems in a compose environment because the core server is unable to properly resolve it. This PR sets a reasonable default and leaves it blank if localhost is specified.

# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added
