### PR TITLE
Adjusted Base Image to be debian:bookworm-slim

### DIFF
--- a/compose/metadata/generate_build_args.sh
+++ b/compose/metadata/generate_build_args.sh
@@ -31,5 +31,5 @@ fi
 
 # Needs to append to the ./build-args.sh file not overwrite.
 cat << EOF >> "$BUILD_ARG_FILE"
-BASE_IMAGE=ubuntu:focal
+BASE_IMAGE=debian:bookworm-slim
 EOF


### PR DESCRIPTION
## Description 

Changed the base image from focal:ubuntu to debian:bookworm-slim

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Build:
- Change BASE_IMAGE in generate_build_args.sh to debian:bookworm-slim