### PR TITLE
Permissions issues when attempting to remove Version.proto during build

### DIFF
--- a/docker/Dockerfile.foxx
+++ b/docker/Dockerfile.foxx
@@ -77,6 +77,7 @@ RUN chown -R datafed:root /home/datafed \
     find ${BUILD_DIR}/config -maxdepth 1 -type f -exec chmod 0664 {} + && \
     find ${BUILD_DIR}/core/database -type f -exec chmod 0664 {} + && \
     find ${BUILD_DIR}/core -type d -exec chmod 0774 {} + && \
+    find ${BUILD_DIR}/common/proto/common -type d -exec chmod 0774 {} + && \
     find ${BUILD_DIR}/common -type f -exec chmod 0664 {} + && \
     find ${DATAFED_DEPENDENCIES_INSTALL_PATH}/nvm -type d -exec chmod 0774 {} + && \
     chmod 774    ${BUILD_DIR} \


### PR DESCRIPTION
## Ticket  

#1619

## Description 

During container startup, the datafed-foxx-1 service fails to start due to a permission error while attempting to remove the file /datafed/source/common/proto/common/Version.proto.

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Fix foxx service startup failure by adjusting Dockerfile permissions to allow removal of Version.proto

Bug Fixes:
- Resolve permission error when removing Version.proto during container startup

Build:
- Update Dockerfile.foxx to set correct ownership and permissions on the Version.proto file