### PR TITLE
Formatting remaining scripts within DataFed

### DIFF
--- a/common/tests/security/tcp_secure/test_tcp_insecure.sh
+++ b/common/tests/security/tcp_secure/test_tcp_insecure.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # If no arguments are provided assume command paths have not been passed in
-if [ $# -eq 0 ]
-then
+if [ $# -eq 0 ]; then
   TIMEOUT_CMD="timeout"
   TCPDUMP_CMD="tcpdump"
   MAX_TEST_TIME_SEC=4
@@ -13,10 +12,8 @@ else
 fi
 
 # Check that pcap group exists and the user is part of it
-if [ $(getent group pcap) ]
-then
-  if id -nG "$USER" | grep -qw "pcap"
-  then
+if [ $(getent group pcap) ]; then
+  if id -nG "$USER" | grep -qw "pcap"; then
     echo "CONTINUE"
   else
     echo "SKIPPING - user does not belong to pcap group cannot run tcp_secure test"
@@ -27,28 +24,27 @@ else
   exit 0
 fi
 
-echo 
+echo
 echo "Running with:"
 echo "TCPDUMP:       ${TCPDUMP_CMD}"
 echo "TIMEOUT:       ${TIMEOUT_CMD}"
 echo "MAX_TEST_TIME: ${MAX_TEST_TIME_SEC}"
 
 # Grab the packets sent on the loop back interface (127.0.0.1) and port 7515
-output=$( ${TIMEOUT_CMD} ${MAX_TEST_TIME_SEC} ${TCPDUMP_CMD} -vvv -A port 7515 -i lo)
-match=$( echo "$output" | grep token)
+output=$(${TIMEOUT_CMD} ${MAX_TEST_TIME_SEC} ${TCPDUMP_CMD} -vvv -A port 7515 -i lo)
+match=$(echo "$output" | grep token)
 
 echo "Content of grep ${match}"
-# If '.magic_token' is returned from the network sniffer then we know that 
+# If '.magic_token' is returned from the network sniffer then we know that
 # the encryption is not working
-if [[ "${match}" == ".magic_token" ]]
-then
+if [[ "${match}" == ".magic_token" ]]; then
   echo "SUCCESS - the connection is expected to be insecure"
   exit 0
 else
   echo "FAILED - the connection is unreadable, either it is encrypted when it should not be or there is an error."
   echo "         it could be the case that the permissions have changed on tcpdump. See the README for settings"
   echo "         that must be enabled to run it correctly."
-  echo 
+  echo
   echo "$output"
   exit 1
 fi

--- a/common/tests/security/tcp_secure/test_tcp_secure.sh
+++ b/common/tests/security/tcp_secure/test_tcp_secure.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # If no arguments are provided assume command paths have not been passed in
-if [ $# -eq 0 ]
-then
+if [ $# -eq 0 ]; then
   TIMEOUT_CMD="timeout"
   TCPDUMP_CMD="tcpdump"
   MAX_TEST_TIME_SEC=2
@@ -13,10 +12,8 @@ else
 fi
 
 # Check that pcap group exists and the user is part of it
-if [ $(getent group pcap) ]
-then
-  if id -nG "$USER" | grep -qw "pcap"
-  then
+if [ $(getent group pcap) ]; then
+  if id -nG "$USER" | grep -qw "pcap"; then
     echo "CONTINUE"
   else
     echo "SKIPPING - user does not belong to pcap group cannot run tcp_secure test"
@@ -34,13 +31,12 @@ echo "TIMEOUT:       ${TIMEOUT_CMD}"
 echo "MAX_TEST_TIME: ${MAX_TEST_TIME_SEC}"
 
 # Grab the first 30 packets sent on the loop back interface (127.0.0.1) and port 7515
-match=$( "${TIMEOUT_CMD}" "${MAX_TEST_TIME_SEC}" "${TCPDUMP_CMD}" -vvv -A port 7515 -i lo | grep token)
+match=$("${TIMEOUT_CMD}" "${MAX_TEST_TIME_SEC}" "${TCPDUMP_CMD}" -vvv -A port 7515 -i lo | grep token)
 
 echo "Content of grep ${match}"
-# If '.magic_token' is returned from the network sniffer then we know that 
+# If '.magic_token' is returned from the network sniffer then we know that
 # the encryption is not working
-if [[ "${match}" == ".magic_token" ]]
-then
+if [[ "${match}" == ".magic_token" ]]; then
   echo "FAILED - the connection is insecure we were able to pull out the token"
   exit 1
 else

--- a/compose/all/cleanup_globus_files.sh
+++ b/compose/all/cleanup_globus_files.sh
@@ -4,4 +4,3 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 
 "${PROJECT_ROOT}/scripts/compose_cleanup_globus_files.sh" -d "$(pwd)"
-

--- a/compose/all/generate_env.sh
+++ b/compose/all/generate_env.sh
@@ -7,4 +7,3 @@ PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 export DATAFED_COMPOSE_REPO_DOMAIN="datafed-repo"
 
 "${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)" "$@"
-

--- a/compose/metadata/build_metadata_images_for_compose.sh
+++ b/compose/metadata/build_metadata_images_for_compose.sh
@@ -8,17 +8,16 @@ PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 
 BUILD_ARG_FILE="$SOURCE/.build-args"
 if [ $# -gt 0 ]; then
-    # Do not check if file already exists becuase other generate scripts
-    # from a different repo might have already put their args in the file
-    # and calling this script might be the second step. Where this step would
-    # be appending to an existing file.
-    BUILD_ARG_FILE="$1/.build-args"
+  # Do not check if file already exists becuase other generate scripts
+  # from a different repo might have already put their args in the file
+  # and calling this script might be the second step. Where this step would
+  # be appending to an existing file.
+  BUILD_ARG_FILE="$1/.build-args"
 fi
 
 # Generate arg list
 
-if [ ! -f "$BUILD_ARG_FILE" ]
-then
+if [ ! -f "$BUILD_ARG_FILE" ]; then
   echo "Missing .build-args file, please run generate_build_args.sh first."
 fi
 

--- a/compose/metadata/generate_build_args.sh
+++ b/compose/metadata/generate_build_args.sh
@@ -22,14 +22,13 @@ if [ $# -gt 0 ]; then
 else
 
   # Force the user to manaully rm the file to avoid accidental overwrites.
-  if [ -f "$BUILD_ARG_FILE" ]
-  then
+  if [ -f "$BUILD_ARG_FILE" ]; then
     echo "$BUILD_ARG_FILE already exist! Will not overwrite!"
     exit 0
   fi
 fi
 
 # Needs to append to the ./build-args.sh file not overwrite.
-cat << EOF >> "$BUILD_ARG_FILE"
+cat <<EOF >>"$BUILD_ARG_FILE"
 BASE_IMAGE=debian:bookworm-slim
 EOF

--- a/compose/metadata/generate_env.sh
+++ b/compose/metadata/generate_env.sh
@@ -4,4 +4,3 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 
 "${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)" -m
-

--- a/compose/repo/cleanup_globus_files.sh
+++ b/compose/repo/cleanup_globus_files.sh
@@ -4,4 +4,3 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 
 "${PROJECT_ROOT}/scripts/compose_cleanup_globus_files.sh" -d "$(pwd)"
-

--- a/compose/repo/generate_env.sh
+++ b/compose/repo/generate_env.sh
@@ -4,4 +4,3 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../../")
 
 "${PROJECT_ROOT}/scripts/compose_generate_env.sh" -d "$(pwd)" -r
-

--- a/core/database/tests/test_fixture_setup.sh
+++ b/core/database/tests/test_fixture_setup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 set -uef -o pipefail
 
 SCRIPT=$(realpath "$BASH_SOURCE[0]")
@@ -10,8 +9,7 @@ source "${PROJECT_ROOT}/config/datafed.sh"
 source "${PROJECT_ROOT}/scripts/dependency_versions.sh"
 source "${PROJECT_ROOT}/scripts/dependency_install_functions.sh"
 
-Help()
-{
+Help() {
   echo "$(basename $0) Will initialize fixtures for Foxx tests"
   echo
   echo "Syntax: $(basename $0) [-h|u|p|y]"
@@ -31,74 +29,71 @@ Help()
 local_DATABASE_NAME="sdms"
 local_DATABASE_USER="root"
 
-if [ -z "${DATAFED_DATABASE_HOST:-}" ]
-then
+if [ -z "${DATAFED_DATABASE_HOST:-}" ]; then
   local_DATAFED_DATABASE_HOST="localhost"
 else
   local_DATAFED_DATABASE_HOST=$(printenv DATAFED_DATABASE_HOST)
 fi
 
-if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]
-then
+if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]; then
   local_DATAFED_DATABASE_PASSWORD=""
 else
   local_DATAFED_DATABASE_PASSWORD=$(printenv DATAFED_DATABASE_PASSWORD)
 fi
 
-if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]
-then
-  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs )
+if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]; then
+  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs)
 else
   local_FOXX_MAJOR_API_VERSION=$(printenv FOXX_MAJOR_API_VERSION)
 fi
 
 VALID_ARGS=$(getopt -o hu:p:f: --long 'help',database-user:,database-password:,foxx-api-major-version: -- "$@")
 if [[ $? -ne 0 ]]; then
-      exit 1;
+  exit 1
 fi
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   echo "$1"
   case "$1" in
-    -h | --help)
-        Help
-        exit 0
-        ;;
-    -u | --database-user)
-        echo "Processing 'Database user' option. Input argument is '$2'"
-        local_DATABASE_USER=$2
-        shift 2
-        ;;
-    -p | --database-password)
-        echo "Processing 'Database password' option. Input argument is '$2'"
-        local_DATAFED_DATABASE_PASSWORD=$2
-        shift 2
-        ;;
-    -f | --foxx-api-major-version)
-        echo "Processing 'Foxx major api version' option. Input argument is '$2'"
-        local_FOXX_MAJOR_API_VERSION=$2
-        shift 2
-        ;;
-    --) shift;
-        break
-        ;;
-    \?) # incorrect option
-        echo "Error: Invalid option"
-        exit;;
+  -h | --help)
+    Help
+    exit 0
+    ;;
+  -u | --database-user)
+    echo "Processing 'Database user' option. Input argument is '$2'"
+    local_DATABASE_USER=$2
+    shift 2
+    ;;
+  -p | --database-password)
+    echo "Processing 'Database password' option. Input argument is '$2'"
+    local_DATAFED_DATABASE_PASSWORD=$2
+    shift 2
+    ;;
+  -f | --foxx-api-major-version)
+    echo "Processing 'Foxx major api version' option. Input argument is '$2'"
+    local_FOXX_MAJOR_API_VERSION=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  \?) # incorrect option
+    echo "Error: Invalid option"
+    exit
+    ;;
   esac
 done
 
 ERROR_DETECTED=0
