### PR TITLE
[DAPS-1775] - fix: core, foxx, add missing {}, foxx query_router add params object …

### DIFF
--- a/core/database/foxx/api/query_router.js
+++ b/core/database/foxx/api/query_router.js
@@ -66,8 +66,6 @@ router
 
                     g_lib.procInputParam(req.body, "title", false, obj);
 
-                    //console.log("qry/create filter:",obj.qry_filter);
-
                     var qry = g_db.q.save(obj, {
                         returnNew: true,
                     }).new;
@@ -124,7 +122,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().allow("").required(),
-                params: joi.any().required(),
+                params: joi.object().required(),
                 limit: joi.number().integer().required(),
                 query: joi.any().required(),
             })
@@ -169,6 +167,7 @@ router
                     qry.qry_begin = req.body.qry_begin;
                     qry.qry_end = req.body.qry_end;
                     qry.qry_filter = req.body.qry_filter;
+
                     qry.params = req.body.params;
                     qry.limit = req.body.limit;
                     qry.query = req.body.query;
@@ -178,7 +177,6 @@ router
                         qry.params.cols = null;
                     }*/
 
-                    //console.log("qry/upd filter:",obj.qry_filter);
                     qry = g_db._update(qry._id, qry, {
                         mergeObjects: false,
                         returnNew: true,
@@ -231,7 +229,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().allow("").required(),
-                params: joi.any().required(),
+                params: joi.object().required(),
                 limit: joi.number().integer().required(),
                 query: joi.any().required(),
             })
@@ -597,10 +595,6 @@ function execQuery(client, mode, published, orig_query) {
 
     qry += query.qry_end;
 
-    //console.log( "execqry" );
-    //console.log( "qry", qry );
-    //console.log( "params", query.params );
-
     // Enforce query paging limits
     if (query.params.cnt > g_lib.MAX_PAGE_SIZE) {
         query.params.cnt = g_lib.MAX_PAGE_SIZE;
@@ -725,7 +719,7 @@ router
 
             const query = {
                 ...req.body,
-                params: JSON.parse(req.body.params),
+                params: req.body.params,
             };
             results = execQuery(client, req.body.mode, req.body.published, query);
 
@@ -762,7 +756,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().optional().allow(""),
-                params: joi.string().required(),
+                params: joi.object().required(),
                 limit: joi.number().integer().required(),
             })
             .required(),

--- a/core/server/DatabaseAPI.cpp
+++ b/core/server/DatabaseAPI.cpp
@@ -1308,7 +1308,7 @@ void DatabaseAPI::generalSearch(const Auth::SearchRequest &a_request,
   payload["qry_begin"] = qry_begin;
   payload["qry_end"] = qry_end;
   payload["qry_filter"] = qry_filter;
-  payload["params"] = "{" + params + "}";
+  payload["params"] = params;
   payload["limit"] = to_string(cnt);
 
   string body = payload.dump(-1, ' ', true);
@@ -3942,7 +3942,7 @@ uint32_t DatabaseAPI::parseSearchRequest(const Auth::SearchRequest &a_request,
   a_qry_begin = a_qry_begin;
   a_qry_end = a_qry_end;
   a_qry_filter = a_qry_filter;
-
+  a_params = "{" + a_params + "}";
   return cnt;
 }
 


### PR DESCRIPTION
…schema to routes.

## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Fix param handling and schema in query_router and DatabaseAPI

Bug Fixes:
- Enforce Joi schema for params as object in Foxx query_router routes
- Remove JSON.parse on params and pass them as objects in query execution
- Eliminate debug console.log statements in query_router
- Adjust DatabaseAPI payload to send params directly without extra braces
- Wrap a_params with braces only in parseSearchRequest to maintain JSON structure