### PR TITLE
[DAPS-1625] Clear Cache for Non-Persistent Keys on Repo Config Reload

### DIFF
--- a/common/source/operators/AuthenticationOperator.cpp
+++ b/common/source/operators/AuthenticationOperator.cpp
@@ -7,6 +7,7 @@
 
 // Standard includes
 #include <any>
+#include <iostream>
 
 namespace SDMS {
 
@@ -36,10 +37,13 @@ void AuthenticationOperator::execute(IMessage &message) {
     try {
       uid = m_authentication_manager->getUID(key);
     } catch (const std::exception& e) {
+      // Log the exception to help diagnose authentication issues
+      std::cerr << "[AuthenticationOperator] Failed to get UID for key: " 
+                << key.substr(0, 8) << "... Exception: " << e.what() << std::endl;
       // Keep uid as "anon" if we fail to get the actual UID
     }
   }
-  
+
   message.set(MessageAttribute::ID, uid);
 }
 

--- a/common/source/operators/AuthenticationOperator.cpp
+++ b/common/source/operators/AuthenticationOperator.cpp
@@ -7,7 +7,6 @@
 
 // Standard includes
 #include <any>
-#include <iostream>
 
 namespace SDMS {
 
@@ -33,8 +32,14 @@ void AuthenticationOperator::execute(IMessage &message) {
   std::string uid = "anon";
   if (m_authentication_manager->hasKey(key)) {
     m_authentication_manager->incrementKeyAccessCounter(key);
-    uid = m_authentication_manager->getUID(key);
+    
+    try {
+      uid = m_authentication_manager->getUID(key);
+    } catch (const std::exception& e) {
+      // Keep uid as "anon" if we fail to get the actual UID
+    }
   }
+  
   message.set(MessageAttribute::ID, uid);
 }
 

--- a/core/server/AuthMap.cpp
+++ b/core/server/AuthMap.cpp
@@ -327,8 +327,11 @@ void AuthMap::migrateKey(const PublicKeyType from_type,
     removeKey(from_type, public_key);
   }
 
-  // Add to destination map
-  addKey(to_type, public_key, id);
+  // Add to destination map only if it does not already exist
+  // This prevents overwriting existing entries
+  if (!hasKey(to_type, public_key)) {
+    addKey(to_type, public_key, id);
+  }
 }
 
 void AuthMap::clearTransientKeys() {

--- a/core/server/AuthMap.hpp
+++ b/core/server/AuthMap.hpp
@@ -33,6 +33,11 @@ private:
   time_t m_trans_active_increment = 0;
   time_t m_session_active_increment = 0;
 
+  /**
+   * WARNING if more than one lock guard need to be applied in a given
+   * method they must be locked in a consistent order to avoid deadlock
+   * TRANSIENT -> SESSION -> PERSISTENT
+   **/
   mutable std::mutex
       m_trans_clients_mtx; ///< Mutex for transient client data access
   mutable std::mutex

--- a/core/server/AuthMap.hpp
+++ b/core/server/AuthMap.hpp
@@ -109,6 +109,12 @@ public:
    **/
   std::string getUID(const PublicKeyType pub_key_type,
                      const std::string &public_key) const;
+  
+  /**
+   * Safe version that returns empty string if key not found
+   **/
+  std::string getUIDSafe(const PublicKeyType pub_key_type,
+                         const std::string &public_key) const;
 
   /**
    * Will return the number of keys of the provided type. Does not currently
@@ -147,6 +153,21 @@ public:
                  const std::string &public_key);
 
   /**
+   * Migrates a key from one map type to another with the specified ID.
+   * This is useful for correcting misclassified keys (e.g., when a repository
+   * key was incorrectly cached as transient/session during DB outage).
+   *
+   * @param from_type The source key type to remove from
+   * @param to_type The destination key type to add to
+   * @param public_key The public key to migrate
+   * @param id The ID to associate with the key in the destination map
+   **/
+  void migrateKey(const PublicKeyType from_type,
+                  const PublicKeyType to_type,
+                  const std::string &public_key,
+                  const std::string &id);
+
+  /**
    * Will reset the access counter of the key to 0 and the allowed expiration
    *time of the key..
    *
@@ -154,6 +175,24 @@ public:
    **/
   void resetKey(const PublicKeyType pub_key_type,
                 const std::string &public_key);
+
+  /**
+   * Clear all transient keys from the authentication map.
+   * This is useful for cleaning up stale keys after service restarts.
+   **/
+  void clearTransientKeys();
+
+  /**
+   * Clear all session keys from the authentication map.
+   * This is useful for cleaning up stale keys after service restarts.
+   **/
+  void clearSessionKeys();
+
+  /**
+   * Clear all non-persistent (transient and session) keys.
+   * Persistent keys are preserved as they represent service accounts.
+   **/
+  void clearAllNonPersistentKeys();
 };
 
 } // namespace Core

