### PR TITLE
Revert "[DAPS-1775] - fix: core, foxx, add missing {}, foxx query_router add params object …"

### DIFF
--- a/core/database/foxx/api/query_router.js
+++ b/core/database/foxx/api/query_router.js
@@ -66,6 +66,8 @@ router
 
                     g_lib.procInputParam(req.body, "title", false, obj);
 
+                    //console.log("qry/create filter:",obj.qry_filter);
+
                     var qry = g_db.q.save(obj, {
                         returnNew: true,
                     }).new;
@@ -122,7 +124,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().allow("").required(),
-                params: joi.object().required(),
+                params: joi.any().required(),
                 limit: joi.number().integer().required(),
                 query: joi.any().required(),
             })
@@ -167,7 +169,6 @@ router
                     qry.qry_begin = req.body.qry_begin;
                     qry.qry_end = req.body.qry_end;
                     qry.qry_filter = req.body.qry_filter;
-
                     qry.params = req.body.params;
                     qry.limit = req.body.limit;
                     qry.query = req.body.query;
@@ -177,6 +178,7 @@ router
                         qry.params.cols = null;
                     }*/
 
+                    //console.log("qry/upd filter:",obj.qry_filter);
                     qry = g_db._update(qry._id, qry, {
                         mergeObjects: false,
                         returnNew: true,
@@ -229,7 +231,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().allow("").required(),
-                params: joi.object().required(),
+                params: joi.any().required(),
                 limit: joi.number().integer().required(),
                 query: joi.any().required(),
             })
@@ -595,6 +597,10 @@ function execQuery(client, mode, published, orig_query) {
 
     qry += query.qry_end;
 
+    //console.log( "execqry" );
+    //console.log( "qry", qry );
+    //console.log( "params", query.params );
+
     // Enforce query paging limits
     if (query.params.cnt > g_lib.MAX_PAGE_SIZE) {
         query.params.cnt = g_lib.MAX_PAGE_SIZE;
@@ -719,7 +725,7 @@ router
 
             const query = {
                 ...req.body,
-                params: req.body.params,
+                params: JSON.parse(req.body.params),
             };
             results = execQuery(client, req.body.mode, req.body.published, query);
 
@@ -756,7 +762,7 @@ router
                 qry_begin: joi.string().required(),
                 qry_end: joi.string().required(),
                 qry_filter: joi.string().optional().allow(""),
-                params: joi.object().required(),
+                params: joi.string().required(),
                 limit: joi.number().integer().required(),
             })
             .required(),

--- a/core/server/DatabaseAPI.cpp
+++ b/core/server/DatabaseAPI.cpp
@@ -1308,7 +1308,7 @@ void DatabaseAPI::generalSearch(const Auth::SearchRequest &a_request,
   payload["qry_begin"] = qry_begin;
   payload["qry_end"] = qry_end;
   payload["qry_filter"] = qry_filter;
-  payload["params"] = params;
+  payload["params"] = "{" + params + "}";
   payload["limit"] = to_string(cnt);
 
   string body = payload.dump(-1, ' ', true);
@@ -3942,7 +3942,7 @@ uint32_t DatabaseAPI::parseSearchRequest(const Auth::SearchRequest &a_request,
   a_qry_begin = a_qry_begin;
   a_qry_end = a_qry_end;
   a_qry_filter = a_qry_filter;
-  a_params = "{" + a_params + "}";
+
   return cnt;
 }
 


### PR DESCRIPTION
Reverts ORNL/DataFed#1776

## Summary by Sourcery

Revert the prior DAPS-1775 changes to the Foxx query router and C++ DatabaseAPI, restoring original parameter handling and payload formatting while adding debug logging

Enhancements:
- restore Joi validation for params as any or string in query_router
- reinstate JSON.parse of request params before executing queries
- revert wrapping of params with braces in DatabaseAPI payload and restore original parseSearchRequest behavior
- add commented console.log statements in query_router for debugging query filters and execution