### PR TITLE
[DAPS-1625] - user id map for session key josh (#1644)

### DIFF
--- a/common/source/operators/AuthenticationOperator.cpp
+++ b/common/source/operators/AuthenticationOperator.cpp
@@ -33,8 +33,17 @@ void AuthenticationOperator::execute(IMessage &message) {
   std::string uid = "anon";
   if (m_authentication_manager->hasKey(key)) {
     m_authentication_manager->incrementKeyAccessCounter(key);
-    uid = m_authentication_manager->getUID(key);
+    
+    try {
+      uid = m_authentication_manager->getUID(key);
+    } catch (const std::exception& e) {
+      // Log the exception to help diagnose authentication issues
+      std::cerr << "[AuthenticationOperator] Failed to get UID for key: " 
+                << key.substr(0, 8) << "... Exception: " << e.what() << std::endl;
+      // Keep uid as "anon" if we fail to get the actual UID
+    }
   }
+
   message.set(MessageAttribute::ID, uid);
 }
 

--- a/core/server/AuthMap.cpp
+++ b/core/server/AuthMap.cpp
@@ -9,7 +9,6 @@ namespace SDMS {
 
 namespace Core {
 AuthMap::AuthMap(const AuthMap &auth_map) {
-
   m_trans_active_increment = auth_map.m_trans_active_increment;
   m_session_active_increment = auth_map.m_session_active_increment;
 
@@ -31,7 +30,6 @@ AuthMap::AuthMap(const AuthMap &auth_map) {
 }
 
 AuthMap &AuthMap::operator=(const AuthMap &&auth_map) {
-
   m_trans_active_increment = auth_map.m_trans_active_increment;
   m_session_active_increment = auth_map.m_session_active_increment;
 
@@ -102,6 +100,11 @@ void AuthMap::removeKey(const PublicKeyType pub_key_type,
     lock_guard<mutex> lock(m_session_clients_mtx);
     if (m_session_auth_clients.count(pub_key)) {
       m_session_auth_clients.erase(pub_key);
+    }
+  } else if (PublicKeyType::PERSISTENT == pub_key_type) {
+    lock_guard<mutex> lock(m_persistent_clients_mtx);
+    if (m_persistent_auth_clients.count(pub_key)) {
+      m_persistent_auth_clients.erase(pub_key);
     }
   } else {
     EXCEPT(1, "Unsupported PublicKey Type during execution of removeKey.");
@@ -181,26 +184,31 @@ void AuthMap::incrementKeyAccessCounter(const PublicKeyType pub_key_type,
 
 bool AuthMap::hasKey(const PublicKeyType pub_key_type,
                      const std::string &public_key) const {
-
   if (pub_key_type == PublicKeyType::TRANSIENT) {
     lock_guard<mutex> lock(m_trans_clients_mtx);
-    if (m_trans_auth_clients.count(public_key)) {
-      return true;
-    }
+    return m_trans_auth_clients.count(public_key) > 0;
   } else if (pub_key_type == PublicKeyType::SESSION) {
     lock_guard<mutex> lock(m_session_clients_mtx);
-    if (m_session_auth_clients.count(public_key))
-      return true;
+    return m_session_auth_clients.count(public_key) > 0;
   } else if (pub_key_type == PublicKeyType::PERSISTENT) {
-    // Check to see if it is a repository key
-    if (m_persistent_auth_clients.count(public_key))
-      return true;
-
-    // Check to see if it is a user key
-    DatabaseAPI db(m_db_url, m_db_user, m_db_pass);
-    std::string uid;
-    if (db.uidByPubKey(public_key, uid)) {
-      return true;
+    // Check to see if it is a repository key FIRST
+    {
+      lock_guard<mutex> lock(m_persistent_clients_mtx);
+      if (m_persistent_auth_clients.count(public_key) > 0) {
+        return true;
+      }
+    }
+    
+    // Only check database for user keys if not found in memory
+    try {
+      DatabaseAPI db(m_db_url, m_db_user, m_db_pass);
+      std::string uid;
+      if (db.uidByPubKey(public_key, uid)) {
+        return true;
+      }
+    } catch (const std::exception& e) {
+      // Database is down, but we already checked memory map
+      // TODO: Caller should log this failure for monitoring/alerting
     }
   } else {
     EXCEPT(1, "Unrecognized PublicKey Type during execution of hasKey.");
@@ -210,40 +218,55 @@ bool AuthMap::hasKey(const PublicKeyType pub_key_type,
 
 std::string AuthMap::getUID(const PublicKeyType pub_key_type,
                             const std::string &public_key) const {
+
+  std::string uid = getUIDSafe(pub_key_type, public_key);
+  
+  if (uid.empty()) {
+    if (pub_key_type == PublicKeyType::TRANSIENT) {
+      EXCEPT(1, "Missing transient public key unable to map to uid.");
+    } else if (pub_key_type == PublicKeyType::SESSION) {
+      EXCEPT(1, "Missing session public key unable to map to uid.");
+    } else if (pub_key_type == PublicKeyType::PERSISTENT) {
+      EXCEPT(1, "Missing persistent public key unable to map to user id or "
+                "repo id. Possibly, cannot connect to database.");
+    } else {
+      EXCEPT(1, "Unrecognized PublicKey Type during execution of getId.");
+    }
+  }
+  
+  return uid;
+}
+
+std::string AuthMap::getUIDSafe(const PublicKeyType pub_key_type,
+                                const std::string &public_key) const {
   if (pub_key_type == PublicKeyType::TRANSIENT) {
     lock_guard<mutex> lock(m_trans_clients_mtx);
     if (m_trans_auth_clients.count(public_key)) {
       return m_trans_auth_clients.at(public_key).uid;
-    } else {
-      EXCEPT(1, "Missing transient public key unable to map to uid.");
     }
-
   } else if (pub_key_type == PublicKeyType::SESSION) {
     lock_guard<mutex> lock(m_session_clients_mtx);
     if (m_session_auth_clients.count(public_key)) {
       return m_session_auth_clients.at(public_key).uid;
-    } else {
-      EXCEPT(1, "Missing session public key unable to map to uid.");
     }
-
   } else if (pub_key_type == PublicKeyType::PERSISTENT) {
-    // If it is a repository key get it
-    // auto auth_clients = m_config.getAuthClients();
-    if (m_persistent_auth_clients.count(public_key)) {
-      return m_persistent_auth_clients.at(public_key);
+    // Check repository keys first (with proper locking)
+    {
+      lock_guard<mutex> lock(m_persistent_clients_mtx);
+      if (m_persistent_auth_clients.count(public_key)) {
+        return m_persistent_auth_clients.at(public_key);
+      }
     }
-
-    // It must be a persistent user key
+    
+    // Check database for user keys
     DatabaseAPI db(m_db_url, m_db_user, m_db_pass);
     std::string uid;
     if (db.uidByPubKey(public_key, uid)) {
       return uid;
-    } else {
-      EXCEPT(1, "Missing persistent public key unable to map to user id or "
-                "repo id. Possibly, cannot connect to database.");
     }
   }
-  EXCEPT(1, "Unrecognized PublicKey Type during execution of getId.");
+  
+  return "";  // Return empty string instead of throwing
 }
 
 bool AuthMap::hasKeyType(const PublicKeyType pub_key_type,
@@ -293,6 +316,76 @@ size_t AuthMap::getAccessCount(const PublicKeyType pub_key_type,
     EXCEPT(1, "Unsupported PublicKey Type during execution of getAccessCount.");
   }
   return 0;
+}
+
+bool isSupportedMigration(const PublicKeyType from, const PublicKeyType to) {
+  // Only support the following migrations
+  // TRANSIENT -> SESSION
+  // SESSION -> PERSISTENT
+  if ((from == PublicKeyType::TRANSIENT && to == PublicKeyType::SESSION ) ||
+      (from == PublicKeyType::SESSION   && to == PublicKeyType::PERSISTENT )) {
+    return true;
+  }
+  return false;
+}
+
+void AuthMap::migrateKey(const PublicKeyType from_type,
+                        const PublicKeyType to_type,
+                        const std::string &public_key,
+                        const std::string &id) {
+
+  if( from_type == to_type ) {
+    return;
+  }
+
+  if ( ! isSupportedMigration(from_type, to_type) ) {
+    EXCEPT(1, "Unsupported key migration attempted, only allowed to migrate to TRANSIENT -> SESSION or SESSION -> PERSISTENT");
+  }
+
+  if (from_type == PublicKeyType::TRANSIENT) {
+    // TRANSIENT -> SESSION
+    std::lock_guard<std::mutex> lock_trans(m_trans_clients_mtx);
+    // Make sure TRANSIENT key exists before trying to remove it.
+    if (! m_trans_auth_clients.count(public_key)) {
+      EXCEPT(1, "Missing TRANSIENT key, unable to migrate key (TRANSIENT->SESSION)!");
+    }
+    std::lock_guard<std::mutex> lock_sess(m_session_clients_mtx);
+    m_trans_auth_clients.erase(public_key);
+    // Make sure SESSION key does not exist before trying to add it.
+    if ( m_session_auth_clients.count(public_key) == 0 ) {
+      AuthElement element = {id, time(0) + m_trans_active_increment, 0};
+      m_session_auth_clients[public_key] = element;
+    }
+
+  } else if (from_type == PublicKeyType::SESSION) {
+    // SESSION -> PERSISTENT
+    std::lock_guard<std::mutex> lock_sess(m_session_clients_mtx);
+    // Make sure SESSION key exists before trying to remove it.
+    if (! m_session_auth_clients.count(public_key)) {
+      EXCEPT(1, "Missing SESSION key, unable to migrate key (SESSION->PERSISTENT)!");
+    }
+    std::lock_guard<std::mutex> lock_pers(m_persistent_clients_mtx);
+    m_session_auth_clients.erase(public_key);
+    // Make sure PERSISTENT key does not exist before trying to add it.
+    if ( m_persistent_auth_clients.count(public_key) == 0 ) {
+      m_persistent_auth_clients[public_key] = id;
+    }
+  }
+}
+
+void AuthMap::clearTransientKeys() {
+  std::lock_guard<std::mutex> lock(m_trans_clients_mtx);
+  m_trans_auth_clients.clear();
+}
+
+void AuthMap::clearSessionKeys() {
+  std::lock_guard<std::mutex> lock(m_session_clients_mtx);
+  m_session_auth_clients.clear();
+}
+
+void AuthMap::clearAllNonPersistentKeys() {
+  clearTransientKeys();
+  clearSessionKeys();
 }
 
 } // namespace Core

--- a/core/server/AuthenticationManager.hpp
+++ b/core/server/AuthenticationManager.hpp
@@ -85,6 +85,35 @@ public:
               const std::string &uid);
 
   /**
+   * Check if a specific key exists in a specific map type
+   **/
+  bool hasKey(const PublicKeyType &pub_key_type, const std::string &public_key) const;
+
+  /**
+   * Migrate a key from one type to another
+   **/
+  void migrateKey(const PublicKeyType &from_type, const PublicKeyType &to_type,
+                  const std::string &public_key, const std::string &uid);
+
+  /**
+   * Clear all transient keys from the authentication map.
+   * This is useful for cleaning up stale keys after service restarts.
+   **/
+  void clearTransientKeys();
+
+  /**
+   * Clear all session keys from the authentication map.
+   * This is useful for cleaning up stale keys after service restarts.
+   **/
+  void clearSessionKeys();
+
+  /**
+   * Clear all non-persistent (transient and session) keys.
+   * Persistent keys are preserved as they represent service accounts.
+   **/
+  void clearAllNonPersistentKeys();
+
+  /**
    * Will the id or throw an error
    *
    * Will look at all keys:
@@ -93,6 +122,12 @@ public:
    * - PERSISTENT
    **/
   virtual std::string getUID(const std::string &pub_key) const final;
+  
+  /**
+   * Safe version that returns empty string if key not found
+   * instead of throwing an exception
+   **/
+  std::string getUIDSafe(const std::string &pub_key) const;
 };
 
 } // namespace Core

--- a/core/server/Config.cpp
+++ b/core/server/Config.cpp
@@ -70,16 +70,55 @@ void Config::loadRepositoryConfig(AuthenticationManager &auth_manager,
       }
 
       // Cache pub key for ZAP handler
-      auth_manager.addKey(PublicKeyType::PERSISTENT, r.pub_key(), r.id());
+      // Historical bug (DAPS-1625): Repository keys could be incorrectly cached as 
+      // transient/session keys if loadRepositoryConfig() was called before the 
+      // AuthenticationManager was properly initialized. This is now fixed by proper
+      // initialization order in CoreServer.cpp, but we keep the migration logic
+      // during config reloads.
+      DL_TRACE(log_context, "Registering repo " << r.id());
+      
+      // Check for duplicate keys across different maps
+      bool in_transient = auth_manager.hasKey(PublicKeyType::TRANSIENT, r.pub_key());
+      bool in_session = auth_manager.hasKey(PublicKeyType::SESSION, r.pub_key());
+      
+      if (in_transient && in_session) {
+        // Key exists in both maps - this is an inconsistent state
+        DL_WARNING(log_context, "Repo " << r.id() << " key found in BOTH TRANSIENT and SESSION maps. "
+                   << "Removing from both and adding to PERSISTENT.");
+        auth_manager.migrateKey(PublicKeyType::TRANSIENT, PublicKeyType::PERSISTENT, r.pub_key(), r.id());
+        auth_manager.migrateKey(PublicKeyType::SESSION, PublicKeyType::PERSISTENT, r.pub_key(), r.id());
+      } else if (in_transient) {
+        DL_INFO(log_context, "Repo " << r.id() << " key found in TRANSIENT map, migrating to PERSISTENT");
+        auth_manager.migrateKey(PublicKeyType::TRANSIENT, PublicKeyType::PERSISTENT, r.pub_key(), r.id());
+      } else if (in_session) {
+        DL_INFO(log_context, "Repo " << r.id() << " key found in SESSION map, migrating to PERSISTENT");
+        auth_manager.migrateKey(PublicKeyType::SESSION, PublicKeyType::PERSISTENT, r.pub_key(), r.id());
+      } else {
+        // Normal case - add as new PERSISTENT key
+        DL_TRACE(log_context, "Adding repo " << r.id() << " key as new PERSISTENT key");
+        auth_manager.addKey(PublicKeyType::PERSISTENT, r.pub_key(), r.id());
+      }
 
       // Cache repo data for data handling
       m_repos_mtx.lock();
-      DL_TRACE(log_context, std::string("Repo ")
+      DL_INFO(log_context, std::string("Repo ")
                                 << r.id() << " OK - UUID: " << r.endpoint()
                                 << " address: " << r.address());
       m_repos[r.id()] = r;
       m_trigger_repo_refresh = false;
       m_repos_mtx.unlock();
+    }
+  }
+  
+  // Validate that repository keys are still present after loading
+  DL_TRACE(log_context, "Validating repository keys after loading");
+  for (const auto& repo_pair : m_repos) {
+    const RepoData& repo = repo_pair.second;
+    if (auth_manager.hasKey(PublicKeyType::PERSISTENT, repo.pub_key())) {
+      DL_TRACE(log_context, "Key for " << repo.id() << " verified in PERSISTENT map");
+    } else {
+      DL_ERROR(log_context, "KEY MISSING! Repository " << repo.id() 
+               << " key not found after loading!");
     }
   }
 }

--- a/core/server/CoreServer.cpp
+++ b/core/server/CoreServer.cpp
@@ -80,13 +80,14 @@ Server::Server(LogContext log_context)
   purge_conditions[PublicKeyType::SESSION].emplace_back(
       std::make_unique<Reset>(accesses_to_reset, key_type_to_apply_reset));
 
-  // Load repository config from DB
-  m_config.loadRepositoryConfig(m_auth_manager, log_context);
-
-  // Must occur after loading config settings
+  // Initialize AuthenticationManager BEFORE loading repository config
+  // This ensures repos are loaded into the correct instance
   m_auth_manager = std::move(AuthenticationManager(
       purge_intervals, std::move(purge_conditions), m_config.db_url,
       m_config.db_user, m_config.db_pass));
+
+  // Now load repository config from DB into the initialized AuthenticationManager
+  m_config.loadRepositoryConfig(m_auth_manager, log_context);
 
   // Start ZAP handler must be started before any other socket binds are called
   // m_zap_thread = thread( &Server::zapHandler, this );


### PR DESCRIPTION
* [DAPS-1625]  fix bug in session and transient keys.

---------

## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Introduce persistent key management and migration in the authentication layer, fix key mapping bugs, add safe UID lookups, and improve initialization order and error handling.

New Features:
- Add migrateKey method to move keys between transient, session and persistent stores
- Introduce clearTransientKeys, clearSessionKeys, and clearAllNonPersistentKeys methods
- Implement getUIDSafe in AuthMap and AuthenticationManager for exception-free UID retrieval
- Add hasKey overload in AuthenticationManager for specific key types

Bug Fixes:
- Fix removeKey and hasKey to correctly handle persistent keys and avoid unnecessary database queries
- Handle database downtime gracefully in hasKey without throwing
- Ensure AuthenticationManager is initialized before loading repository config to prevent incorrect key caching

Enhancements:
- Log repository key migrations and validation steps
- Catch exceptions in AuthenticationOperator when retrieving UIDs to prevent crashes
- Document consistent lock ordering in AuthMap to avoid deadlocks

Documentation:
- Add detailed comments in AuthMap and AuthenticationManager headers for key migration and clearing methods