### PR TITLE
bug: fix mapping of multiple globus accounts.

### DIFF
--- a/web/datafed-ws.js
+++ b/web/datafed-ws.js
@@ -592,11 +592,14 @@ the registration page.
 
                                     a_resp.redirect("/ui/register");
                                 } else {
-				    if ( reply.user.length > 1 ) {
-				        logger.warn("ui/authn", getCurrentLineNumber(), "More than one user was returned from DataFed, this can happen if a user has registered two or more separate accounts with DataFed and has since linked their identities from a third party identity manager. DataFed will select the first identity when logging in.");
-
-			            }
-				    let username = reply.user[0]?.uid?.replace(/^u\//, '');
+                                    if (reply.user.length > 1) {
+                                        logger.warn(
+                                            "ui/authn",
+                                            getCurrentLineNumber(),
+                                            "More than one user was returned from DataFed, this can happen if a user has registered two or more separate accounts with DataFed and has since linked their identities from a third party identity manager. DataFed will select the first identity when logging in.",
+                                        );
+                                    }
+                                    let username = reply.user[0]?.uid?.replace(/^u\//, "");
                                     logger.info(
                                         "/ui/authn",
                                         getCurrentLineNumber(),
@@ -604,7 +607,7 @@ the registration page.
                                             uid +
                                             " verified, mapped to: " +
                                             username +
-					    " acc:" +
+                                            " acc:" +
                                             xfr_token.access_token +
                                             ", ref: " +
                                             xfr_token.refresh_token +


### PR DESCRIPTION
## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Select and map the first DataFed user identity as the session user ID, warn when multiple identities are returned, and include the mapped username in authentication logs

Bug Fixes:
- Assign session.uid from the first DataFed user identity after stripping the 'u/' prefix

Enhancements:
- Log a warning when multiple DataFed user identities are returned
- Include the mapped username in the authentication info logs