### PR TITLE
replace os.path.join with urllib.parse.urljoin

### DIFF
--- a/scripts/globus/generate_web_server_credentials.py
+++ b/scripts/globus/generate_web_server_credentials.py
@@ -5,6 +5,7 @@ from globus_sdk import AuthClient, GroupsClient
 import utils
 
 import os, sys
+import urllib.parse
 
 CLIENT_ID = "f8d0afca-7ac4-4a3c-ac05-f94f5d9afce8"
 
@@ -40,7 +41,7 @@ default_DOMAIN = "localhost"
 DOMAIN = os.getenv("DATAFED_DOMAIN", default_DOMAIN)
 if len(DOMAIN) == 0:
     DOMAIN = default_DOMAIN
-REDIRECT_PATH = os.path.join("https://", DOMAIN, "ui/authn")
+REDIRECT_PATH = urllib.parse.urljoin(f"https://{DOMAIN}","ui/authn")
 
 # begin oauth
 client = globus_sdk.NativeAppAuthClient(CLIENT_ID)


### PR DESCRIPTION
## Description 

Resolves #1742 

## How Has This Been Tested?  

Cleared all existing configuration, created new `.env` file and new globus credentials, ran metadata docker compose and successfully logged in using globus account.

## Summary by Sourcery

Switch to urljoin for constructing redirect URLs in generate_web_server_credentials.py to ensure correct URL assembly.

Bug Fixes:
- Correct redirect URL generation by replacing os.path.join with urllib.parse.urljoin.

Enhancements:
- Add urllib.parse import and update REDIRECT_PATH to use urljoin.