-if [ -z "$local_DATAFED_DATABASE_PASSWORD" ]
-then
+if [ -z "$local_DATAFED_DATABASE_PASSWORD" ]; then
   echo "Error DATAFED_DATABASE_PASSWORD is not defined, this is a required argument"
   echo "      This variable can be set using the command line option -p, --database-password"
   echo "      or with the environment variable DATAFED_DATABASE_PASSWORD."
   ERROR_DETECTED=1
 fi
 
-if [ "$ERROR_DETECTED" == "1" ]
-then
+if [ "$ERROR_DETECTED" == "1" ]; then
   exit 1
 fi
 
@@ -116,30 +111,30 @@ install_nvm
 install_node
 
 FOXX_PREFIX=""
-if ! command -v foxx > /dev/null 2>&1; then
-    FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
+if ! command -v foxx >/dev/null 2>&1; then
+  FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
 fi
 
 PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
 
 # set up test user fixtures, this script should be idempotent, this script is described in the manifest
 "${FOXX_PREFIX}foxx" script -u "${local_DATABASE_USER}" \
-   --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" \
-    -p "${PATH_TO_PASSWD_FILE}" \
-    --database "${local_DATABASE_NAME}" \
-    "/api/${local_FOXX_MAJOR_API_VERSION}" user-fixture
+  --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" \
+  -p "${PATH_TO_PASSWD_FILE}" \
+  --database "${local_DATABASE_NAME}" \
+  "/api/${local_FOXX_MAJOR_API_VERSION}" user-fixture
 
 # set up test globus collection fixtures, this script should be idempotent, this script is described in the manifest
 "${FOXX_PREFIX}foxx" script -u "${local_DATABASE_USER}" \
-   --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" \
-    -p "${PATH_TO_PASSWD_FILE}" \
-    --database "${local_DATABASE_NAME}" \
-    "/api/${local_FOXX_MAJOR_API_VERSION}" collection-fixture
+  --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" \
+  -p "${PATH_TO_PASSWD_FILE}" \
+  --database "${local_DATABASE_NAME}" \
+  "/api/${local_FOXX_MAJOR_API_VERSION}" collection-fixture
 
 # set up test globus token fixtures, this script should be idempotent, this script is described in the manifest
 # order matters, must follow user and collection fixtures
 "${FOXX_PREFIX}foxx" script -u "${local_DATABASE_USER}" \
-   --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" \
-    -p "${PATH_TO_PASSWD_FILE}" \
-    --database "${local_DATABASE_NAME}" \
-    "/api/${local_FOXX_MAJOR_API_VERSION}" globus-token-fixture
+  --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" \
+  -p "${PATH_TO_PASSWD_FILE}" \
+  --database "${local_DATABASE_NAME}" \
+  "/api/${local_FOXX_MAJOR_API_VERSION}" globus-token-fixture

--- a/core/database/tests/test_foxx.sh
+++ b/core/database/tests/test_foxx.sh
@@ -17,8 +17,7 @@ source ${PROJECT_ROOT}/config/datafed.sh
 source "${PROJECT_ROOT}/scripts/dependency_versions.sh"
 source "${PROJECT_ROOT}/scripts/dependency_install_functions.sh"
 
-Help()
-{
+Help() {
   echo "$(basename $0) Will run a Foxx unit test"
   echo
   echo "Syntax: $(basename $0) [-h|u|p|t]"
@@ -40,16 +39,14 @@ Help()
 local_DATABASE_NAME="sdms"
 local_DATABASE_USER="root"
 
-if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]
-then
+if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]; then
   local_DATAFED_DATABASE_PASSWORD=""
 else
   local_DATAFED_DATABASE_PASSWORD=$(printenv DATAFED_DATABASE_PASSWORD)
 fi
 
-if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]
-then
-  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs )
+if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]; then
+  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs)
 else
   local_FOXX_MAJOR_API_VERSION=$(printenv FOXX_MAJOR_API_VERSION)
 fi
@@ -58,64 +55,64 @@ TEST_TO_RUN="all"
 
 VALID_ARGS=$(getopt -o hu:p:f:t: --long 'help',database-user:,database-password:,foxx-api-major-version:,test: -- "$@")
 if [[ $? -ne 0 ]]; then
