### PR TITLE
[DAPS-1527] - Bug in CMake Protobuf build causing build failure due to race condition.

### DIFF
--- a/common/proto/common/CMakeLists.txt
+++ b/common/proto/common/CMakeLists.txt
@@ -1,21 +1,24 @@
 cmake_minimum_required (VERSION 3.17.0)
 
-add_library( protobuf-target ${ProtoFiles} )
-
 # Create the .cpp and .hpp files
 protobuf_generate(
-  TARGET protobuf-target
   LANGUAGE cpp 
+  PROTOS ${ProtoFiles}
   IMPORT_DIRS "${DataFed_SOURCE_DIR}/common/proto/common"
   OUT_VAR protobuf-generated-files
 )
 
+add_custom_target(protobuf-gen-target DEPENDS ${protobuf-generated-files})
+
 # make sure that datafed-protobuf is dependent on the cpp files when it compiles
 if(BUILD_SHARED_LIBS)
-  add_library( datafed-protobuf SHARED ${protobuf-generated-files} )
+  add_library( datafed-protobuf SHARED ${protobuf-generated-files}  )
 else()
   add_library( datafed-protobuf STATIC ${protobuf-generated-files} )
 endif()
+# The following command makes sure that the protobuf files are generated
+# before attempting to compile with them.
+add_dependencies(datafed-protobuf protobuf-gen-target)
 set_target_properties(datafed-protobuf PROPERTIES POSITION_INDEPENDENT_CODE ON SOVERSION ${DATAFED_COMMON_PROTOCOL_API_MAJOR} VERSION ${DATAFED_COMMON_PROTOCOL_API_MAJOR}.${DATAFED_COMMON_PROTOCOL_API_MINOR}.${DATAFED_COMMON_PROTOCOL_API_PATCH} )
 target_link_libraries( datafed-protobuf protobuf::libprotobuf protobuf::libprotoc protobuf::libprotobuf-lite)
 target_include_directories( datafed-protobuf INTERFACE ${PROJECT_BINARY_DIR}/common/proto)


### PR DESCRIPTION
…ent race condition.

## Ticket  

#1527 and #1442

## Description 

Essentially, cmake is generating the protobuf files at the same time it is trying to build with them leading to compiler issues.

## How Has This Been Tested?  

This has been difficult to reproduce because it is a timing item. 

## Artifacts (if appropriate):  

Other than the CI consistently passing, it will be difficult to know if this PR fixes the item. However, explicitly adding dependencies will not hurt.

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Make protobuf file generation and compile order explicit to prevent race conditions.

Bug Fixes:
- Prevent race condition by ensuring protobuf files are generated before building datafed-protobuf.

Build:
- Introduce a custom 'protobuf-gen-target' that depends on generated protobuf files.
- Add an explicit add_dependencies call to make datafed-protobuf depend on protobuf-gen-target.
- Update protobuf_generate invocation to use PROTOS and OUT_VAR and remove the deprecated TARGET parameter.