### PR TITLE
refactor - fix exception messages in resetKey, setAccessCount, getAcc…

### DIFF
--- a/core/server/AuthMap.cpp
+++ b/core/server/AuthMap.cpp
@@ -129,7 +129,7 @@ void AuthMap::resetKey(const PublicKeyType pub_key_type,
       EXCEPT(1, "Missing public key cannot reset session expiration.");
     }
   } else {
-    EXCEPT(1, "Unsupported PublicKey Type during execution of addKey.");
+    EXCEPT(1, "Unsupported PublicKey Type during execution of resetKey.");
   }
 }
 
@@ -273,7 +273,7 @@ void AuthMap::setAccessCount(const PublicKeyType pub_key_type,
       m_session_auth_clients.at(public_key).access_count = count;
     }
   } else {
-    EXCEPT(1, "Unsupported PublicKey Type during execution of hasKeyType.");
+    EXCEPT(1, "Unsupported PublicKey Type during execution of setAccessCount.");
   }
 }
 
@@ -290,7 +290,7 @@ size_t AuthMap::getAccessCount(const PublicKeyType pub_key_type,
       return m_session_auth_clients.at(public_key).access_count;
     }
   } else {
-    EXCEPT(1, "Unsupported PublicKey Type during execution of hasKeyType.");
+    EXCEPT(1, "Unsupported PublicKey Type during execution of getAccessCount.");
   }
   return 0;
 }


### PR DESCRIPTION
…essCount in AuthMap

## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Update exception messages in AuthMap to correctly reference their respective methods when encountering unsupported public key types.

Bug Fixes:
- Correct exception message in AuthMap::resetKey to reference resetKey instead of addKey
- Correct exception message in AuthMap::setAccessCount to reference setAccessCount instead of hasKeyType
- Correct exception message in AuthMap::getAccessCount to reference getAccessCount instead of hasKeyType