-      exit 1;
+  exit 1
 fi
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   case "$1" in
-    -h | --help)
-        Help
-        exit 0
-        ;;
-    -u | --database-user)
-        echo "Processing 'Database user' option. Input argument is '$2'"
-        local_DATABASE_USER=$2
-        shift 2
-        ;;
-    -p | --database-password)
-        echo "Processing 'Database password' option. Input argument is '$2'"
-        local_DATAFED_DATABASE_PASSWORD=$2
-        shift 2
-        ;;
-    -f | --foxx-api-major-version)
-        echo "Processing 'Foxx major api version' option. Input argument is '$2'"
-        local_FOXX_MAJOR_API_VERSION=$2
-        shift 2
-        ;;
-    -t | --test)
-        echo "Processing 'test' option. Input argument is '$2'"
-        TEST_TO_RUN=$2
-        shift 2
-        ;;
-    --) shift; 
-        break 
-        ;;
-    \?) # incorrect option
-        echo "Error: Invalid option"
-        exit;;
+  -h | --help)
+    Help
+    exit 0
+    ;;
+  -u | --database-user)
+    echo "Processing 'Database user' option. Input argument is '$2'"
+    local_DATABASE_USER=$2
+    shift 2
+    ;;
+  -p | --database-password)
+    echo "Processing 'Database password' option. Input argument is '$2'"
+    local_DATAFED_DATABASE_PASSWORD=$2
+    shift 2
+    ;;
+  -f | --foxx-api-major-version)
+    echo "Processing 'Foxx major api version' option. Input argument is '$2'"
+    local_FOXX_MAJOR_API_VERSION=$2
+    shift 2
+    ;;
+  -t | --test)
+    echo "Processing 'test' option. Input argument is '$2'"
+    TEST_TO_RUN=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  \?) # incorrect option
+    echo "Error: Invalid option"
+    exit
+    ;;
   esac
 done
 
 ERROR_DETECTED=0
-if [ -z "$local_DATAFED_DATABASE_PASSWORD" ]
-then
+if [ -z "$local_DATAFED_DATABASE_PASSWORD" ]; then
   echo "Error DATAFED_DATABASE_PASSWORD is not defined, this is a required argument"
   echo "      This variable can be set using the command line option -p, --database-password"
   echo "      or with the environment variable DATAFED_DATABASE_PASSWORD."
   ERROR_DETECTED=1
 fi
 
-if [ "$ERROR_DETECTED" == "1" ]
-then
+if [ "$ERROR_DETECTED" == "1" ]; then
   exit 1
 fi
 
 # There are apparently 3 different ways to deploy Foxx microservices,
 # Using curl with http requests
-# Using the Arango web ui 
+# Using the Arango web ui
 # Using node module
 #
-# The web deployment requires manual interaction, and I could not figure out the 
+# The web deployment requires manual interaction, and I could not figure out the
 # syntax for the REST http endpoints with curl so we are going to try the node module
 
 # Will only install if not already present
@@ -123,24 +120,23 @@ install_nvm
 install_node
 
 FOXX_PREFIX=""
-if ! command -v foxx > /dev/null 2>&1; then
-      FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
+if ! command -v foxx >/dev/null 2>&1; then
+  FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
 fi
 
 PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
-if [ "$TEST_TO_RUN" == "all" ]
-then
-  # WARNING Foxx and arangosh arguments differ --server is used for Foxx not --server.endpoint 
+if [ "$TEST_TO_RUN" == "all" ]; then
+  # WARNING Foxx and arangosh arguments differ --server is used for Foxx not --server.endpoint
   "${FOXX_PREFIX}foxx" test -u "${local_DATABASE_USER}" \
-   --server "tcp://${DATAFED_DATABASE_HOST}:8529" \
+    --server "tcp://${DATAFED_DATABASE_HOST}:8529" \
     -p "${PATH_TO_PASSWD_FILE}" \
     --database "${local_DATABASE_NAME}" \
     "/api/${local_FOXX_MAJOR_API_VERSION}" --reporter spec
 else
   echo "Test: $TEST_TO_RUN"
-  # WARNING Foxx and arangosh arguments differ --server is used for Foxx not --server.endpoint 
+  # WARNING Foxx and arangosh arguments differ --server is used for Foxx not --server.endpoint
   "${FOXX_PREFIX}foxx" test -u "${local_DATABASE_USER}" \
-  --server "tcp://${DATAFED_DATABASE_HOST}:8529" \
+    --server "tcp://${DATAFED_DATABASE_HOST}:8529" \
     -p "${PATH_TO_PASSWD_FILE}" \
     --database "${local_DATABASE_NAME}" \
     "/api/${local_FOXX_MAJOR_API_VERSION}" "$TEST_TO_RUN" --reporter spec --verbose

--- a/core/database/tests/test_setup.sh
+++ b/core/database/tests/test_setup.sh
@@ -18,8 +18,7 @@ source "${PROJECT_ROOT}/config/datafed.sh"
 source "${PROJECT_ROOT}/scripts/dependency_versions.sh"
 source "${PROJECT_ROOT}/scripts/dependency_install_functions.sh"
 
-Help()
-{
+Help() {
   echo "$(basename $0) Will set up a configuration file for the core server"
   echo
   echo "Syntax: $(basename $0) [-h|u|p|y]"
@@ -40,74 +39,71 @@ Help()
 local_DATABASE_NAME="sdms"
 local_DATABASE_USER="root"
 
-if [ -z "${DATAFED_DATABASE_HOST:-}" ]
-then
+if [ -z "${DATAFED_DATABASE_HOST:-}" ]; then
   local_DATAFED_DATABASE_HOST="localhost"
 else
   local_DATAFED_DATABASE_HOST=$(printenv DATAFED_DATABASE_HOST)
 fi
 
-if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]
-then
+if [ -z "${DATAFED_DATABASE_PASSWORD:-}" ]; then
   local_DATAFED_DATABASE_PASSWORD=""
 else
   local_DATAFED_DATABASE_PASSWORD=$(printenv DATAFED_DATABASE_PASSWORD)
 fi
 
-if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]
-then
-  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs )
+if [ -z "${FOXX_MAJOR_API_VERSION:-}" ]; then
+  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs)
 else
   local_FOXX_MAJOR_API_VERSION=$(printenv FOXX_MAJOR_API_VERSION)
 fi
 
 VALID_ARGS=$(getopt -o hu:p:f: --long 'help',database-user:,database-password:,foxx-api-major-version: -- "$@")
 if [[ $? -ne 0 ]]; then
-      exit 1;
+  exit 1
 fi
 eval set -- "$VALID_ARGS"
 while [ : ]; do
   echo "$1"
   case "$1" in
-    -h | --help)
-        Help
-        exit 0
-        ;;
-    -u | --database-user)
-        echo "Processing 'Database user' option. Input argument is '$2'"
-        local_DATABASE_USER=$2
-        shift 2
-        ;;
-    -p | --database-password)
-        echo "Processing 'Database password' option. Input argument is '$2'"
-        local_DATAFED_DATABASE_PASSWORD=$2
-        shift 2
-        ;;
-    -f | --foxx-api-major-version)
-        echo "Processing 'Foxx major api version' option. Input argument is '$2'"
-        local_FOXX_MAJOR_API_VERSION=$2
-        shift 2
-        ;;
-    --) shift; 
-        break 
-        ;;
-    \?) # incorrect option
-        echo "Error: Invalid option"
-        exit;;
+  -h | --help)
+    Help
+    exit 0
+    ;;
+  -u | --database-user)
+    echo "Processing 'Database user' option. Input argument is '$2'"
+    local_DATABASE_USER=$2
+    shift 2
+    ;;
+  -p | --database-password)
+    echo "Processing 'Database password' option. Input argument is '$2'"
+    local_DATAFED_DATABASE_PASSWORD=$2
+    shift 2
+    ;;
+  -f | --foxx-api-major-version)
+    echo "Processing 'Foxx major api version' option. Input argument is '$2'"
+    local_FOXX_MAJOR_API_VERSION=$2
+    shift 2
+    ;;
+  --)
+    shift
+    break
+    ;;
+  \?) # incorrect option
+    echo "Error: Invalid option"
+    exit
+    ;;
   esac
 done
 
 ERROR_DETECTED=0
-if [ -z "$local_DATAFED_DATABASE_PASSWORD" ]
-then
+if [ -z "$local_DATAFED_DATABASE_PASSWORD" ]; then
   echo "Error DATAFED_DATABASE_PASSWORD is not defined, this is a required argument"
   echo "      This variable can be set using the command line option -p, --database-password"
   echo "      or with the environment variable DATAFED_DATABASE_PASSWORD."
   ERROR_DETECTED=1
 fi
 
