### PR TITLE
fix: limit arangodb job output to last 3 hours.

### DIFF
--- a/.gitlab/end_to_end.yml
+++ b/.gitlab/end_to_end.yml
@@ -462,7 +462,7 @@ end_to_end_error_discovery_arango:
     tags:
         - ci-datafed-arango
     script:
-        - sudo journalctl --no-pager -u arangodb3.service
+        - sudo journalctl --no-pager -u arangodb3.service --since "3 hours ago"
 
 end_to_end_error_discovery_gcs:
     needs: ["check-ci-infrastructure", "end-to-end-gcs-authz-setup", "end-to-end-signal"]


### PR DESCRIPTION
## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

CI:
- Limit arangodb3.service journalctl output to the last 3 hours in the end_to_end_error_discovery_arango job.