### PR TITLE
Adding Correlation ID to Logging

### DIFF
--- a/core/server/DatabaseAPI.cpp
+++ b/core/server/DatabaseAPI.cpp
@@ -126,12 +126,20 @@ long DatabaseAPI::dbGet(const char *a_url_path,
   curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &res_json);
   curl_easy_setopt(m_curl, CURLOPT_ERRORBUFFER, error);
   curl_easy_setopt(m_curl, CURLOPT_HTTPGET, 1);
+  struct curl_slist* headers = nullptr;
 
+  // safe: curl_slist_append copies the string internally
+  std::string header = "x-correlation-id: " + log_context.correlation_id;
+  headers = curl_slist_append(headers, header.c_str());
+
+  // attach headers to the CURL handle
+  curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, headers);
   CURLcode res = curl_easy_perform(m_curl);
 
   long http_code = 0;
   curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &http_code);
-
+  curl_slist_free_all(headers);
+  
   if (res == CURLE_OK) {
     if (res_json.size()) {
       try {
@@ -168,13 +176,14 @@ bool DatabaseAPI::dbGetRaw(const std::string url, string &a_result) {
   a_result.clear();
   error[0] = 0;
 
+  curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, nullptr);  // Clear any previous headers
+  // attach headers to the CURL handle
   curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &a_result);
   curl_easy_setopt(m_curl, CURLOPT_ERRORBUFFER, error);
   curl_easy_setopt(m_curl, CURLOPT_HTTPGET, 1);
 
   CURLcode res = curl_easy_perform(m_curl);
-
   long http_code = 0;
   curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &http_code);
   if (res == CURLE_OK && (http_code >= 200 && http_code < 300))
@@ -198,7 +207,14 @@ long DatabaseAPI::dbPost(const char *a_url_path,
 
   // TODO: construct URL outside of function
   const string url = buildSearchParamURL(a_url_path, a_params);
+  struct curl_slist* headers = nullptr;
 
+  // safe: curl_slist_append copies the string internally
+  std::string header = "x-correlation-id: " + log_context.correlation_id;
+  headers = curl_slist_append(headers, header.c_str());
+
+  // attach headers to the CURL handle
+  curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, headers);
   curl_easy_setopt(m_curl, CURLOPT_URL, url.c_str());
   curl_easy_setopt(m_curl, CURLOPT_WRITEDATA, &res_json);
   curl_easy_setopt(m_curl, CURLOPT_ERRORBUFFER, error);
@@ -210,6 +226,7 @@ long DatabaseAPI::dbPost(const char *a_url_path,
                    a_body ? a_body->c_str() : empty_body);
 
   CURLcode res = curl_easy_perform(m_curl);
+  curl_slist_free_all(headers);
 
   long http_code = 0;
   curl_easy_getinfo(m_curl, CURLINFO_RESPONSE_CODE, &http_code);


### PR DESCRIPTION
## Ticket  

#1663 

## Description 

Added correlation ID to the logging in order to comply with standards

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

New Features:
- Add an x-correlation-id header using log_context.correlation_id to dbGet, dbGetRaw, and dbPost methods