### PR TITLE
[DAPS-1833] - refactor: test_api_record.py add env vars for specifying endpoint and…

### DIFF
--- a/tests/end-to-end/test_api_record.py
+++ b/tests/end-to-end/test_api_record.py
@@ -176,8 +176,13 @@ class TestDataFedPythonAPIRecordCRUD(unittest.TestCase):
 
         # May not work depending on traffic
         esnet_uuid = "ece400da-0182-4777-91d6-27a1808f8371"
+        endpoint_uuid = os.environ.get('DATAFED_TEST_GLOBUS_ENDPOINT', esnet_uuid)
+        test_file_path_on_endpoint = os.environ.get('DATAFED_TEST_GLOBUS_ENDPOINT_FILE', "/1M.dat")
 
-        put_task = self._df_api.dataPut(new_alias, esnet_uuid + "/1M.dat")
+        if not test_file_path_on_endpoint.startswith("/"):
+            test_file_path_on_endpoint = "/" + test_file_path_on_endpoint
+
+        put_task = self._df_api.dataPut(new_alias, endpoint_uuid + test_file_path_on_endpoint)
 
         task_id = put_task[0].task.id
 


### PR DESCRIPTION
… file in end to end test.

## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Allow end-to-end API record tests to use configurable Globus endpoint and file path via environment variables while preserving existing defaults.

Enhancements:
- Make the data transfer target endpoint UUID configurable via the DATAFED_TEST_GLOBUS_ENDPOINT environment variable with a default to the existing ESnet endpoint.
- Make the test file path on the endpoint configurable via the DATAFED_TEST_GLOBUS_ENDPOINT_FILE environment variable, normalizing it to an absolute path when needed.

Tests:
- Update the record create/delete end-to-end test to use configurable endpoint and file path values instead of hard-coded constants.