### PR TITLE
Centralize timeout values using env variable within end-to-end testing

### DIFF
--- a/tests/end-to-end/test_api_alloc.py
+++ b/tests/end-to-end/test_api_alloc.py
@@ -47,6 +47,7 @@ class TestDataFedPythonAPIRepoAlloc(unittest.TestCase):
 
         username = "datafed89"
         password = os.environ.get("DATAFED_USER89_PASSWORD")
+        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
 
         count = 0
         while True:
@@ -103,7 +104,7 @@ class TestDataFedPythonAPIRepoAlloc(unittest.TestCase):
         result = self._df_api.repoList(list_all=True)
         count = 0
         while len(result[0].repo) == 0:
-            time.sleep(1)
+            time.sleep(timeout)
             result = self._df_api.repoList(list_all=True)
             count = count + 1
             if count > 3:
@@ -147,7 +148,7 @@ class TestDataFedPythonAPIRepoAlloc(unittest.TestCase):
                     " all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             print("Calling taskView")
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
@@ -180,7 +181,7 @@ class TestDataFedPythonAPIRepoAlloc(unittest.TestCase):
                     "sure all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1

--- a/tests/end-to-end/test_api_collection.py
+++ b/tests/end-to-end/test_api_collection.py
@@ -51,6 +51,7 @@ class TestDataFedPythonAPICollectionCRUD(unittest.TestCase):
 
         self._username = "datafed89"
         password = os.environ.get("DATAFED_USER89_PASSWORD")
+        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
 
         count = 0
         while True:
@@ -106,7 +107,7 @@ class TestDataFedPythonAPICollectionCRUD(unittest.TestCase):
         result = self._df_api.repoList(list_all=True)
         count = 0
         while len(result[0].repo) == 0:
-            time.sleep(1)
+            time.sleep(timeout)
             result = self._df_api.repoList(list_all=True)
             count = count + 1
             if count > 3:
@@ -141,7 +142,7 @@ class TestDataFedPythonAPICollectionCRUD(unittest.TestCase):
                     "sure all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1
@@ -220,7 +221,7 @@ class TestDataFedPythonAPICollectionCRUD(unittest.TestCase):
                     "make sure all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1
@@ -251,7 +252,7 @@ class TestDataFedPythonAPICollectionCRUD(unittest.TestCase):
                     " make sure all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1

--- a/tests/end-to-end/test_api_context.py
+++ b/tests/end-to-end/test_api_context.py
@@ -46,6 +46,7 @@ class TestDataFedPythonAPIContext(unittest.TestCase):
 
         self._username = "datafed99"
         password = os.environ.get("DATAFED_USER99_PASSWORD")
+        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
 
         count = 0
         while True:

--- a/tests/end-to-end/test_api_endpoint.py
+++ b/tests/end-to-end/test_api_endpoint.py
@@ -46,6 +46,7 @@ class TestDataFedPythonAPIEndpoint(unittest.TestCase):
 
         username = "datafed89"
         password = os.environ.get("DATAFED_USER89_PASSWORD")
+        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
 
         count = 0
         while True:

--- a/tests/end-to-end/test_api_record.py
+++ b/tests/end-to-end/test_api_record.py
@@ -53,6 +53,7 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
         self._username = "datafed89"
         password = os.environ.get("DATAFED_USER89_PASSWORD")
 
+        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
         count = 0
         while True:
             try:
@@ -106,7 +107,7 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
         result = self._df_api.repoList(list_all=True)
         count = 0
         while len(result[0].repo) == 0:
-            time.sleep(1)
+            time.sleep(timeout)
             result = self._df_api.repoList(list_all=True)
             count = count + 1
             if count > 3:
@@ -141,7 +142,7 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
                     "all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1
@@ -188,7 +189,7 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
         while status < 3:
             if count > 30:
                 break
-            time.sleep(4)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             print("task Result **************")
             print(task_result)
@@ -210,7 +211,7 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
         while status < 3:
             if count > 20:
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1
@@ -242,7 +243,7 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
                     " all services are running."
                 )
                 break
-            time.sleep(1)
+            time.sleep(timeout)
             task_result = self._df_api.taskView(task_id)
             status = task_result[0].task[0].status
             count = count + 1

--- a/tests/end-to-end/test_api_repo.py
+++ b/tests/end-to-end/test_api_repo.py
@@ -41,7 +41,7 @@ class TestDataFedPythonAPIRepo(unittest.TestCase):
 
         username = "datafed89"
         password = os.environ.get("DATAFED_USER89_PASSWORD")
-        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
+        timeout  = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
 
         count = 0
         while True:

--- a/tests/end-to-end/test_api_repo.py
+++ b/tests/end-to-end/test_api_repo.py
@@ -41,6 +41,7 @@ class TestDataFedPythonAPIRepo(unittest.TestCase):
 
         username = "datafed89"
         password = os.environ.get("DATAFED_USER89_PASSWORD")
+        timeout = int(os.environ.get('DATAFED_TEST_TIMEOUT_OVERRIDE', '1'));
 
         count = 0
         while True:


### PR DESCRIPTION
## Ticket  

#1572

## Description 

Currently, the timeout values used in our end-to-end tests are hardcoded throughout the codebase. This approach makes it difficult to adjust timeouts consistently across different environments or testing scenarios.


## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added
