### PR TITLE
[DAPS-1514] Integrate validation into existing repo router

### DIFF
--- a/core/database/foxx/api/repo_router.js
+++ b/core/database/foxx/api/repo_router.js
@@ -7,6 +7,7 @@ const joi = require("joi");
 const g_db = require("@arangodb").db;
 const g_lib = require("./support");
 const g_tasks = require("./tasks");
+const { validateGlobusConfig, validatePartialGlobusConfig } = require("./repository/validation");
 
 module.exports = router;
 
@@ -121,27 +122,31 @@ router
                     g_lib.procInputParam(req.body, "summary", false, obj);
                     g_lib.procInputParam(req.body, "domain", false, obj);
 
-                    if (!obj.path.startsWith("/"))
-                        throw [
-                            g_lib.ERR_INVALID_PARAM,
-                            "Repository path must be an absolute path file system path.",
-                        ];
-
-                    if (!obj.path.endsWith("/")) obj.path += "/";
-
-                    var idx = obj.path.lastIndexOf("/", obj.path.length - 2);
-                    if (obj.path.substr(idx + 1, obj.path.length - idx - 2) != obj._key)
-                        throw [
-                            g_lib.ERR_INVALID_PARAM,
-                            "Last part of repository path must be repository ID suffix (" +
-                                obj._key +
-                                ")",
-                        ];
-
                     if (req.body.exp_path) {
                         obj.exp_path = req.body.exp_path;
-                        if (!obj.exp_path.endsWith("/")) obj.path += "/";
                     }