--- a/core/server/AuthMap.hpp
+++ b/core/server/AuthMap.hpp
@@ -153,14 +153,29 @@ public:
                  const std::string &public_key);
 
   /**
-   * Migrates a key from one map type to another with the specified ID.
+   * @brief Migrates an authentication key from one storage type to another.
+   *
+   * This method supports migrating keys between specific `PublicKeyType`s:
+   * - TRANSIENT -> SESSION
+   * - SESSION   -> PERSISTENT
+   *
    * This is useful for correcting misclassified keys (e.g., when a repository
    * key was incorrectly cached as transient/session during DB outage).
    *
-   * @param from_type The source key type to remove from
-   * @param to_type The destination key type to add to
-   * @param public_key The public key to migrate
-   * @param id The ID to associate with the key in the destination map
+   * The migration process ensures:
+   *  - The source key exists before attempting removal.
+   *  - The destination key does not exist before insertion.
+   *  - Appropriate locks are taken to ensure thread safety.
+   *
+   * @param from_type   The original type of the key (TRANSIENT or SESSION).
+   * @param to_type     The target type of the key (SESSION or PERSISTENT).
+   * @param public_key  The public key to be migrated.
+   * @param id          The identifier associated with the key.
+   *
+   * @throws Exception if:
+   *   - Migration is not supported.
+   *   - The source key is missing.
+   *   - Any internal invariant fails during migration.
    **/
   void migrateKey(const PublicKeyType from_type,
                   const PublicKeyType to_type,

--- a/core/server/AuthenticationManager.hpp
+++ b/core/server/AuthenticationManager.hpp
@@ -85,6 +85,35 @@ public:
               const std::string &uid);
 
   /**
+   * Check if a specific key exists in a specific map type
+   **/
+  bool hasKey(const PublicKeyType &pub_key_type, const std::string &public_key) const;
+
+  /**
+   * Migrate a key from one type to another
+   **/
+  void migrateKey(const PublicKeyType &from_type, const PublicKeyType &to_type,
+                  const std::string &public_key, const std::string &uid);
+
+  /**
+   * Clear all transient keys from the authentication map.
+   * This is useful for cleaning up stale keys after service restarts.
+   **/
+  void clearTransientKeys();
+
+  /**
+   * Clear all session keys from the authentication map.
+   * This is useful for cleaning up stale keys after service restarts.
+   **/
+  void clearSessionKeys();
+
+  /**
+   * Clear all non-persistent (transient and session) keys.
+   * Persistent keys are preserved as they represent service accounts.
+   **/
+  void clearAllNonPersistentKeys();
+
+  /**
    * Will the id or throw an error
    *
    * Will look at all keys:
@@ -93,6 +122,12 @@ public:
    * - PERSISTENT
    **/
   virtual std::string getUID(const std::string &pub_key) const final;
+  
+  /**
+   * Safe version that returns empty string if key not found
+   * instead of throwing an exception
+   **/
+  std::string getUIDSafe(const std::string &pub_key) const;
 };
 
 } // namespace Core