-if [ "$ERROR_DETECTED" == "1" ]
-then
+if [ "$ERROR_DETECTED" == "1" ]; then
   exit 1
 fi
 
@@ -116,19 +112,19 @@ fi
 output=$(curl --user $local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD http://${local_DATAFED_DATABASE_HOST}:8529/_api/database/user)
 
 if [[ "$output" =~ .*"sdms".* ]]; then
-	echo "SDMS already exists do nothing"
+  echo "SDMS already exists do nothing"
 else
-	echo "Creating SDMS"
-  arangosh  --server.endpoint "tcp://${local_DATAFED_DATABASE_HOST}:8529"   --server.password "${local_DATAFED_DATABASE_PASSWORD}" --server.username "${local_DATABASE_USER}" --javascript.execute "${PROJECT_ROOT}/core/database/foxx/db_create.js"
+  echo "Creating SDMS"
+  arangosh --server.endpoint "tcp://${local_DATAFED_DATABASE_HOST}:8529" --server.password "${local_DATAFED_DATABASE_PASSWORD}" --server.username "${local_DATABASE_USER}" --javascript.execute "${PROJECT_ROOT}/core/database/foxx/db_create.js"
   # Give time for the database to be created
   sleep 2
-  arangosh  --server.endpoint "tcp://${local_DATAFED_DATABASE_HOST}:8529" --server.password "${local_DATAFED_DATABASE_PASSWORD}" --server.username "${local_DATABASE_USER}" --javascript.execute-string 'db._useDatabase("sdms"); db.config.insert({"_key": "msg_daily", "msg" : "DataFed servers will be off-line for regular maintenance every Sunday night from 11:45 pm until 12:15 am EST Monday morning."}, {overwrite: true});'
-  arangosh  --server.endpoint "tcp://${local_DATAFED_DATABASE_HOST}:8529" --server.password "${local_DATAFED_DATABASE_PASSWORD}" --server.username "${local_DATABASE_USER}" --javascript.execute-string "db._useDatabase(\"sdms\"); db.config.insert({ \"_key\": \"system\", \"_id\": \"config/system\"}, {overwrite: true } );"
+  arangosh --server.endpoint "tcp://${local_DATAFED_DATABASE_HOST}:8529" --server.password "${local_DATAFED_DATABASE_PASSWORD}" --server.username "${local_DATABASE_USER}" --javascript.execute-string 'db._useDatabase("sdms"); db.config.insert({"_key": "msg_daily", "msg" : "DataFed servers will be off-line for regular maintenance every Sunday night from 11:45 pm until 12:15 am EST Monday morning."}, {overwrite: true});'
+  arangosh --server.endpoint "tcp://${local_DATAFED_DATABASE_HOST}:8529" --server.password "${local_DATAFED_DATABASE_PASSWORD}" --server.username "${local_DATABASE_USER}" --javascript.execute-string "db._useDatabase(\"sdms\"); db.config.insert({ \"_key\": \"system\", \"_id\": \"config/system\"}, {overwrite: true } );"
 fi
 
 # There are apparently 3 different ways to deploy Foxx microservices,
 # Using curl with http requests
-# Using the Arango web ui 
+# Using the Arango web ui
 # Using node module
 #
 # The web deployment requires manual interaction, and I could not figure out
@@ -143,22 +139,20 @@ install_node
 $NVM_DIR/nvm-exec npm install --global foxx-cli
 
 FOXX_PREFIX=""
-if ! command -v foxx > /dev/null 2>&1; then
-    FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
+if ! command -v foxx >/dev/null 2>&1; then
+  FOXX_PREFIX="${DATAFED_DEPENDENCIES_INSTALL_PATH}/npm/bin/"
 fi
 
 PATH_TO_PASSWD_FILE=${SOURCE}/database_temp.password
-echo "$local_DATAFED_DATABASE_PASSWORD" > "${PATH_TO_PASSWD_FILE}"
+echo "$local_DATAFED_DATABASE_PASSWORD" >"${PATH_TO_PASSWD_FILE}"
 # Check if database foxx services have already been installed
 # WARNING Foxx and arangosh arguments differ --server is used for Foxx not --server.endpoint
-existing_services=$("${FOXX_PREFIX}foxx" list -a -u "$local_DATABASE_USER" -p "${PATH_TO_PASSWD_FILE}"  --server "tcp://${local_DATAFED_DATABASE_HOST}:8529"  --database "$local_DATABASE_NAME")
+existing_services=$("${FOXX_PREFIX}foxx" list -a -u "$local_DATABASE_USER" -p "${PATH_TO_PASSWD_FILE}" --server "tcp://${local_DATAFED_DATABASE_HOST}:8529" --database "$local_DATABASE_NAME")
 echo "existing services ${existing_services}"
 
-if [[ "$existing_services" =~ .*"DataFed".* ]]
-then
+if [[ "$existing_services" =~ .*"DataFed".* ]]; then
   echo "Running tests"
 else
   echo "Foxx services have not been installed cannot run tests!"
   exit 1
 fi
-

--- a/core/docker/entrypoint.sh
+++ b/core/docker/entrypoint.sh
@@ -14,8 +14,7 @@ env
 
 log_path="$DATAFED_DEFAULT_LOG_PATH"
 
-if [ ! -d "${log_path}" ]
-then
+if [ ! -d "${log_path}" ]; then
   mkdir -p ${log_path}
 fi
 
@@ -29,8 +28,7 @@ if [ "$#" -eq 0 ]; then
 fi
 
 datafed_core_exec=$(basename "$1")
-if [ "${datafed_core_exec}" = "datafed-core" ]
-then
+if [ "${datafed_core_exec}" = "datafed-core" ]; then
   # Send output to log file
   # For this to work all commands must be passed in as a single string
   "$@" -- argv0 "$@" 2>&1 | tee $log_path/datafed-core.log

--- a/docker/entrypoint_foxx.sh
+++ b/docker/entrypoint_foxx.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 # NOTE We do not need to change the user in this container because we should not have
 # any log output, and running chmod to update all the folders during runtime is
 # expensive!
-# 
+#
 # The following lines are not needed
 # if [ -n "$UID" ]; then
 #     usermod -u $UID datafed
@@ -15,19 +15,17 @@ SCRIPT=$(realpath "$0")
 SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath "${SOURCE}/../")
 
-# Why is this flag used, it is used because the same container is used for 
+# Why is this flag used, it is used because the same container is used for
 # compose as is for operations and ci. If you have a compose dev environment
 # we may want to keep the existing state and not overwrite the database.
 install_flag="/tmp/.foxx_is_installed"
-if [ ! -f "$install_flag" ]
-then
+if [ ! -f "$install_flag" ]; then
   echo "Installing foxx."
   log_path="$DATAFED_DEFAULT_LOG_PATH"
-  if [ ! -d "${log_path}" ]
-  then
+  if [ ! -d "${log_path}" ]; then
     su -c "mkdir -p ${log_path}" datafed
   fi
-  
+
   # It should be fine to run this as root because it is an ephemeral container anyway
   cd "${PROJECT_ROOT}"
   # Check to see if foxx has previously been installed
