### PR TITLE
[DAPS-1529] Rework generate env script

### DIFF
--- a/compose/all/generate_env.sh
+++ b/compose/all/generate_env.sh
@@ -6,5 +6,5 @@ PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 # Variables specific to running the compose instance
 export DATAFED_COMPOSE_REPO_DOMAIN="datafed-repo"
 
-"${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)"
+"${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)" $@
 

--- a/compose/all/generate_env.sh
+++ b/compose/all/generate_env.sh
@@ -6,5 +6,5 @@ PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 # Variables specific to running the compose instance
 export DATAFED_COMPOSE_REPO_DOMAIN="datafed-repo"
 
-"${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)" $@
+"${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)" "$@"
 


### PR DESCRIPTION
## Ticket  

#1529  

## Description 

In this PR I rewrote a lot of the `compose_generate_env.sh` script so its behavior is more consistent and so that it is easier to use an existing `.env` file, and so that you can run it to generate certs even if they already exist.

## How Has This Been Tested?  

I verified multiple times that the files it generates are the same as it was before, and with all combinations of flags.

## Tasks

* [X] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [X] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [X] - A user has been assigned to work on the pr
