### PR TITLE
[DAPS-1519] Update SDK, add tests

### DIFF
--- a/python/datafed_pkg/datafed/CommandLib.py
+++ b/python/datafed_pkg/datafed/CommandLib.py
@@ -22,7 +22,6 @@ from . import Config
 # Repository type constants
 VALID_REPO_TYPES = ["globus", "metadata_only"]
 
-
 class API:
     """
     A high-level messaging interface to the DataFed core server
@@ -192,7 +191,7 @@ class API:
         path=None,
         exp_path=None,
         admins=[],
-        repo_type="globus",
+        type="globus",
     ):
         """
         Create a repository
@@ -231,7 +230,7 @@ class API:
         admins : list[str]
             A list of DataFed users that will have repository admin rights on
             the repository. i.e. ["u/tony_stark", "u/pepper"]
-        repo_type : str, optional
+        type : str, optional
             Repository type: "globus" for Globus-based repositories or 
             "metadata_only" for metadata-only repositories. Default is "globus".
 
@@ -244,10 +243,10 @@ class API:
         Exception : On communication or server error
         """
         # Validate repository type
-        if repo_type is None:
-            repo_type = "globus"
-        if repo_type not in VALID_REPO_TYPES:
-            raise ValueError(f"Invalid repository type '{repo_type}'. Must be one of: {', '.join(VALID_REPO_TYPES)}")
+        if type is None:
+            type = "globus"
+        if type not in VALID_REPO_TYPES:
+            raise ValueError(f"Invalid repository type '{type}'. Must be one of: {', '.join(VALID_REPO_TYPES)}")
         
         msg = auth.RepoCreateRequest()
         msg.id = repo_id
@@ -260,7 +259,7 @@ class API:
         msg.pub_key = pub_key
         msg.path = path
         msg.capacity = capacity
-        msg.type = repo_type
+        msg.type = type
 
         if isinstance(admins, list):
             for admin in admins:

--- a/python/datafed_pkg/test/Test_RepositoryTypes.py
+++ b/python/datafed_pkg/test/Test_RepositoryTypes.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python3
-"""
-Simple test for repository type functionality in DataFed Python SDK.
-Tests the validation logic without requiring full API setup.
-"""
-
 import sys
 from pathlib import Path
 
@@ -20,106 +15,90 @@ except ImportError:
 
 def test_repository_type_validation():
     """Test repository type validation logic."""
-    print("Testing repository type validation...")
+    print("Testing type validation...")
     
-    # Simulate the validation logic from CommandLib.py
     def validate_repo_type(type_value):
-        """Validate repository type (from CommandLib.py)."""
+        """Validate repository type."""
         if type_value is None:
             type_value = "globus"
         if type_value not in VALID_REPO_TYPES:
             raise ValueError(f"Invalid repository type '{type_value}'. Must be one of: {', '.join(VALID_REPO_TYPES)}")
         return True
     
-    # Test valid types
     test_cases = [
-        ("globus", True, "Valid 'globus' type"),
-        ("metadata_only", True, "Valid 'metadata_only' type"),
-        ("invalid", False, "Invalid type should raise error"),
-        ("", False, "Empty type should raise error"),
-        ("GLOBUS", False, "Uppercase should raise error (case-sensitive)"),
-        ("Metadata_Only", False, "Mixed case should raise error"),
-        (None, True, "None type should default to 'globus'"),
-        (123, False, "Integer type should raise error"),
-        ([], False, "List type should raise error"),
-        ({}, False, "Dict type should raise error"),
-        (3.14, False, "Float type should raise error"),
+        ("globus", True),
+        ("metadata_only", True,),
+        ("invalid", False),
+        ("", False),
+        ("GLOBUS", False),
+        ("Metadata_Only", False),
+        (None, True),
+        (123, False),
+        ([], False),
+        ({}, False),
+        (3.14, False),
     ]
     
-    passed = 0
     failed = 0
     
-    for type_value, should_pass, description in test_cases:
+    for type_value, should_pass in test_cases:
         try:
             validate_repo_type(type_value)
-            if should_pass:
-                print(f"✓ {description}: '{type_value}' accepted")
-                passed += 1
-            else:
-                print(f"✗ {description}: '{type_value}' should have been rejected")
-                failed += 1
-        except ValueError as e:
             if not should_pass:
-                print(f"✓ {description}: '{type_value}' correctly rejected - {e}")
-                passed += 1
-            else:
-                print(f"✗ {description}: '{type_value}' incorrectly rejected - {e}")
+                print(f"FAIL: '{type_value}' should have been rejected")
+                failed += 1
+        except ValueError:
+            if should_pass:
+                print(f"FAIL: '{type_value}' incorrectly rejected")
                 failed += 1
     
-    print(f"\nResults: {passed} passed, {failed} failed")
     return failed == 0
 
 
 def test_default_type_behavior():
     """Test that type defaults to 'globus'."""
-    print("\nTesting default type behavior...")
+    print("Testing default behavior...")
     
-    # Simulate default parameter behavior with None handling
     def create_repo(repo_id, repo_type="globus", **kwargs):
         """Simulate repoCreate with default type."""
         if repo_type is None:
             repo_type = "globus"
         return {"repo_id": repo_id, "type": repo_type}
     
-    # Test with explicit type
-    result = create_repo("test1", repo_type="metadata_only")
-    assert result["type"] == "metadata_only", "Explicit type not preserved"
-    print("✓ Explicit type 'metadata_only' preserved")
+    # Test explicit, default, and None cases
+    tests = [
+        (create_repo("test1", repo_type="metadata_only"), "metadata_only"),
+        (create_repo("test2"), "globus"),
+        (create_repo("test3", repo_type=None), "globus"),
+    ]
     
-    # Test with default type
-    result = create_repo("test2")
-    assert result["type"] == "globus", "Default type not set to 'globus'"
-    print("✓ Default type is 'globus'")
-    
-    # Test with type=None
-    result = create_repo("test3", repo_type=None)
-    assert result["type"] == "globus", "Type=None did not default to 'globus'"
-    print("✓ Type=None defaults to 'globus'")
+    for result, expected in tests:
+        if result["type"] != expected:
+            print(f"FAIL: Expected '{expected}', got '{result['type']}'")
+            return False
     
     return True
 
 
 def main():
     """Run all tests."""
-    print("DataFed Python SDK Repository Type Tests")
-    print("=" * 50)
+    print("Repository Type Tests")
+    print("-" * 30)
     
     all_passed = True
     
-    # Run validation tests
     if not test_repository_type_validation():
         all_passed = False
     
-    # Run default behavior tests
     if not test_default_type_behavior():
         all_passed = False
     
-    print("\n" + "=" * 50)
+    print("-" * 30)
     if all_passed:
-        print("🎉 All tests passed!")
+        print("All tests passed")
         return 0
     else:
-        print("❌ Some tests failed")
+        print("Tests failed")
         return 1
 
 


### PR DESCRIPTION
## Ticket  

[DAPS-1519](https://github.com/ORNL/DataFed/issues/1519)

## Description 

This PR adds repository type support to the DataFed Python SDK's `repoCreate` method, enabling users to specify whether a repository is a traditional Globus-based repository or a metadata-only repository.

## How Has This Been Tested?  

Pending

## Artifacts (if appropriate):  

Pending

## Summary by Sourcery

Add repository type parameter to DataFed Python SDK's repoCreate method with validation and default value, include it in the request payload, and add tests for validation and default behavior.

New Features:
- Allow specifying repository type ('globus' or 'metadata_only') in repoCreate

Enhancements:
- Validate the repository type parameter and include it in the gRPC request
- Default the repository type to 'globus' when not specified

Tests:
- Add unit tests for repository type validation logic
- Add unit tests for default repository type behavior