### PR TITLE
fix: Added appropriate move to AuthenticationManager

### DIFF
--- a/core/server/AuthenticationManager.cpp
+++ b/core/server/AuthenticationManager.cpp
@@ -36,6 +36,7 @@ AuthenticationManager::operator=(AuthenticationManager &&other) {
     m_next_purge = other.m_next_purge;
     m_purge_interval = other.m_purge_interval;
     m_purge_conditions = std::move(other.m_purge_conditions);
+    m_auth_mapper = std::move(other.m_auth_mapper);
   }
   return *this;
 }


### PR DESCRIPTION
## Ticket  
#1547 [[Bug] Missing Move Assignment in authentication manager](https://github.com/ORNL/DataFed/issues/1547)

## Description 
The authentication manager is missing the assignment of the member auth_mapper. This creates problems when the AuthMap is used because it will miss any settings that were used during construction of the AuthenticationManager. 

## Tasks

* [x] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [x] - Labels have been assigned to the pr
* [x] - A reviwer has been added
* [x] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Bug Fixes:
- Add missing move assignment of auth_mapper in AuthenticationManager move operator