### PR TITLE
refactor: remove useless secret from user_router.

### DIFF
--- a/core/database/foxx/api/user_router.js
+++ b/core/database/foxx/api/user_router.js
@@ -72,17 +72,6 @@ router
                     write: ["u", "c", "a", "g", "acl", "owner", "ident", "uuid", "alias", "admin"],
                 },
                 action: function () {
-                    var cfg = g_db.config.document("config/system");
-                    if (req.queryParams.secret != cfg.secret) {
-                        console.log(
-                            "ERROR: user create called with incorrect system secret. uid:",
-                            req.queryParams.uid,
-                            ", name:",
-                            req.queryParams.name,
-                        );
-                        throw [g_lib.ERR_AUTHN_FAILED, "Invalid system credentials"];
-                    }
-
                     var i,
                         time = Math.floor(Date.now() / 1000),
                         name = req.queryParams.name.trim(),
@@ -222,7 +211,7 @@ router
     })
     .queryParam(
         "secret",
-        joi.string().required(),
+        joi.string().optional(),
         "System secret required to authorize this action",
     )
     .queryParam("uid", joi.string().required(), "SDMS user ID (globus) for new user")


### PR DESCRIPTION
## Ticket  

#1531 

## Description 

First issue, in steps to remove system secret from repo.

## How Has This Been Tested?  

Run through the CI

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Remove redundant system secret authentication from the user creation endpoint and relax the secret query parameter to be optional.

Enhancements:
- Remove server-side validation and logging of the system secret in the user creation route
- Change the "secret" query parameter in the router schema from required to optional