@@ -38,22 +36,22 @@ then
 
   # Define common CMake options
   cmake_options=(
-	  -S. -B build
-	  -DBUILD_REPO_SERVER=False
-	  -DBUILD_COMMON=False
-	  -DBUILD_AUTHZ=False
-	  -DBUILD_CORE_SERVER=False
-	  -DBUILD_WEB_SERVER=False
-	  -DBUILD_DOCS=False
-	  -DBUILD_PYTHON_CLIENT=False
-	  -DBUILD_FOXX=True
-	  -DINSTALL_FOXX=True
+    -S. -B build
+    -DBUILD_REPO_SERVER=False
+    -DBUILD_COMMON=False
+    -DBUILD_AUTHZ=False
+    -DBUILD_CORE_SERVER=False
+    -DBUILD_WEB_SERVER=False
+    -DBUILD_DOCS=False
+    -DBUILD_PYTHON_CLIENT=False
+    -DBUILD_FOXX=True
+    -DINSTALL_FOXX=True
   )
 
   # Add the ENABLE_FOXX_TESTS option if it's set to TRUE
   # Should only run this if you are ok with making changes to the database
   if [ "$ENABLE_FOXX_TESTS" == "TRUE" ]; then
-	  cmake_options+=(-DENABLE_FOXX_TESTS=True)
+    cmake_options+=(-DENABLE_FOXX_TESTS=True)
   fi
 
   # Run the CMake command with the constructed options
@@ -66,8 +64,7 @@ then
   sleep 5
   "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" --build build --target install
 
-  if [ "$ENABLE_FOXX_TESTS" == "TRUE" ]
-  then
+  if [ "$ENABLE_FOXX_TESTS" == "TRUE" ]; then
     "${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/cmake" \
       --build build \
       --target test
@@ -75,7 +72,7 @@ then
     if [ "$EXIT_CODE" != "0" ]; then exit "$EXIT_CODE"; fi
   fi
 
-  # Create flag to indicate container has done its job  
+  # Create flag to indicate container has done its job
   touch "$install_flag"
   chown -R "$UID":"$UID" "/tmp"
 else

--- a/python/docker/entrypoint.sh
+++ b/python/docker/entrypoint.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 SCRIPT=$(realpath "$0")
 SOURCE=$(dirname "$SCRIPT")
 
-# Entry point file expects that the directory where the DataFed source file 
+# Entry point file expects that the directory where the DataFed source file
 # is passed in as the first argument
 
 echo "SOURCE BUILD DIR $BUILD_DIR"
@@ -20,7 +20,7 @@ source "${BUILD_DIR}/config/datafed.sh"
 mkdir -p "/home/datafed/.datafed"
 
 # At this point we will create an ini file
-cat << EOF > "/home/datafed/.datafed/datafed-client.ini"
+cat <<EOF >"/home/datafed/.datafed/datafed-client.ini"
 [server]
 host = ${DATAFED_DOMAIN}
 port = ${DATAFED_SERVER_PORT}
@@ -37,4 +37,3 @@ if [ "$#" -eq 0 ]; then
 fi
 
 "$@"
-

--- a/repository/docker/entrypoint_authz.sh
+++ b/repository/docker/entrypoint_authz.sh
@@ -9,26 +9,25 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath ${SOURCE}/../..)
 # Translate datafed env variables to globus env variables
 
-# Do not set DATAFED_GCS_COLLECTION_ROOT_PATH here, it should be defined in 
+# Do not set DATAFED_GCS_COLLECTION_ROOT_PATH here, it should be defined in
 # the Dockerfile as an env variable
 
 # The env variables below are needed for running globus-connect-server without
 # interactively logging in
-export GCS_CLI_CLIENT_ID=$(jq -r .client < /opt/datafed/globus/client_cred.json)
-export GCS_CLI_CLIENT_SECRET=$(jq -r .secret < /opt/datafed/globus/client_cred.json)
-export GCS_CLI_ENDPOINT_ID=$(jq -r .client_id < /opt/datafed/globus/deployment-key.json)
+export GCS_CLI_CLIENT_ID=$(jq -r .client </opt/datafed/globus/client_cred.json)
+export GCS_CLI_CLIENT_SECRET=$(jq -r .secret </opt/datafed/globus/client_cred.json)
+export GCS_CLI_ENDPOINT_ID=$(jq -r .client_id </opt/datafed/globus/deployment-key.json)
 
 export DEPLOYMENT_KEY_PATH="/opt/datafed/globus/deployment-key.json"
 # These env variables are for running the gcs entrypoint file
 
-export GLOBUS_CLIENT_ID=$(jq -r .client < /opt/datafed/globus/client_cred.json)
-export GLOBUS_CLIENT_SECRET=$(jq -r .secret < /opt/datafed/globus/client_cred.json)
-export DEPLOYMENT_KEY=$(cat "$DEPLOYMENT_KEY_PATH"  )
+export GLOBUS_CLIENT_ID=$(jq -r .client </opt/datafed/globus/client_cred.json)
+export GLOBUS_CLIENT_SECRET=$(jq -r .secret </opt/datafed/globus/client_cred.json)
+export DEPLOYMENT_KEY=$(cat "$DEPLOYMENT_KEY_PATH")
 
-if [ "$BUILD_WITH_METADATA_SERVICES" == "TRUE" ]
-then
+if [ "$BUILD_WITH_METADATA_SERVICES" == "TRUE" ]; then
 
-cat <<EOF >> /etc/apache2/sites-available/000-default.conf
+  cat <<EOF >>/etc/apache2/sites-available/000-default.conf
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet
 # This block is needed if core web services are running on the same machine as
@@ -67,15 +66,14 @@ EOF
 fi
 
 if [ -n "$UID" ]; then
-    echo "Switching datafed user to UID: ${UID}"
-    usermod -u $UID datafed
-    # All files should be owned by the datafed user
-    chown -R datafed:root ${DATAFED_DIR}
-    chown -R datafed:root ${DATAFED_INSTALL_PATH}/authz
+  echo "Switching datafed user to UID: ${UID}"
+  usermod -u $UID datafed
+  # All files should be owned by the datafed user
+  chown -R datafed:root ${DATAFED_DIR}
+  chown -R datafed:root ${DATAFED_INSTALL_PATH}/authz
 fi
 
-if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]
-then
+if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]; then
   echo "datafed-core-key.pub not found, downloading from the core server"
   wget --no-check-certificate "https://${DATAFED_DOMAIN}/datafed-core-key.pub" -P "${DATAFED_INSTALL_PATH}/keys/"
 fi
@@ -101,7 +99,7 @@ cp "$PROJECT_ROOT/config/datafed-authz.cfg" "${DATAFED_INSTALL_PATH}/authz"
 
 # Make sure files did not persist from a previous docker compose run
 # This code block is used for cleaning up files that might have been cached by
-# docker compose. These files are not always appropraitely removed when the 
+# docker compose. These files are not always appropraitely removed when the
 # Globus container exits.
 #
 # List of files to delete
@@ -130,24 +128,22 @@ export NODE_SETUP_ARGS="--ip-address ${DATAFED_GCS_IP}"
 
 # Make sure globus-gridftp-server is running before running setup_globus
 data=$(ps aux | awk '{print $11}' | grep apache2 || true)
-while [ -z "${data}" ]
-do
-        data=$(ps aux | awk '{print $11}' | grep apache2 || true)
-        echo "Waiting for apache2 to start running"
-        sleep 1
+while [ -z "${data}" ]; do
+  data=$(ps aux | awk '{print $11}' | grep apache2 || true)
+  echo "Waiting for apache2 to start running"
+  sleep 1
 done
 echo "apache2 service found to be running!"
 
 # Needs a few seconds
-while [ ! -f /run/globus-gridftp-server.pid ]
-do
+while [ ! -f /run/globus-gridftp-server.pid ]; do
   echo "Waiting for globus-gridftp-server pid file to be created"
   sleep 1
 done
 echo "globus-gridftp-server pid file found!"
 
 # Need to wait until the domain name is properly registered
-DATAFED_GCS_URL=$(jq -r .domain_name < /var/lib/globus-connect-server/info.json)
+DATAFED_GCS_URL=$(jq -r .domain_name </var/lib/globus-connect-server/info.json)
 set +e
 HTTP_CODE=$("${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/curl" -s -o /dev/null -w "%{http_code}\n" -I "https://${DATAFED_GCS_URL}/api/info")
 echo "curl exit code: $?"
