### PR TITLE
[DAPS-1549] Fix memory bug - move assignment operator and destructor for GlobusAPI to handle curl cleanup safely

### DIFF
--- a/core/server/GlobusAPI.cpp
+++ b/core/server/GlobusAPI.cpp
@@ -48,16 +48,26 @@ GlobusAPI::GlobusAPI(LogContext log_context)
 
 GlobusAPI &GlobusAPI::operator=(GlobusAPI &&other) noexcept {
   if (this != &other) {
+    curl_easy_cleanup(m_curl_auth);
+    curl_easy_cleanup(m_curl_xfr);
     this->m_curl_xfr = other.m_curl_xfr;
     this->m_curl_auth = other.m_curl_auth;
+    other.m_curl_xfr = nullptr;
+    other.m_curl_auth = nullptr;
     this->m_log_context = other.m_log_context;
   }
   return *this;
 }
 
 GlobusAPI::~GlobusAPI() {
-  curl_easy_cleanup(m_curl_auth);
-  curl_easy_cleanup(m_curl_xfr);
+  if(m_curl_auth)
+  {
+    curl_easy_cleanup(m_curl_auth);
+  }
+  if(m_curl_xfr)
+  {
+    curl_easy_cleanup(m_curl_xfr);
+  }
 }
 
 long GlobusAPI::get(CURL *a_curl, const std::string &a_base_url,


### PR DESCRIPTION
## Ticket  

#1549 

## Description 

This PR refactors the move assignment operator and destructor of the GlobusAPI class to ensure proper and safe cleanup of the underlying CURL handles (m_curl_auth and m_curl_xfr).

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Refactor GlobusAPI move assignment operator and destructor to ensure safe and proper cleanup of CURL handles

Bug Fixes:
- Clean up existing CURL handles before move assignment to prevent resource leaks
- Nullify moved-from CURL pointers in move assignment to avoid double cleanup
- Guard CURL cleanup calls in destructor with null checks to prevent invalid operations