### PR TITLE
1396 add missing python module

### DIFF
--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -149,7 +149,7 @@ install_protobuf() {
     cd python
     init_python
     source "${DATAFED_PYTHON_ENV}/bin/activate"
-    LD_LIBRARY_PATH="$LD_LIBRARY_PATH" PATH="$PATH" python3 -m pip install numpy
+    LD_LIBRARY_PATH="$LD_LIBRARY_PATH" PATH="$PATH" python3 -m pip install numpy tzdata
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH" PATH="$PATH" python3 setup.py build
     LD_LIBRARY_PATH="$LD_LIBRARY_PATH" PATH="$PATH" python3 setup.py test
     # Because we have activaited a venv we don't want to use the --user flag


### PR DESCRIPTION
# PR Description

New version of protobuf leads to errors if tzdata module is missing. This PR adds it as part of the protobuf install.

# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added
