### PR TITLE
Switch to using .tar file install of libsodium

### DIFF
--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -177,14 +177,10 @@ install_libsodium() {
       # sudo required because of egg file
       "$SUDO_CMD" rm -rf "${PROJECT_ROOT}/external/libsodium"
     fi
-    # Here we are using clone instead of submodule update, because submodule
-    # requires the .git folder exist and the current folder be considered a repo
-    # this creates problems in docker because each time a commit is made the 
-    # .git folder contents are changed causing a fresh rebuild of all containers
-    git clone https://github.com/jedisct1/libsodium.git "${PROJECT_ROOT}/external/libsodium"
+
+    wget "https://download.libsodium.org/libsodium/releases/libsodium-${DATAFED_PROTOBUF_VERSION}.tar.gz" -C "./external"
+    tar -xvzf "./external/libsodium-${DATAFED_PROTOBUF_VERSION}.tar.gz" -C "./external/"
     cd "${PROJECT_ROOT}/external/libsodium"
-    git checkout "$DATAFED_LIBSODIUM_VERSION"
-    ./autogen.sh
     # Build static ONLY!!!!
     # Note if zmq detects a shared sodium library it will grab it no matter what
     # --enable-shared=no must be set here


### PR DESCRIPTION
# PR Description

Depends on the tar file for libsodium

# Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Switch from git cloning to downloading a tar file for libsodium dependency installation

Enhancements:
- Modify libsodium installation method to use wget and tar extraction instead of git clone

Chores:
- Simplify dependency installation process by removing git-related steps