@@ -155,25 +151,22 @@ set -e
 echo "Waiting for domain name (https://${DATAFED_GCS_URL}) to be registered! Code: $HTTP_CODE"
 printf "\n"
 minutes=0
-while [ "$HTTP_CODE" != "200" ]
-do
+while [ "$HTTP_CODE" != "200" ]; do
 
   EraseToEOL=$(tput el)
 
   msg="Minutes $minutes "
-  for i in {1..12}
-  do
-      printf "%s" "${msg}"
-      msg='.'
-      sleep 5
-  
-      set +e
-      HTTP_CODE=$("${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/curl" -s -o /dev/null  -w "%{http_code}\n" -I "https://${DATAFED_GCS_URL}/api/info")
-      set -e
-      if [ "$HTTP_CODE" == "200" ]
-      then
-        break
-      fi  
+  for i in {1..12}; do
+    printf "%s" "${msg}"
+    msg='.'
+    sleep 5
+
+    set +e
+    HTTP_CODE=$("${DATAFED_DEPENDENCIES_INSTALL_PATH}/bin/curl" -s -o /dev/null -w "%{http_code}\n" -I "https://${DATAFED_GCS_URL}/api/info")
+    set -e
+    if [ "$HTTP_CODE" == "200" ]; then
+      break
+    fi
   done
   printf "\r${EraseToEOL}"
 
@@ -186,13 +179,11 @@ printf "\n"
 
 log_path="$DATAFED_DEFAULT_LOG_PATH"
 
-if [ ! -d "${log_path}" ]
-then
+if [ ! -d "${log_path}" ]; then
   mkdir -p "${log_path}"
 fi
 
-if [ ! -d "${DATAFED_GCS_COLLECTION_ROOT_PATH}" ]
-then
+if [ ! -d "${DATAFED_GCS_COLLECTION_ROOT_PATH}" ]; then
   mkdir -p ""${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}""
   chown -R datafed:root "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
 fi
@@ -207,29 +198,28 @@ source "${BUILD_DIR}/scripts/dependency_versions.sh"
 
 # Must be passed in directly
 GCS_CLI_ENDPOINT_ID="$GCS_CLI_ENDPOINT_ID" \
-DATAFED_GCS_COLLECTION_BASE_PATH="$DATAFED_GCS_COLLECTION_BASE_PATH" \
-DATAFED_GCS_URL="$DATAFED_GCS_URL" \
-GCS_CLI_CLIENT_ID="$GCS_CLI_CLIENT_ID" \
-GCS_CLI_CLIENT_SECRET="$GCS_CLI_CLIENT_SECRET" \
-DATAFED_REPO_USER="$DATAFED_REPO_USER" \
+  DATAFED_GCS_COLLECTION_BASE_PATH="$DATAFED_GCS_COLLECTION_BASE_PATH" \
+  DATAFED_GCS_URL="$DATAFED_GCS_URL" \
+  GCS_CLI_CLIENT_ID="$GCS_CLI_CLIENT_ID" \
+  GCS_CLI_CLIENT_SECRET="$GCS_CLI_CLIENT_SECRET" \
+  DATAFED_REPO_USER="$DATAFED_REPO_USER" \
   "python${DATAFED_PYTHON_VERSION}" "${BUILD_DIR}/scripts/globus/create_guest_collection.py"
 
 "${BUILD_DIR}/scripts/globus/generate_repo_form.sh" -j -s
 
-# Why is this approach being used? 
-# 
+# Why is this approach being used?
+#
 # Wild card expansion with *form was not working from within the script.
 find /opt/datafed/authz/ -name '*form.json' -or -name '*form.sh' | while read -r file; do
-    if [ -e "$file" ]; then
-        echo "Moving $file to /opt/datafed/globus/"
-        mv "$file" /opt/datafed/globus/
-    else
-        echo "No matching files found for pattern: $file"
-    fi
+  if [ -e "$file" ]; then
+    echo "Moving $file to /opt/datafed/globus/"
+    mv "$file" /opt/datafed/globus/
+  else
+    echo "No matching files found for pattern: $file"
+  fi
 done
 
 echo "Container is running."
 
 # Return to last file
 tail -f "${DATAFED_DEFAULT_LOG_PATH}/datafed-gsi-authz.log"
-

--- a/repository/docker/entrypoint_repo.sh
+++ b/repository/docker/entrypoint_repo.sh
@@ -11,35 +11,35 @@ PROJECT_ROOT=$(realpath "${SOURCE}/../..")
 
 # This is only part of the solution the other part is running chown
 if [ -n "$UID" ]; then
-	echo "Switching datafed user to UID: ${UID}"
-	usermod -u "$UID" datafed
-	chown -R datafed:root "${PROJECT_ROOT}"
-	chown -R datafed:root "${DATAFED_INSTALL_PATH}/repo/"
-	# Make sure the folder exists
-	mkdir -p "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
-	chown -R datafed:root "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
+  echo "Switching datafed user to UID: ${UID}"
+  usermod -u "$UID" datafed
+  chown -R datafed:root "${PROJECT_ROOT}"
+  chown -R datafed:root "${DATAFED_INSTALL_PATH}/repo/"
+  # Make sure the folder exists
+  mkdir -p "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
+  chown -R datafed:root "${DATAFED_GCS_COLLECTION_ROOT_PATH}/${DATAFED_REPO_ID_AND_DIR}"
 fi
 
 log_path="$DATAFED_DEFAULT_LOG_PATH"
 
 if [ ! -d "${log_path}" ]; then
-	su -c "mkdir -p ${log_path}" datafed
+  su -c "mkdir -p ${log_path}" datafed
 fi
 
 if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]; then
-	echo "datafed-core-key.pub not found, downloading from the core server"
-	wget --no-check-certificate "https://${DATAFED_DOMAIN}/datafed-core-key.pub" -P "${DATAFED_INSTALL_PATH}/keys/"
+  echo "datafed-core-key.pub not found, downloading from the core server"
+  wget --no-check-certificate "https://${DATAFED_DOMAIN}/datafed-core-key.pub" -P "${DATAFED_INSTALL_PATH}/keys/"
 fi
 
 datafed_repo_exec=$(basename "$1")
 if [ "${datafed_repo_exec}" = "datafed-repo" ]; then
-	# Send output to log file
-	# For this to work all commands must be passed in as a single string
-	su datafed -c '"$@"' -- argv0 "$@" 2>&1 | tee -a "$log_path/datafed-repo.log"
+  # Send output to log file
+  # For this to work all commands must be passed in as a single string
+  su datafed -c '"$@"' -- argv0 "$@" 2>&1 | tee -a "$log_path/datafed-repo.log"
 else
-	echo "Not sending output to datafed-core.log"
-	# If not do not by default send to log file
-	su datafed -c '"$@"' -- argv0 "$@"
+  echo "Not sending output to datafed-core.log"
+  # If not do not by default send to log file
+  su datafed -c '"$@"' -- argv0 "$@"
 fi
 
 # Allow the container to exist for a bit in case we need to jump in and look

--- a/repository/gridftp/globus5/authz/tests/mock/mock_start.sh
+++ b/repository/gridftp/globus5/authz/tests/mock/mock_start.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-if [ -f ./mock.log ]
-then
+if [ -f ./mock.log ]; then
   rm ./mock.log
 fi
-./datafed-mock-core --gen-keys 
-./datafed-mock-core > mock.log 2>&1 &
+./datafed-mock-core --gen-keys
+./datafed-mock-core >mock.log 2>&1 &
 sleep 2

--- a/repository/gridftp/globus5/authz/tests/mock/mock_stop.sh
+++ b/repository/gridftp/globus5/authz/tests/mock/mock_stop.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 echo "Stopping Mock Server"
-kill $(cat ./server.pid ) && rm -f ./server.pid
+kill $(cat ./server.pid) && rm -f ./server.pid
 cat ./mock.log

