### PR TITLE
[DAPS-1616] [Common] fix: make system secret optional before removing completely.

### DIFF
--- a/common/proto/common/SDMS_Auth.proto
+++ b/common/proto/common/SDMS_Auth.proto
@@ -149,7 +149,7 @@ message UserCreateRequest
     required string             email       = 4; // Email address
     repeated string             uuid        = 5; // UUID for primary Globus account
     optional string             options     = 6; // DataFed options (JSON string)
-    required string             secret      = 7; // System secret
+    optional string             secret      = 7; // System secret
 }
 
 // Request to find DataFed user by one or more Globus UUIDs


### PR DESCRIPTION
## Ticket  

#1616 

## Description 

We have been removing system secrets as part of a cleanup effort. However, the proto message still had the secret as a required parameter and was causing an error to be thrown when trying to create a user account.

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Bug Fixes:
- Make secret field in SDMS_Auth.proto optional to prevent errors when creating users without a system secret