### PR TITLE
refactor: allow optional fields when creating repo to support metadat…

### DIFF
--- a/common/proto/common/SDMS_Auth.proto
+++ b/common/proto/common/SDMS_Auth.proto
@@ -922,7 +922,7 @@ message RepoCreateRequest
     optional string             endpoint    = 9; // Globus endpoint UUID or legacy name
     optional string             pub_key     = 10; // Public encryption key
     required uint64             capacity    = 11; // Total data capacity
-    optional string             admin       = 12; // Repo admin(s)
+    repeated string             admin       = 12; // Repo admin(s)
     optional string             type        = 13; // Repository type (defaults to "globus")
 }
 


### PR DESCRIPTION
…a only mode.

## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Enable metadata-only repository creation by refactoring the repository creation API and making relevant fields optional in the protocol definitions.

New Features:
- Allow repository creation with optional fields for metadata-only mode

Enhancements:
- Refactor SDMS_Auth.proto to mark repository creation fields as optional