--- a/core/server/Config.cpp
+++ b/core/server/Config.cpp
@@ -28,13 +28,6 @@ void Config::loadRepositoryConfig(AuthenticationManager &auth_manager,
     m_repos_mtx.unlock();
   }
 
-  // Clear all non-persistent keys before reloading repository configurations
-  // This ensures stale cached keys don't interfere with authentication.
-  // NOTE: Non-persistent keys are cleared during configuration reload (typically at startup or explicit refresh).
-  // This may impact any sessions active during a reload, but such cases are rare in normal operation.
-  DL_INFO(log_context, "Clearing non-persistent keys before loading repository configuration");
-  auth_manager.clearAllNonPersistentKeys();
-
   DatabaseAPI db_client(db_url, db_user, db_pass);
 
   std::vector<RepoData> temp_repos;

--- a/core/server/CoreServer.cpp
+++ b/core/server/CoreServer.cpp
@@ -80,13 +80,14 @@ Server::Server(LogContext log_context)
   purge_conditions[PublicKeyType::SESSION].emplace_back(
       std::make_unique<Reset>(accesses_to_reset, key_type_to_apply_reset));
 
-  // Load repository config from DB
-  m_config.loadRepositoryConfig(m_auth_manager, log_context);
-
-  // Must occur after loading config settings
+  // Initialize AuthenticationManager BEFORE loading repository config
+  // This ensures repos are loaded into the correct instance
   m_auth_manager = std::move(AuthenticationManager(
       purge_intervals, std::move(purge_conditions), m_config.db_url,
       m_config.db_user, m_config.db_pass));
+
+  // Now load repository config from DB into the initialized AuthenticationManager
+  m_config.loadRepositoryConfig(m_auth_manager, log_context);
 
   // Start ZAP handler must be started before any other socket binds are called
   // m_zap_thread = thread( &Server::zapHandler, this );

--- a/core/server/tests/unit/test_AuthMap.cpp
+++ b/core/server/tests/unit/test_AuthMap.cpp
@@ -7,6 +7,9 @@
 // Local private includes
 #include "AuthMap.hpp"
 
+// Local public includes
+#include "common/TraceException.hpp"
+
 // Third party includes
 #include <google/protobuf/stubs/common.h>
 
