### PR TITLE
[DAPS-1551] ci job fail correctly on failed curl

### DIFF
--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -5,6 +5,9 @@ source "${SOURCE}/dependency_versions.sh"
 PROJECT_ROOT=$(realpath "${SOURCE}/..")
 source "${SOURCE}/utils.sh"
 
+# Ensures the shell returns the exit code of the first failed command in a pipeline
+set -o pipefail
+
 sudo_command
 # these are the dependencies to be installed by apt
 export apt_file_path="${PROJECT_ROOT}/tmp/apt_deps"

--- a/scripts/dependency_install_functions.sh
+++ b/scripts/dependency_install_functions.sh
@@ -461,7 +461,8 @@ install_nvm() {
     # will use it to set the install path
     export NVM_DIR="${DATAFED_DEPENDENCIES_INSTALL_PATH}/nvm"
     mkdir -p "${NVM_DIR}"
-    curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/${DATAFED_NVM_VERSION}/install.sh" | bash
+    # --fail makes curl return a non-zero exit code for HTTP errors like 404 or 500.
+    curl --fail -o- "https://raw.githubusercontent.com/nvm-sh/nvm/${DATAFED_NVM_VERSION}/install.sh" | bash
     # Mark nvm as installed
     touch "${DATAFED_DEPENDENCIES_INSTALL_PATH}/${NVM_FLAG_PREFIX}${DATAFED_NVM_VERSION}"
   else


### PR DESCRIPTION
## Ticket  

#1551 

## Description 

Causes job to fail in ci pipeline, making it clearer where the problem originates from.

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Enable CI job to properly fail when curl errors occur during dependency installation

Bug Fixes:
- Enable pipefail to ensure pipeline failures are propagated
- Add --fail flag to curl in nvm install step to return non-zero on HTTP errors