### PR TITLE
[DAPS-1551] fix promotion

### DIFF
--- a/core/server/AuthMap.cpp
+++ b/core/server/AuthMap.cpp
@@ -259,6 +259,24 @@ bool AuthMap::hasKeyType(const PublicKeyType pub_key_type,
   }
 }
 
+void AuthMap::setAccessCount(const PublicKeyType pub_key_type,
+                             const std::string &public_key,
+                             const size_t count) {
+  if (pub_key_type == PublicKeyType::TRANSIENT) {
+    std::lock_guard<std::mutex> lock(m_trans_clients_mtx);
+    if (m_trans_auth_clients.count(public_key)) {
+      m_trans_auth_clients.at(public_key).access_count = count;
+    }
+  } else if (pub_key_type == PublicKeyType::SESSION) {
+    std::lock_guard<std::mutex> lock(m_session_clients_mtx);
+    if (m_session_auth_clients.count(public_key)) {
+      m_session_auth_clients.at(public_key).access_count = count;
+    }
+  } else {
+    EXCEPT(1, "Unsupported PublicKey Type during execution of hasKeyType.");
+  }
+}
+
 size_t AuthMap::getAccessCount(const PublicKeyType pub_key_type,
                                const std::string &public_key) const {
   if (pub_key_type == PublicKeyType::TRANSIENT) {

--- a/core/server/AuthMap.hpp
+++ b/core/server/AuthMap.hpp
@@ -97,6 +97,13 @@ public:
                         const std::string &public_key) const;
 
   /**
+   * Set the access count on a key.
+   **/
+  void setAccessCount(const PublicKeyType pub_key_type,
+                      const std::string &public_key,
+                      const size_t);
+
+  /**
    * Will return the users Unique ID if it exists, will throw an error if it
    *does not exist. Best to call hasKey first.
    **/

--- a/core/server/ClientWorker.cpp
+++ b/core/server/ClientWorker.cpp
@@ -363,8 +363,9 @@ void ClientWorker::workerThread(LogContext log_context) {
         const std::string uid =
             std::get<std::string>(message.get(MessageAttribute::ID));
         if (msg_type != task_list_msg_type) {
-          DL_DEBUG(message_log_context,
-                   "W" << m_tid << " msg " << msg_type << " [" << uid << "]");
+          DL_DEBUG(message_log_context, "W" << m_tid << " msg "
+                                            << proto_map.toString(msg_type)
+                                            << " [" << uid << "]");
         }
 
         if (uid.compare("anon") == 0 && msg_type > 0x1FF) {

--- a/core/server/Condition.cpp
+++ b/core/server/Condition.cpp
@@ -19,6 +19,8 @@ void Promote::enforce(AuthMap &auth_map, const std::string &public_key) {
     }
     // Remove expired short lived transient key
     auth_map.removeKey(m_promote_from, public_key);
+    // Set the access counter so that it doesn't get prematurely removed
+    auth_map.setAccessCount(m_promote_to, public_key, access_count);
   }
 }
 

--- a/core/server/tests/unit/test_AuthMap.cpp
+++ b/core/server/tests/unit/test_AuthMap.cpp
@@ -13,10 +13,10 @@
 using namespace SDMS::Core;
 
 struct GlobalProtobufTeardown {
-    ~GlobalProtobufTeardown() {
-        // This is the teardown function that runs once at the end
-        google::protobuf::ShutdownProtobufLibrary();
-    }
+  ~GlobalProtobufTeardown() {
+    // This is the teardown function that runs once at the end
+    google::protobuf::ShutdownProtobufLibrary();
+  }
 };
 
 // Declare a global fixture instance
@@ -45,6 +45,31 @@ BOOST_AUTO_TEST_CASE(testing_AuthMap) {
   BOOST_TEST(auth_map.hasKey(PublicKeyType::PERSISTENT, new_pub_key) == false);
 
   BOOST_TEST(auth_map.getUID(PublicKeyType::TRANSIENT, new_pub_key) == user_id);
+}
+
+BOOST_AUTO_TEST_CASE(testing_AuthMap_setgetcount) {
+  time_t active_transient_key_time = 30;
+  time_t active_session_key_time = 30;
+  std::string db_url = "https://db/sdms/blah";
+  std::string db_user = "greatestone";
+  std::string db_pass = "1234";
+
+  AuthMap auth_map(active_transient_key_time, active_session_key_time, db_url,
+                   db_user, db_pass);
+
+  BOOST_TEST(auth_map.size(PublicKeyType::TRANSIENT) == 0);
+
+  std::string new_pub_key = "ugh";
+  std::string user_id = "u/bob";
+  auth_map.addKey(PublicKeyType::TRANSIENT, new_pub_key, user_id);
+
+  BOOST_TEST(auth_map.getAccessCount(PublicKeyType::TRANSIENT, new_pub_key) ==
+             0);
+
+  auth_map.setAccessCount(PublicKeyType::TRANSIENT, new_pub_key, 5);
+
+  BOOST_TEST(auth_map.getAccessCount(PublicKeyType::TRANSIENT, new_pub_key) ==
+             5);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Ticket  

Promotion logic of transient key to session key on connection was leading to the access_counts being set to 0 on creation of the session key, session key cleanup and removal was picking up the new session key and assuming it was not being used and purging it prematurely.

## Description 

A method was added to get the access attempts from the transient key and make sure the newly created Session key record in the core server started with the number of accesses from the transient key.

## How Has This Been Tested?  

print statements were placed around the promotion logic. On fixing it was made clear that the newly created session keys were set to the same number of access attempts as the transient. The session key was then not removed as it had been but simply reset when the Reset Condition was met.

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Introduce a method to set the access count on authorization keys, ensure the count is preserved during promotion, and improve related tests and logging.

New Features:
- Add AuthMap::setAccessCount to allow updating a key's access count.

Bug Fixes:
- Preserve access count when promoting a key in Promote::enforce.

Enhancements:
- Use proto_map.toString(msg_type) for more readable message logging in ClientWorker.

Tests:
- Add unit test to verify getAccessCount and setAccessCount behavior.