--- a/tests/end-to-end/setup.sh
+++ b/tests/end-to-end/setup.sh
@@ -4,9 +4,9 @@
 set -ef -o pipefail
 
 # # Description
-# 
+#
 # This script is designed to set up two DataFed users in the ArangoDB database, this
-# cannot be done via the public facing DataFed API because it requires a OAuth flow 
+# cannot be done via the public facing DataFed API because it requires a OAuth flow
 # that requires user interaction.
 #
 # The public API also does not allow creation of repos and adding allocations this is
@@ -37,16 +37,14 @@ set -ef -o pipefail
 local_DATABASE_NAME="sdms"
 local_DATABASE_USER="root"
 
-if [ -z "${DATAFED_DATABASE_PASSWORD}" ]
-then
+if [ -z "${DATAFED_DATABASE_PASSWORD}" ]; then
   local_DATAFED_DATABASE_PASSWORD=""
 else
   local_DATAFED_DATABASE_PASSWORD=$(printenv DATAFED_DATABASE_PASSWORD)
 fi
 
 local_DATAFED_USER89_PASSWORD=""
-if [ -z "${DATAFED_USER89_PASSWORD}" ]
-then
+if [ -z "${DATAFED_USER89_PASSWORD}" ]; then
   echo "REQUIRED env variable DATAFED_USER89_PASSWORD has not been set"
   exit 1
 else
@@ -55,26 +53,22 @@ else
   local_DATAFED_USER89_PASSWORD=$(echo "${DATAFED_USER89_PASSWORD}" | sed 's/!/%21/')
 fi
 
-if [ -z "${DATAFED_USER89_GLOBUS_REFRESH_TOKEN}" ]
-then
+if [ -z "${DATAFED_USER89_GLOBUS_REFRESH_TOKEN}" ]; then
   echo "REQUIRED env variable DATAFED_USER89_GLOBUS_REFRESH_TOKEN has not been set"
   exit 1
 fi
 
-if [ -z "${DATAFED_USER89_GLOBUS_ACCESS_TOKEN}" ]
-then
+if [ -z "${DATAFED_USER89_GLOBUS_ACCESS_TOKEN}" ]; then
   echo "REQUIRED env variable DATAFED_USER89_GLOBUS_ACCESS_TOKEN has not been set"
   exit 1
 fi
 
-if [ -z "${DATAFED_USER89_GLOBUS_UUID}" ]
-then
+if [ -z "${DATAFED_USER89_GLOBUS_UUID}" ]; then
   echo "REQUIRED env variable DATAFED_USER89_GLOBUS_UUID has not been set"
   exit 1
 fi
 
-if [ -z "${DATAFED_USER99_PASSWORD}" ]
-then
+if [ -z "${DATAFED_USER99_PASSWORD}" ]; then
   echo "REQUIRED env variable DATAFED_USER99_PASSWORD has not been set"
   exit 1
 else
@@ -83,20 +77,17 @@ else
   local_DATAFED_USER99_PASSWORD=$(echo "${DATAFED_USER99_PASSWORD}" | sed 's/!/%21/')
 fi
 
-if [ -z "${DATAFED_USER99_GLOBUS_REFRESH_TOKEN}" ]
-then
+if [ -z "${DATAFED_USER99_GLOBUS_REFRESH_TOKEN}" ]; then
   echo "REQUIRED env variable DATAFED_USER99_GLOBUS_REFRESH_TOKEN has not been set"
   exit 1
 fi
 
-if [ -z "${DATAFED_USER99_GLOBUS_ACCESS_TOKEN}" ]
-then
+if [ -z "${DATAFED_USER99_GLOBUS_ACCESS_TOKEN}" ]; then
   echo "REQUIRED env variable DATAFED_USER99_GLOBUS_ACCESS_TOKEN has not been set"
   exit 1
 fi
 
-if [ -z "${DATAFED_USER99_GLOBUS_UUID}" ]
-then
+if [ -z "${DATAFED_USER99_GLOBUS_UUID}" ]; then
   echo "REQUIRED env variable DATAFED_USER99_GLOBUS_UUID has not been set"
   exit 1
 fi
@@ -106,28 +97,24 @@ SOURCE=$(dirname "$SCRIPT")
 PROJECT_ROOT=$(realpath ${SOURCE}/../../)
 source ${PROJECT_ROOT}/config/datafed.sh
 
-if [ -z "${FOXX_MAJOR_API_VERSION}" ]
-then
-  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs )
+if [ -z "${FOXX_MAJOR_API_VERSION}" ]; then
+  local_FOXX_MAJOR_API_VERSION=$(cat ${PROJECT_ROOT}/cmake/Version.cmake | grep -o -P "(?<=FOXX_API_MAJOR).*(?=\))" | xargs)
 else
   local_FOXX_MAJOR_API_VERSION=$(printenv FOXX_MAJOR_API_VERSION)
 fi
 
-
 # Detect whether arangodb is running locally
 {
-	ARANGODB_RUNNING=$(systemctl is-active --quiet arangodb3.service && echo "RUNNING")
+  ARANGODB_RUNNING=$(systemctl is-active --quiet arangodb3.service && echo "RUNNING")
 } || {
-	echo "Arangodb service is not locally detected."
+  echo "Arangodb service is not locally detected."
 }
 
-if [ "${DATAFED_DATABASE_HOST}" == "localhost" ] || [ "${DATAFED_DATABASE_HOST}" == "127.0.0.1" ]
-then
-	if [ "$ARANGODB_RUNNING" != "RUNNING" ]
-	then
-	  echo "REQUIRED the arangodb service has not been detected to be running by systemctl"
-	  exit 1
-	fi
+if [ "${DATAFED_DATABASE_HOST}" == "localhost" ] || [ "${DATAFED_DATABASE_HOST}" == "127.0.0.1" ]; then
+  if [ "$ARANGODB_RUNNING" != "RUNNING" ]; then
+    echo "REQUIRED the arangodb service has not been detected to be running by systemctl"
+    exit 1
+  fi
 fi
 
 # First step is to clear the database
@@ -139,20 +126,17 @@ echo "Installing foxx services and API"
 ${PROJECT_ROOT}/scripts/install_foxx.sh
 echo "Completed"
 
-if [ -z "${DATAFED_DATABASE_HOST}" ]
-then
+if [ -z "${DATAFED_DATABASE_HOST}" ]; then
   local_DATAFED_DATABASE_HOST=$(hostname -I | awk '{print $1}')
 else
   local_DATAFED_DATABASE_HOST=$(printenv DATAFED_DATABASE_HOST)
 fi
 
-if [ -z "${DATAFED_DATABASE_PORT}" ]
-then
+if [ -z "${DATAFED_DATABASE_PORT}" ]; then
   local_DATAFED_DATABASE_PORT="8529"
 else
   local_DATAFED_DATABASE_PORT=$(printenv DATAFED_DATABASE_PORT)
 fi
-
 
 # If the database was set up correctly auth will be turned on
 basic_auth="$local_DATABASE_USER:$local_DATAFED_DATABASE_PASSWORD"
@@ -161,51 +145,47 @@ echo "IP is ${local_DATAFED_DATABASE_HOST}"
 echo "USER89 GLobud ID $DATAFED_USER89_GLOBUS_UUID"
 echo "Refresh is ${DATAFED_USER89_GLOBUS_REFRESH_TOKEN}"
 # Chreate user datafed89 who is admin
-HTTP_CODE=$( curl --user "${basic_auth}" -w "%{http_code}" -o /dev/null -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed89&uuids=%5B\"${DATAFED_USER89_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER89_PASSWORD}&email=datafed89%40gmail.com&is_admin=true" )
+HTTP_CODE=$(curl --user "${basic_auth}" -w "%{http_code}" -o /dev/null -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed89&uuids=%5B\"${DATAFED_USER89_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER89_PASSWORD}&email=datafed89%40gmail.com&is_admin=true")
 echo "HTTP_CODE: ${HTTP_CODE}"
 FIRST_INT=${HTTP_CODE:0:1}