@@ -70,6 +73,101 @@ BOOST_AUTO_TEST_CASE(testing_AuthMap_setgetcount) {
 
   BOOST_TEST(auth_map.getAccessCount(PublicKeyType::TRANSIENT, new_pub_key) ==
              5);
+}
+
+BOOST_AUTO_TEST_CASE(testing_migrateKey_TRANSIENT_to_SESSION) {
+  time_t active_transient_key_time = 30;
+  time_t active_session_key_time = 30;
+  std::string db_url = "https://db/sdms/blah";
+  std::string db_user = "greatestone";
+  std::string db_pass = "1234";
+
+  AuthMap auth_map(active_transient_key_time, active_session_key_time, db_url,
+                   db_user, db_pass);
+
+  std::string pub_key = "test_key";
+  std::string user_id = "u/alice";
+
+  // Add TRANSIENT key first
+  auth_map.addKey(PublicKeyType::TRANSIENT, pub_key, user_id);
+  BOOST_TEST(auth_map.hasKey(PublicKeyType::TRANSIENT, pub_key));
+
+  // Migrate to SESSION
+  auth_map.migrateKey(PublicKeyType::TRANSIENT, PublicKeyType::SESSION, pub_key, user_id);
+
+  // Verify key is moved
+  BOOST_TEST(!auth_map.hasKey(PublicKeyType::TRANSIENT, pub_key));
+  BOOST_TEST(auth_map.hasKey(PublicKeyType::SESSION, pub_key));
+  BOOST_TEST(auth_map.getUID(PublicKeyType::SESSION, pub_key) == user_id);
+}
+
+BOOST_AUTO_TEST_CASE(testing_migrateKey_SESSION_to_PERSISTENT) {
+  time_t active_transient_key_time = 30;
+  time_t active_session_key_time = 30;
+  std::string db_url = "https://db/sdms/blah";
+  std::string db_user = "greatestone";
+  std::string db_pass = "1234";
+
+  AuthMap auth_map(active_transient_key_time, active_session_key_time, db_url,
+                   db_user, db_pass);
+
+  std::string pub_key = "test_key2";
+  std::string user_id = "u/bob";
+
+  // Add SESSION key first
+  auth_map.addKey(PublicKeyType::SESSION, pub_key, user_id);
+  BOOST_TEST(auth_map.hasKey(PublicKeyType::SESSION, pub_key));
+
+  // Migrate to PERSISTENT
+  auth_map.migrateKey(PublicKeyType::SESSION, PublicKeyType::PERSISTENT, pub_key, user_id);
+
+  // Verify key is moved
+  BOOST_TEST(!auth_map.hasKey(PublicKeyType::SESSION, pub_key));
+  BOOST_TEST(auth_map.hasKey(PublicKeyType::PERSISTENT, pub_key));
+  BOOST_TEST(auth_map.getUID(PublicKeyType::PERSISTENT, pub_key) == user_id);
+}
+
+BOOST_AUTO_TEST_CASE(testing_migrateKey_invalid_migration) {
+  time_t active_transient_key_time = 30;
+  time_t active_session_key_time = 30;
+  std::string db_url = "https://db/sdms/blah";
+  std::string db_user = "greatestone";
+  std::string db_pass = "1234";
+
+  AuthMap auth_map(active_transient_key_time, active_session_key_time, db_url,
+                   db_user, db_pass);
+
+  std::string pub_key = "test_key3";
+  std::string user_id = "u/charlie";
+
+  // Add PERSISTENT key (not allowed to migrate from here)
+  auth_map.addKey(PublicKeyType::PERSISTENT, pub_key, user_id);
+
+  // Attempt an invalid migration (PERSISTENT -> SESSION)
+  BOOST_CHECK_THROW(
+    auth_map.migrateKey(PublicKeyType::PERSISTENT, PublicKeyType::SESSION, pub_key, user_id),
+    TraceException
+  );
+}
+
+BOOST_AUTO_TEST_CASE(testing_migrateKey_missing_source_key) {
+  time_t active_transient_key_time = 30;
+  time_t active_session_key_time = 30;
+  std::string db_url = "https://db/sdms/blah";
+  std::string db_user = "greatestone";
+  std::string db_pass = "1234";
+
+  AuthMap auth_map(active_transient_key_time, active_session_key_time, db_url,
+                   db_user, db_pass);
+
+  std::string pub_key = "test_key4";
+  std::string user_id = "u/dave";
+
+  // Try to migrate a missing TRANSIENT key
+  BOOST_CHECK_THROW(
+    auth_map.migrateKey(PublicKeyType::TRANSIENT, PublicKeyType::SESSION, pub_key, user_id),
+    TraceException
+  );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Ticket  

[DAPS-1625](https://github.com/ORNL/DataFed/issues/1625)

## Description 

`AuthenticationManager` was being initialized AFTER `loadRepositoryConfig()` was called in `CoreServer.cpp`, resulting in repository keys being added to a temporary instance that was then overwritten

1. Fixed initialization order in `CoreServer.cpp` - `AuthenticationManager` is now initialized **BEFORE** loading repository configuration
2. Added defensive checks to handle misclassified keys during `repo config` reloads
3. Fixed race conditions by adding missing `mutex locks` for persistent key access in `AuthMap::getUID` and `getUIDSafe`
4. Refactored `getUID` to use `getUIDSafe` internally
5. Added key clearing methods (`clearTransientKeys`, `clearSessionKeys`, `clearAllNonPersistentKeys`) for proper cleanup on `repo config` reload
6. Added logs for debugging and general logging

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<details><summary>Details</summary>
<p>

1. Register repo
```bash
datafed-core-1  | [AUTHMAP hasKey @0x7ffe582733a0] Checking PERSISTENT memory map for *dJW...cKkD - FOUND (map size: 1)
```
2. New data record, add data, process
3. Shut down Arango Service
4. Keep Core up
5. See core tries to auth via persistant key
6. Restart core service
7. Restart arango service
```bash
datafed-core-1  | 2025-09-10T21:13:12.125744Z INFO /datafed/source/core/server/CoreServer.cpp:waitForDB:138 { "thread_name": "core_server", "message": "Waiting for DB..." }
datafed-core-1  | 2025-09-10T21:13:12.128415Z INFO /datafed/source/core/server/CoreServer.cpp:waitForDB:145 { "thread_name": "core_server", "message": "DB Ping Success" }
datafed-core-1  | [AUTH_MANAGER] Initialized with AuthMap at 0x7ffe58272d18
datafed-core-1  | [AUTHMAP MOVE=] Moving AuthMap from 0x7ffe58272d18 to 0x7ffe582733a0
datafed-core-1  | [AUTHMAP MOVE=] Moved 0 persistent keys
datafed-core-1  | 2025-09-10T21:13:12.128538Z INFO /datafed/source/core/server/Config.cpp:loadRepositoryConfig:33 { "thread_name": "core_server", "message": "Clearing non-persistent keys before loading repository configuration" }
datafed-core-1  | [CONFIG] About to clear all non-persistent keys before repo config reload
datafed-core-1  | [AUTHMAP] Cleared 0 transient keys
datafed-core-1  | [AUTHMAP] Cleared 0 session keys
datafed-core-1  | [AUTHMAP] All non-persistent keys cleared
datafed-core-1  | [CONFIG] Finished clearing non-persistent keys
datafed-core-1  | [CONFIG] Registering repo repo/compose-home with key *dJWx(D$...
datafed-core-1  | [AUTHMAP hasKey] Checking TRANSIENT for *dJW...cKkD - NOT FOUND (map size: 0)
datafed-core-1  | [AUTHMAP hasKey] Checking SESSION for *dJW...cKkD - NOT FOUND (map size: 0)
datafed-core-1  | [CONFIG] Adding repo repo/compose-home key as new PERSISTENT key
datafed-core-1  | [AUTH_MANAGER @0x7ffe58273308] Adding key, AuthMap at 0x7ffe582733a0
datafed-core-1  | [AUTHMAP addKey @0x7ffe582733a0] Adding PERSISTENT key for id: repo/compose-home, key: *dJWx(D$...
datafed-core-1  | [AUTHMAP addKey @0x7ffe582733a0] PERSISTENT map now has 1 keys
datafed-core-1  | [AUTHMAP addKey] - Key: *dJWx(D$... -> repo/compose-home
datafed-core-1  | 2025-09-10T21:13:12.132117Z INFO /datafed/source/core/server/Config.cpp:loadRepositoryConfig:100 { "thread_name": "core_server", "message": "Repo repo/compose-home OK - UUID: 2fef93cc-92f0-4d53-ba88-5c1ab78abc5a address: tcp://dataflow-dev.ornl.gov:9000" }
datafed-core-1  | [CONFIG] Repo repo/compose-home successfully registered
datafed-core-1  | [CONFIG] Validating repository keys after loading...
datafed-core-1  | [AUTHMAP hasKey @0x7ffe582733a0] Checking PERSISTENT memory map for *dJW...cKkD - FOUND (map size: 1)
datafed-core-1  | [AUTHMAP hasKey] Keys in PERSISTENT map:
datafed-core-1  | [AUTHMAP hasKey]   - *dJWx(D$... -> repo/compose-home
datafed-core-1  | [AUTHMAP hasKey] Key found in PERSISTENT memory map, returning true
datafed-core-1  | [CONFIG] ✓ Key for repo/compose-home verified in PERSISTENT map
datafed-core-1  | [CONFIG] Repository key validation complete
datafed-core-1  | 2025-09-10T21:13:12.132556Z WARN /datafed/source/core/server/DatabaseAPI.cpp:metricsUpdateMsgCounts:3754 { "thread_name": "core_server-metricsThread", "thread_id": "3", "message": "Serialized metric bodies did not match, new serialization yielded:
datafed-core-1  | {"timestamp":"1757538792","total":"0","uids":null}
datafed-core-1  |  old serialization yielded:
datafed-core-1  | {"timestamp":1757538792,"total":0,"uids":{}}" }
datafed-core-1  | 2025-09-10T21:13:12.135427Z INFO /datafed/source/core/server/CoreServer.cpp:run:166 { "thread_name": "core_server", "message": "Public/private MAPI starting on ports 7512/7513" }
datafed-core-1  | 2025-09-10T21:13:12.484689Z INFO /datafed/source/core/server/TaskMgr.cpp:maintenanceThread:146 { "thread_name": "core_server-TaskMgr-maintenaceThread", "thread_id": "1", "message": "MAINT: Next purge: 1757560392" }
datafed-core-1  | 2025-09-10T21:13:12.484745Z INFO /datafed/source/core/server/TaskMgr.cpp:maintenanceThread:150 { "thread_name": "core_server-TaskMgr-maintenaceThread", "thread_id": "1", "message": "MAINT: tasks in retry queue: 0" }
datafed-core-1  | 2025-09-10T21:13:12.484785Z INFO /datafed/source/core/server/TaskMgr.cpp:maintenanceThread:167 { "thread_name": "core_server-TaskMgr-maintenaceThread", "thread_id": "1", "message": "MAINT: timeout: 1757560392" }
datafed-core-1  | 2025-09-10T21:13:12.484826Z INFO /datafed/source/core/server/TaskMgr.cpp:maintenanceThread:177 { "thread_name": "core_server-TaskMgr-maintenaceThread", "thread_id": "1", "message": "MAINT: timeout > now then wait_until " }
datafed-core-1  | 2025-09-10T21:13:13.173439Z ERROR /datafed/source/core/server/GlobusAPI.cpp:transfer:320 { "message": "{
datafed-core-1  |   "code": "Conflict",
datafed-core-1  |   "message": "A transfer with identical paths has not yet completed",
datafed-core-1  |   "request_id": "1IZNZLTFl",
datafed-core-1  |   "resource": "/transfer"
datafed-core-1  | }" }
datafed-core-1  | 2025-09-10T21:13:13.173541Z ERROR /datafed/source/core/server/TaskWorker.cpp:workerThread:150 { "thread_name": "core_server-TaskMgr-TaskWorker", "thread_id": "1", "message": "Task worker 1 exception: Globus transfer API call failed.
datafed-core-1  | Request failed, code: 409, reason: A transfer with identical paths has not yet completed task_id is task/3701 cmd is 1" }
```

</p>
</details>

## Summary by Sourcery

Ensure proper initialization and robust cache handling for repository keys by clearing stale non-persistent keys, migrating misclassified keys, and adding synchronization and safe lookup methods.

Enhancements:
- Initialize AuthenticationManager before loading repository configuration to prevent key overwrites
- Add clearTransientKeys, clearSessionKeys, and clearAllNonPersistentKeys in AuthMap and AuthenticationManager and invoke them on repo config reload to purge stale keys
- Introduce migrateKey to reclassify misclassified transient or session keys as persistent during repository reloads
- Refactor AuthMap getUID to use getUIDSafe internally and expose getUIDSafe in both AuthMap and AuthenticationManager to return empty string instead of throwing
- Guard all persistent map accesses with mutex locks to eliminate race conditions
- Enhance logging in Config and AuthMap for key clearing, migration, and post-reload validation traces