+
+                    // Validate the configuration
+                    const validationResult = validateGlobusConfig({
+                        id: obj._key,
+                        title: obj.title,
+                        capacity: obj.capacity,
+                        admins: req.body.admins,
+                        pub_key: obj.pub_key,
+                        address: obj.address,
+                        endpoint: obj.endpoint,
+                        domain: obj.domain,
+                        path: obj.path,
+                        exp_path: obj.exp_path,
+                    });
+
+                    if (!validationResult.ok) {
+                        throw [validationResult.error.code, validationResult.error.message];
+                    }
+
+                    // Ensure path ends with / for saving
+                    if (!obj.path.endsWith("/")) obj.path += "/";
+                    if (obj.exp_path && !obj.exp_path.endsWith("/")) obj.exp_path += "/";
 
                     var repo = g_db.repo.save(obj, {
                         returnNew: true,
@@ -211,40 +216,40 @@ router
                     g_lib.procInputParam(req.body, "summary", true, obj);
                     g_lib.procInputParam(req.body, "domain", true, obj);
 
-                    if (req.body.path) {
-                        if (!req.body.path.startsWith("/"))
-                            throw [
-                                g_lib.ERR_INVALID_PARAM,
-                                "Repository path must be an absolute path file system path.",
-                            ];
-
-                        obj.path = req.body.path;
-                        if (!obj.path.endsWith("/")) obj.path += "/";
-
-                        // Last part of storage path MUST end with the repo ID
-                        var idx = obj.path.lastIndexOf("/", obj.path.length - 2);
-                        var key = req.body.id.substr(5);
-                        if (obj.path.substr(idx + 1, obj.path.length - idx - 2) != key)
-                            throw [
-                                g_lib.ERR_INVALID_PARAM,
-                                "Last part of repository path must be repository ID suffix (" +
-                                    key +
-                                    ")",
-                            ];
-                    }
-
-                    if (req.body.exp_path) {
-                        obj.exp_path = req.body.exp_path;
-                        if (!obj.exp_path.endsWith("/")) obj.exp_path += "/";
-                    }
-
+                    if (req.body.path) obj.path = req.body.path;
+                    if (req.body.exp_path) obj.exp_path = req.body.exp_path;
                     if (req.body.capacity) obj.capacity = req.body.capacity;
-
                     if (req.body.pub_key) obj.pub_key = req.body.pub_key;
-
                     if (req.body.address) obj.address = req.body.address;
-
                     if (req.body.endpoint) obj.endpoint = req.body.endpoint;
+
+                    // Extract repo key from ID for validation
+                    var key = req.body.id.substr(5);
+
+                    // Validate the partial configuration
+                    const updateConfig = {
+                        title: req.body.title,
+                        domain: req.body.domain,
+                        path: req.body.path,
+                        exp_path: req.body.exp_path,
+                        capacity: req.body.capacity,
+                        pub_key: req.body.pub_key,
+                        address: req.body.address,
+                        endpoint: req.body.endpoint,
+                        admins: req.body.admins,
+                    };
+
+                    // Remove undefined fields
+                    Object.keys(updateConfig).forEach(k => updateConfig[k] === undefined && delete updateConfig[k]);
+
+                    const validationResult = validatePartialGlobusConfig(updateConfig, key);
+                    if (!validationResult.ok) {
+                        throw [validationResult.error.code, validationResult.error.message];
+                    }
+
+                    // Ensure paths end with / for saving
+                    if (obj.path && !obj.path.endsWith("/")) obj.path += "/";
+                    if (obj.exp_path && !obj.exp_path.endsWith("/")) obj.exp_path += "/";
 
                     var repo = g_db._update(req.body.id, obj, {
                         returnNew: true,

--- a/core/database/foxx/api/repo_router.js
+++ b/core/database/foxx/api/repo_router.js
@@ -9,6 +9,18 @@ const g_lib = require("./support");
 const g_tasks = require("./tasks");
 const { validateGlobusConfig, validatePartialGlobusConfig } = require("./repository/validation");
 
+// Helper function to prepare repository data for saving
+const prepareRepoData = (obj) => {
+    // Ensure paths end with / for saving
+    if (obj.path && !obj.path.endsWith("/")) {
+        obj.path += "/";
+    }
+    if (obj.exp_path && !obj.exp_path.endsWith("/")) {
+        obj.exp_path += "/";
+    }
+    return obj;
+};
+
 module.exports = router;
 
 router
@@ -144,9 +156,8 @@ router
                         throw [validationResult.error.code, validationResult.error.message];
                     }
 
-                    // Ensure path ends with / for saving
-                    if (!obj.path.endsWith("/")) obj.path += "/";
-                    if (obj.exp_path && !obj.exp_path.endsWith("/")) obj.exp_path += "/";
+                    // Prepare repository data for saving
+                    prepareRepoData(obj);
 
                     var repo = g_db.repo.save(obj, {
                         returnNew: true,
@@ -224,7 +235,7 @@ router
                     if (req.body.endpoint) obj.endpoint = req.body.endpoint;
 
                     // Extract repo key from ID for validation
-                    var key = req.body.id.substr(5);
+                    const key = req.body.id.substr(5);
 
                     // Validate the partial configuration
                     const updateConfig = {
@@ -249,9 +260,8 @@ router
                         throw [validationResult.error.code, validationResult.error.message];
                     }
 
-                    // Ensure paths end with / for saving
-                    if (obj.path && !obj.path.endsWith("/")) obj.path += "/";
-                    if (obj.exp_path && !obj.exp_path.endsWith("/")) obj.exp_path += "/";
+                    // Prepare repository data for saving
+                    prepareRepoData(obj);
 
                     var repo = g_db._update(req.body.id, obj, {
                         returnNew: true,

--- a/core/database/foxx/api/repo_router.js
+++ b/core/database/foxx/api/repo_router.js
@@ -240,7 +240,9 @@ router
                     };
 
                     // Remove undefined fields
-                    Object.keys(updateConfig).forEach(k => updateConfig[k] === undefined && delete updateConfig[k]);
+                    Object.keys(updateConfig).forEach(
+                        (k) => updateConfig[k] === undefined && delete updateConfig[k],
+                    );
 
                     const validationResult = validatePartialGlobusConfig(updateConfig, key);
                     if (!validationResult.ok) {

--- a/core/database/foxx/api/repository/factory.js
+++ b/core/database/foxx/api/repository/factory.js
@@ -30,7 +30,7 @@ const g_lib = require("../support");
  * @param {string[]} config.admins - Array of admin user IDs
  * @param {string} [config.endpoint] - Globus endpoint (required for GLOBUS type)
  * @param {string} [config.path] - File path (required for GLOBUS type)
- * @param {string} [config.pub_key] - Public SSH key (required for GLOBUS type)
+ * @param {string} [config.pub_key] - Public key (required for GLOBUS type)
  * @param {string} [config.address] - Network address (required for GLOBUS type)
  * @param {string} [config.exp_path] - Export path (optional for GLOBUS type)
  * @param {string} [config.domain] - Domain name (required for GLOBUS type)

--- a/core/database/foxx/api/repository/types.js
+++ b/core/database/foxx/api/repository/types.js
@@ -68,7 +68,7 @@ const createRepositoryData = ({
  * @param {object} config - Globus configuration object
  * @param {string} config.endpoint - Globus endpoint identifier
  * @param {string} config.path - Repository path on filesystem
- * @param {string} config.pub_key - Public SSH key for authentication
+ * @param {string} config.pub_key - Public key for authentication
  * @param {string} config.address - Network address
  * @param {string} [config.exp_path] - Export path
  * @param {string} config.domain - Domain name

--- a/core/database/foxx/api/repository/validation.js
+++ b/core/database/foxx/api/repository/validation.js
@@ -215,6 +215,82 @@ const validateAllocationParams = (params) => {
     return Result.ok(true);
 };
 
+// Validate partial Globus configuration for updates
+const validatePartialGlobusConfig = (config, repoId) => {
+    const errors = [];
+
+    // Validate individual fields if provided
+    if (config.title !== undefined) {
+        const titleValidation = validateNonEmptyString(config.title, "Repository title");
+        if (!titleValidation.ok) {
+            errors.push(titleValidation.error.message);
+        }
+    }
+
+    if (config.capacity !== undefined) {
+        if (typeof config.capacity !== "number" || config.capacity <= 0) {
+            errors.push("Repository capacity must be a positive number");
+        }
+    }
+
+    if (config.pub_key !== undefined) {
+        const pubKeyValidation = validateNonEmptyString(config.pub_key, "Public key");
+        if (!pubKeyValidation.ok) {
+            errors.push(pubKeyValidation.error.message);
+        }
+    }
+
+    if (config.address !== undefined) {
+        const addressValidation = validateNonEmptyString(config.address, "Address");
+        if (!addressValidation.ok) {
+            errors.push(addressValidation.error.message);
+        }
+    }
+
+    if (config.endpoint !== undefined) {
+        const endpointValidation = validateNonEmptyString(config.endpoint, "Endpoint");
+        if (!endpointValidation.ok) {
+            errors.push(endpointValidation.error.message);
+        }
+    }
+
+    if (config.domain !== undefined) {
+        const domainValidation = validateNonEmptyString(config.domain, "Domain");
+        if (!domainValidation.ok) {
+            errors.push(domainValidation.error.message);
+        }
+    }
+
+    if (config.path !== undefined) {
+        const pathResult = validateRepositoryPath(config.path, repoId);
+        if (!pathResult.ok) {
+            return pathResult;
+        }
+    }
+
+    if (config.exp_path !== undefined) {
+        const expPathResult = validatePOSIXPath(config.exp_path, "Export path");
+        if (!expPathResult.ok) {
+            return expPathResult;
+        }
+    }
+
+    if (config.admins !== undefined) {
+        if (!Array.isArray(config.admins) || config.admins.length === 0) {
+            errors.push("Repository must have at least one admin");
+        }
+    }
+
+    if (errors.length > 0) {
+        return Result.err({
+            code: g_lib.ERR_INVALID_PARAM,
+            message: errors.join("; "),
+        });
+    }
+
+    return Result.ok(true);
+};
+
 module.exports = {
     validateNonEmptyString,
     validateCommonFields,
@@ -223,4 +299,5 @@ module.exports = {
     validateGlobusConfig,
     validateMetadataConfig,
     validateAllocationParams,
+    validatePartialGlobusConfig,
 };

--- a/core/database/foxx/tests/validation.test.js
+++ b/core/database/foxx/tests/validation.test.js
@@ -10,6 +10,7 @@ const {
     validateGlobusConfig,
     validateMetadataConfig,
     validateAllocationParams,
+    validatePartialGlobusConfig,
 } = require("../api/repository/validation");
 
 describe("Repository Validation Tests", function () {
@@ -347,6 +348,81 @@ describe("Repository Validation Tests", function () {
             const result = validateAllocationParams(params);
             expect(result.ok).to.be.false;
             expect(result.error.message).to.include("Allocation path must be a string");
+        });
+    });
+
+    describe("validatePartialGlobusConfig", function () {
+        it("should accept empty configuration", function () {
+            const result = validatePartialGlobusConfig({}, "test-repo");
+            expect(result.ok).to.be.true;
+        });
+
+        it("should accept partial title update", function () {
+            const result = validatePartialGlobusConfig({ title: "New Title" }, "test-repo");
+            expect(result.ok).to.be.true;
+        });
+
+        it("should reject invalid title update", function () {
+            const result = validatePartialGlobusConfig({ title: "" }, "test-repo");
+            expect(result.ok).to.be.false;
+            expect(result.error.message).to.include("Repository title is required");
+        });
+
+        it("should accept partial capacity update", function () {
+            const result = validatePartialGlobusConfig({ capacity: 2000000 }, "test-repo");
+            expect(result.ok).to.be.true;
+        });
+
+        it("should reject invalid capacity update", function () {
+            const result = validatePartialGlobusConfig({ capacity: 0 }, "test-repo");
+            expect(result.ok).to.be.false;
+            expect(result.error.message).to.include("Repository capacity must be a positive number");
+        });
+
+        it("should accept path update with correct repo ID", function () {
+            const result = validatePartialGlobusConfig({ path: "/new/path/test-repo" }, "test-repo");
+            expect(result.ok).to.be.true;
+        });
+
+        it("should reject path update with wrong repo ID", function () {
+            const result = validatePartialGlobusConfig({ path: "/new/path/wrong-id" }, "test-repo");
+            expect(result.ok).to.be.false;
+            expect(result.error.message).to.include("must end with repository ID");
+        });
+
+        it("should validate multiple fields", function () {
+            const config = {
+                title: "Updated Title",
+                capacity: 3000000,
+                pub_key: "ssh-rsa UPDATED...",
+                address: "new.server.com",
+            };
+            const result = validatePartialGlobusConfig(config, "test-repo");
+            expect(result.ok).to.be.true;
+        });
+
+        it("should reject multiple invalid fields", function () {
+            const config = {
+                title: "",
+                capacity: -100,
+                pub_key: "",
+            };
+            const result = validatePartialGlobusConfig(config, "test-repo");
+            expect(result.ok).to.be.false;
+            expect(result.error.message).to.include("Repository title is required");
+            expect(result.error.message).to.include("Repository capacity must be a positive number");
+            expect(result.error.message).to.include("Public key is required");
+        });
+
+        it("should validate admin updates", function () {
+            const result = validatePartialGlobusConfig({ admins: ["user1", "user2"] }, "test-repo");
+            expect(result.ok).to.be.true;
+        });
+
+        it("should reject empty admin array", function () {
+            const result = validatePartialGlobusConfig({ admins: [] }, "test-repo");
+            expect(result.ok).to.be.false;
+            expect(result.error.message).to.include("Repository must have at least one admin");
         });
     });
 });

--- a/core/database/foxx/tests/validation.test.js
+++ b/core/database/foxx/tests/validation.test.js
@@ -196,7 +196,7 @@ describe("Repository Validation Tests", function () {
                 title: "Test Repository",
                 capacity: 1000000,
                 admins: ["user1"],
-                pub_key: "ssh-rsa AAAAB3...",
+                pub_key: "pubkey:AAAAB3...",
                 address: "server.example.com",
                 endpoint: "endpoint-id",
                 domain: "example.com",
@@ -284,7 +284,7 @@ describe("Repository Validation Tests", function () {
 
         it("should reject configuration with Globus fields", function () {
             const config = getValidMetadataConfig();
-            config.pub_key = "ssh-rsa AAAAB3...";
+            config.pub_key = "pubkey:AAAAB3...";
             config.endpoint = "endpoint-id";
             const result = validateMetadataConfig(config);
             expect(result.ok).to.be.false;
@@ -399,7 +399,7 @@ describe("Repository Validation Tests", function () {
             const config = {
                 title: "Updated Title",
                 capacity: 3000000,
-                pub_key: "ssh-rsa UPDATED...",
+                pub_key: "pubkey:UPDATED...",
                 address: "new.server.com",
             };
             const result = validatePartialGlobusConfig(config, "test-repo");

--- a/core/database/foxx/tests/validation.test.js
+++ b/core/database/foxx/tests/validation.test.js
@@ -376,11 +376,16 @@ describe("Repository Validation Tests", function () {
         it("should reject invalid capacity update", function () {
             const result = validatePartialGlobusConfig({ capacity: 0 }, "test-repo");
             expect(result.ok).to.be.false;
-            expect(result.error.message).to.include("Repository capacity must be a positive number");
+            expect(result.error.message).to.include(
+                "Repository capacity must be a positive number",
+            );
         });
 
         it("should accept path update with correct repo ID", function () {
-            const result = validatePartialGlobusConfig({ path: "/new/path/test-repo" }, "test-repo");
+            const result = validatePartialGlobusConfig(
+                { path: "/new/path/test-repo" },
+                "test-repo",
+            );
             expect(result.ok).to.be.true;
         });
 
@@ -410,7 +415,9 @@ describe("Repository Validation Tests", function () {
             const result = validatePartialGlobusConfig(config, "test-repo");
             expect(result.ok).to.be.false;
             expect(result.error.message).to.include("Repository title is required");
-            expect(result.error.message).to.include("Repository capacity must be a positive number");
+            expect(result.error.message).to.include(
+                "Repository capacity must be a positive number",
+            );
             expect(result.error.message).to.include("Public key is required");
         });
 


### PR DESCRIPTION
## Ticket

[DAPS-1514](https://github.com/ORNL/DataFed/issues/1514)

## Description

This PR integrates the validation logic from PR #1539 into the existing repository router endpoints. It replaces inline validation with reusable validation functions while maintaining backward compatibility.

**What's included:**
- Import validation functions into 
- Replace inline validation in  endpoint with 
- Add  for partial updates
- Update  endpoint to use partial validation
- Add comprehensive tests for partial validation

## How Has This Been Tested?

- Added tests
- Tests cover all update scenarios (single field, multiple fields, invalid data)
- Existing repository creation and update functionality preserved

## Artifacts

See CI