-if [ "${FIRST_INT}" -ne "2" ]
-then
-  response=$( curl --user "${basic_auth}" -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed89&uuids=%5B\"${DATAFED_USER89_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER89_PASSWORD}&email=datafed89%40gmail.com&is_admin=true" )
-  CODE=$(echo $response | jq .code )
-  ERROR_MSG=$(echo $response | jq .errorMessage )
+if [ "${FIRST_INT}" -ne "2" ]; then
+  response=$(curl --user "${basic_auth}" -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed89&uuids=%5B\"${DATAFED_USER89_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER89_PASSWORD}&email=datafed89%40gmail.com&is_admin=true")
+  CODE=$(echo $response | jq .code)
+  ERROR_MSG=$(echo $response | jq .errorMessage)
   echo "$ERROR_MSG"
   exit 1
 fi
 # Set globus tokens
-HTTP_CODE=$(curl --user "${basic_auth}" -w "%{http_code}" -o /dev/null  -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed89&access=${DATAFED_USER89_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER89_GLOBUS_REFRESH_TOKEN}&expires_in=1")
+HTTP_CODE=$(curl --user "${basic_auth}" -w "%{http_code}" -o /dev/null -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed89&access=${DATAFED_USER89_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER89_GLOBUS_REFRESH_TOKEN}&expires_in=1")
 echo "HTTP_CODE: ${HTTP_CODE}"
 FIRST_INT=${HTTP_CODE:0:1}
-if [ "${FIRST_INT}" -ne "2" ]
-then
+if [ "${FIRST_INT}" -ne "2" ]; then
   response=$(curl --user "${basic_auth}" --fail-early -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed89&access=${DATAFED_USER89_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER89_GLOBUS_REFRESH_TOKEN}&expires_in=1")
-  CODE=$(echo $response | jq .code )
-  ERROR_MSG=$(echo $response | jq .errorMessage )
+  CODE=$(echo $response | jq .code)
+  ERROR_MSG=$(echo $response | jq .errorMessage)
   echo "$ERROR_MSG"
   exit 1
 fi
 
 # Create user datafed99 who is not admin
-HTTP_CODE=$(curl  --user "${basic_auth}"  -w "%{http_code}" -o /dev/null  -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed99&uuids=%5B\"${DATAFED_USER99_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER99_PASSWORD}&email=datafed99%40gmail.com&is_admin=false")
+HTTP_CODE=$(curl --user "${basic_auth}" -w "%{http_code}" -o /dev/null -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed99&uuids=%5B\"${DATAFED_USER99_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER99_PASSWORD}&email=datafed99%40gmail.com&is_admin=false")
 echo "HTTP_CODE: ${HTTP_CODE}"
 FIRST_INT=${HTTP_CODE:0:1}
-if [ "${FIRST_INT}" -ne "2" ]
-then
-  response=$(curl  --user "${basic_auth}" --fail-early -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed99&uuids=%5B\"${DATAFED_USER99_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER99_PASSWORD}&email=datafed99%40gmail.com&is_admin=false")
-  CODE=$(echo $response | jq .code )
-  ERROR_MSG=$(echo $response | jq .errorMessage )
+if [ "${FIRST_INT}" -ne "2" ]; then
+  response=$(curl --user "${basic_auth}" --fail-early -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/create?name=Data%20Fed&uid=datafed99&uuids=%5B\"${DATAFED_USER99_GLOBUS_UUID}\"%5D&password=${local_DATAFED_USER99_PASSWORD}&email=datafed99%40gmail.com&is_admin=false")
+  CODE=$(echo $response | jq .code)
+  ERROR_MSG=$(echo $response | jq .errorMessage)
   echo "$ERROR_MSG"
   exit 1
 fi
 # Set globus tokens
-HTTP_CODE=$(curl --user "${basic_auth}"   -w "%{http_code}" -o /dev/null  -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed99&access=${DATAFED_USER99_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER99_GLOBUS_REFRESH_TOKEN}&expires_in=1")
+HTTP_CODE=$(curl --user "${basic_auth}" -w "%{http_code}" -o /dev/null -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed99&access=${DATAFED_USER99_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER99_GLOBUS_REFRESH_TOKEN}&expires_in=1")
 echo "HTTP_CODE: ${HTTP_CODE}"
 FIRST_INT=${HTTP_CODE:0:1}
-if [ "${FIRST_INT}" -ne "2" ]
-then
-  response=$(curl --user "${basic_auth}"  --fail-early -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed99&access=${DATAFED_USER99_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER99_GLOBUS_REFRESH_TOKEN}&expires_in=1")
-  CODE=$(echo $response | jq .code )
-  ERROR_MSG=$(echo $response | jq .errorMessage )
+if [ "${FIRST_INT}" -ne "2" ]; then
+  response=$(curl --user "${basic_auth}" --fail-early -X GET "http://${local_DATAFED_DATABASE_HOST}:${local_DATAFED_DATABASE_PORT}/_db/${local_DATABASE_NAME}/api/${local_FOXX_MAJOR_API_VERSION}/usr/token/set?client=u%2Fdatafed99&access=${DATAFED_USER99_GLOBUS_ACCESS_TOKEN}&refresh=${DATAFED_USER99_GLOBUS_REFRESH_TOKEN}&expires_in=1")
+  CODE=$(echo $response | jq .code)
+  ERROR_MSG=$(echo $response | jq .errorMessage)
   echo "$ERROR_MSG"
   exit 1
 fi

--- a/web/docker/entrypoint.sh
+++ b/web/docker/entrypoint.sh
@@ -4,7 +4,7 @@
 set -euf -o pipefail
 
 if [ -n "$UID" ]; then
-    usermod -u "$UID" datafed
+  usermod -u "$UID" datafed
 fi
 
 chown -R datafed:root "${DATAFED_INSTALL_PATH}/web"
@@ -32,13 +32,11 @@ fi
 # Send output to file as well as print to terminal
 log_path=$(grep "log-path" "${BUILD_DIR}/config/datafed-ws.cfg" | cut -d "=" -f 2 | tr -d ' ')
 
-if [ ! -d "${log_path}" ]
-then
+if [ ! -d "${log_path}" ]; then
   su -c "mkdir -p ${log_path}" datafed
 fi
 
-if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]
-then
+if [ ! -f "${DATAFED_INSTALL_PATH}/keys/datafed-core-key.pub" ]; then
   echo "datafed-core-key.pub not found"
   exit 1
 fi
@@ -52,8 +50,7 @@ fi
 
 cd "$DATAFED_INSTALL_PATH/web"
 datafed_ws_exec=$(basename "$1")
-if [ "${datafed_ws_exec}" = "datafed-ws.js" ]
-then
+if [ "${datafed_ws_exec}" = "datafed-ws.js" ]; then
   # Send output to log file
   su datafed -c '"$@"' -- argv0 "$@" 2>&1 | su datafed -c "tee $log_path/datafed-ws.log"
 else
@@ -61,4 +58,3 @@ else
   # If not do not by default send to log file
   su datafed -c '"$@"' -- argv0 "$@"
 fi
-


### PR DESCRIPTION
## Ticket  

#1568 

## Description 

Formatting the remaining scripts within DataFed

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Standardize formatting of shell scripts across the DataFed codebase by applying consistent bracing, whitespace, indentation, and redirection style.

Enhancements:
- Apply consistent if-statement bracing and semicolon placement across all scripts
- Unify redirection syntax by moving input redirection next to command names
- Normalize indentation levels, remove trailing whitespace, and adjust blank lines in entrypoint, test, and compose scripts
- Run automated formatter on remaining shell scripts under repository/docker, core/database/tests, tests/end-to-end, common/tests, compose, python/docker, and web/docker directories