### PR TITLE
feat: add protobuf3 replacement files.

### DIFF
--- a/common/proto3/common/CMakeLists.txt
+++ b/common/proto3/common/CMakeLists.txt
@@ -1,14 +1,5 @@
 cmake_minimum_required(VERSION 3.17.0)
 
-# Collect proto files from the new 1-1-1 structure
-file(GLOB_RECURSE ProtoFiles
-    "${CMAKE_CURRENT_SOURCE_DIR}/enums/*.proto"
-    "${CMAKE_CURRENT_SOURCE_DIR}/messages/*.proto"
-    "${CMAKE_CURRENT_SOURCE_DIR}/anon/*.proto"
-    "${CMAKE_CURRENT_SOURCE_DIR}/auth/*.proto"
-    "${CMAKE_CURRENT_SOURCE_DIR}/envelope.proto"
-)
-
 # Generate C++ from protos
 protobuf_generate(
     LANGUAGE cpp
@@ -40,5 +31,5 @@ target_link_libraries(datafed-protobuf
 
 target_include_directories(datafed-protobuf
     PUBLIC ${CMAKE_CURRENT_BINARY_DIR}  # Where generated files go
-    INTERFACE ${PROJECT_BINARY_DIR}/common/proto
+    INTERFACE ${PROJECT_BINARY_DIR}/common/proto3
 )

--- a/common/proto3/common/anon/ack_reply.proto
+++ b/common/proto3/common/anon/ack_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/auth_status_reply.proto
+++ b/common/proto3/common/anon/auth_status_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/authenticate_by_password_request.proto
+++ b/common/proto3/common/anon/authenticate_by_password_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/authenticate_by_token_request.proto
+++ b/common/proto3/common/anon/authenticate_by_token_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/daily_message_reply.proto
+++ b/common/proto3/common/anon/daily_message_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/daily_message_request.proto
+++ b/common/proto3/common/anon/daily_message_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/get_auth_status_request.proto
+++ b/common/proto3/common/anon/get_auth_status_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/nack_reply.proto
+++ b/common/proto3/common/anon/nack_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/error_code.proto";
 

--- a/common/proto3/common/anon/version_reply.proto
+++ b/common/proto3/common/anon/version_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/anon/version_request.proto
+++ b/common/proto3/common/anon/version_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/acl_data_reply.proto
+++ b/common/proto3/common/auth/acl_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/acl_rule.proto";
 

--- a/common/proto3/common/auth/acl_shared_list_items_request.proto
+++ b/common/proto3/common/auth/acl_shared_list_items_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/acl_shared_list_request.proto
+++ b/common/proto3/common/auth/acl_shared_list_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/acl_update_request.proto
+++ b/common/proto3/common/auth/acl_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/acl_view_request.proto
+++ b/common/proto3/common/auth/acl_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/check_perms_reply.proto
+++ b/common/proto3/common/auth/check_perms_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/check_perms_request.proto
+++ b/common/proto3/common/auth/check_perms_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_create_request.proto
+++ b/common/proto3/common/auth/coll_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_data_reply.proto
+++ b/common/proto3/common/auth/coll_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/coll_data.proto";
 import "messages/listing_data.proto";

--- a/common/proto3/common/auth/coll_delete_request.proto
+++ b/common/proto3/common/auth/coll_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_get_offset_reply.proto
+++ b/common/proto3/common/auth/coll_get_offset_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_get_offset_request.proto
+++ b/common/proto3/common/auth/coll_get_offset_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_get_parents_request.proto
+++ b/common/proto3/common/auth/coll_get_parents_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_list_published_request.proto
+++ b/common/proto3/common/auth/coll_list_published_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_move_request.proto
+++ b/common/proto3/common/auth/coll_move_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_path_reply.proto
+++ b/common/proto3/common/auth/coll_path_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/path_data.proto";
 

--- a/common/proto3/common/auth/coll_read_request.proto
+++ b/common/proto3/common/auth/coll_read_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_update_request.proto
+++ b/common/proto3/common/auth/coll_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_view_request.proto
+++ b/common/proto3/common/auth/coll_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/coll_write_request.proto
+++ b/common/proto3/common/auth/coll_write_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/data_delete_request.proto
+++ b/common/proto3/common/auth/data_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/data_get_reply.proto
+++ b/common/proto3/common/auth/data_get_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/listing_data.proto";
 import "messages/task_data.proto";

--- a/common/proto3/common/auth/data_get_request.proto
+++ b/common/proto3/common/auth/data_get_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/encryption.proto";
 

--- a/common/proto3/common/auth/data_path_reply.proto
+++ b/common/proto3/common/auth/data_path_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/data_path_request.proto
+++ b/common/proto3/common/auth/data_path_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/data_put_reply.proto
+++ b/common/proto3/common/auth/data_put_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/record_data.proto";
 import "messages/task_data.proto";

--- a/common/proto3/common/auth/data_put_request.proto
+++ b/common/proto3/common/auth/data_put_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/encryption.proto";
 

--- a/common/proto3/common/auth/generate_credentials_reply.proto
+++ b/common/proto3/common/auth/generate_credentials_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/generate_credentials_request.proto
+++ b/common/proto3/common/auth/generate_credentials_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/get_perms_reply.proto
+++ b/common/proto3/common/auth/get_perms_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/get_perms_request.proto
+++ b/common/proto3/common/auth/get_perms_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/group_create_request.proto
+++ b/common/proto3/common/auth/group_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/group_data.proto";
 

--- a/common/proto3/common/auth/group_data_reply.proto
+++ b/common/proto3/common/auth/group_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/group_data.proto";
 

--- a/common/proto3/common/auth/group_delete_request.proto
+++ b/common/proto3/common/auth/group_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/group_list_request.proto
+++ b/common/proto3/common/auth/group_list_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/group_update_request.proto
+++ b/common/proto3/common/auth/group_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/group_view_request.proto
+++ b/common/proto3/common/auth/group_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/listing_reply.proto
+++ b/common/proto3/common/auth/listing_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/listing_data.proto";
 

--- a/common/proto3/common/auth/metadata_validate_reply.proto
+++ b/common/proto3/common/auth/metadata_validate_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/metadata_validate_request.proto
+++ b/common/proto3/common/auth/metadata_validate_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/note_comment_edit_request.proto
+++ b/common/proto3/common/auth/note_comment_edit_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/note_create_request.proto
+++ b/common/proto3/common/auth/note_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/note_type.proto";
 

--- a/common/proto3/common/auth/note_data_reply.proto
+++ b/common/proto3/common/auth/note_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/note_data.proto";
 import "messages/listing_data.proto";

--- a/common/proto3/common/auth/note_list_by_subject_request.proto
+++ b/common/proto3/common/auth/note_list_by_subject_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/note_update_request.proto
+++ b/common/proto3/common/auth/note_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/note_type.proto";
 import "enums/note_state.proto";

--- a/common/proto3/common/auth/note_view_request.proto
+++ b/common/proto3/common/auth/note_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/project_create_request.proto
+++ b/common/proto3/common/auth/project_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/project_data_reply.proto
+++ b/common/proto3/common/auth/project_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/project_data.proto";
 

--- a/common/proto3/common/auth/project_delete_request.proto
+++ b/common/proto3/common/auth/project_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/project_get_role_reply.proto
+++ b/common/proto3/common/auth/project_get_role_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/project_role.proto";
 

--- a/common/proto3/common/auth/project_get_role_request.proto
+++ b/common/proto3/common/auth/project_get_role_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/project_list_request.proto
+++ b/common/proto3/common/auth/project_list_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/sort_option.proto";
 

--- a/common/proto3/common/auth/project_search_request.proto
+++ b/common/proto3/common/auth/project_search_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/project_update_request.proto
+++ b/common/proto3/common/auth/project_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/project_view_request.proto
+++ b/common/proto3/common/auth/project_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/query_create_request.proto
+++ b/common/proto3/common/auth/query_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "auth/search_request.proto";
 

--- a/common/proto3/common/auth/query_data_reply.proto
+++ b/common/proto3/common/auth/query_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "auth/search_request.proto";
 

--- a/common/proto3/common/auth/query_delete_request.proto
+++ b/common/proto3/common/auth/query_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/query_exec_request.proto
+++ b/common/proto3/common/auth/query_exec_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/query_list_request.proto
+++ b/common/proto3/common/auth/query_list_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/query_update_request.proto
+++ b/common/proto3/common/auth/query_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "auth/search_request.proto";
 

--- a/common/proto3/common/auth/query_view_request.proto
+++ b/common/proto3/common/auth/query_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_alloc_change_reply.proto
+++ b/common/proto3/common/auth/record_alloc_change_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/task_data.proto";
 

--- a/common/proto3/common/auth/record_alloc_change_request.proto
+++ b/common/proto3/common/auth/record_alloc_change_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_create_batch_request.proto
+++ b/common/proto3/common/auth/record_create_batch_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_create_request.proto
+++ b/common/proto3/common/auth/record_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/dependency_spec_data.proto";
 

--- a/common/proto3/common/auth/record_data_reply.proto
+++ b/common/proto3/common/auth/record_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/record_data.proto";
 import "messages/listing_data.proto";

--- a/common/proto3/common/auth/record_delete_request.proto
+++ b/common/proto3/common/auth/record_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_export_reply.proto
+++ b/common/proto3/common/auth/record_export_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_export_request.proto
+++ b/common/proto3/common/auth/record_export_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_get_dependency_graph_request.proto
+++ b/common/proto3/common/auth/record_get_dependency_graph_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_list_by_alloc_request.proto
+++ b/common/proto3/common/auth/record_list_by_alloc_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_lock_request.proto
+++ b/common/proto3/common/auth/record_lock_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_owner_change_reply.proto
+++ b/common/proto3/common/auth/record_owner_change_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_data.proto";
 import "messages/task_data.proto";

--- a/common/proto3/common/auth/record_owner_change_request.proto
+++ b/common/proto3/common/auth/record_owner_change_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_update_batch_request.proto
+++ b/common/proto3/common/auth/record_update_batch_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/record_update_request.proto
+++ b/common/proto3/common/auth/record_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/dependency_spec_data.proto";
 

--- a/common/proto3/common/auth/record_view_request.proto
+++ b/common/proto3/common/auth/record_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_allocation_create_request.proto
+++ b/common/proto3/common/auth/repo_allocation_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_allocation_create_response.proto
+++ b/common/proto3/common/auth/repo_allocation_create_response.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/execution_method.proto";
 import "messages/task_data.proto";

--- a/common/proto3/common/auth/repo_allocation_delete_request.proto
+++ b/common/proto3/common/auth/repo_allocation_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_allocation_set_default_request.proto
+++ b/common/proto3/common/auth/repo_allocation_set_default_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_allocation_set_request.proto
+++ b/common/proto3/common/auth/repo_allocation_set_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_allocation_stats_reply.proto
+++ b/common/proto3/common/auth/repo_allocation_stats_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_stats_data.proto";
 

--- a/common/proto3/common/auth/repo_allocation_stats_request.proto
+++ b/common/proto3/common/auth/repo_allocation_stats_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_allocations_reply.proto
+++ b/common/proto3/common/auth/repo_allocations_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_data.proto";
 

--- a/common/proto3/common/auth/repo_authz_request.proto
+++ b/common/proto3/common/auth/repo_authz_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_calc_size_reply.proto
+++ b/common/proto3/common/auth/repo_calc_size_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_stats_data.proto";
 

--- a/common/proto3/common/auth/repo_calc_size_request.proto
+++ b/common/proto3/common/auth/repo_calc_size_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_create_request.proto
+++ b/common/proto3/common/auth/repo_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_data_delete_request.proto
+++ b/common/proto3/common/auth/repo_data_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/record_data_location.proto";
 

--- a/common/proto3/common/auth/repo_data_get_size_request.proto
+++ b/common/proto3/common/auth/repo_data_get_size_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/record_data_location.proto";
 

--- a/common/proto3/common/auth/repo_data_reply.proto
+++ b/common/proto3/common/auth/repo_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/repo_data.proto";
 

--- a/common/proto3/common/auth/repo_data_size_reply.proto
+++ b/common/proto3/common/auth/repo_data_size_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/record_data_size.proto";
 

--- a/common/proto3/common/auth/repo_delete_request.proto
+++ b/common/proto3/common/auth/repo_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_list_allocations_request.proto
+++ b/common/proto3/common/auth/repo_list_allocations_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_list_object_allocations_request.proto
+++ b/common/proto3/common/auth/repo_list_object_allocations_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_list_request.proto
+++ b/common/proto3/common/auth/repo_list_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_list_subject_allocations_request.proto
+++ b/common/proto3/common/auth/repo_list_subject_allocations_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_path_create_request.proto
+++ b/common/proto3/common/auth/repo_path_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_path_delete_request.proto
+++ b/common/proto3/common/auth/repo_path_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_update_request.proto
+++ b/common/proto3/common/auth/repo_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_view_allocation_request.proto
+++ b/common/proto3/common/auth/repo_view_allocation_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/repo_view_request.proto
+++ b/common/proto3/common/auth/repo_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/revoke_credentials_request.proto
+++ b/common/proto3/common/auth/revoke_credentials_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/schema_create_request.proto
+++ b/common/proto3/common/auth/schema_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/schema_data_reply.proto
+++ b/common/proto3/common/auth/schema_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/schema_data.proto";
 

--- a/common/proto3/common/auth/schema_delete_request.proto
+++ b/common/proto3/common/auth/schema_delete_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/schema_revise_request.proto
+++ b/common/proto3/common/auth/schema_revise_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/schema_search_request.proto
+++ b/common/proto3/common/auth/schema_search_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/sort_option.proto";
 

--- a/common/proto3/common/auth/schema_update_request.proto
+++ b/common/proto3/common/auth/schema_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/schema_view_request.proto
+++ b/common/proto3/common/auth/schema_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/search_request.proto
+++ b/common/proto3/common/auth/search_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/search_mode.proto";
 import "enums/sort_option.proto";

--- a/common/proto3/common/auth/tag_data_reply.proto
+++ b/common/proto3/common/auth/tag_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/tag_data.proto";
 

--- a/common/proto3/common/auth/tag_list_by_count_request.proto
+++ b/common/proto3/common/auth/tag_list_by_count_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/tag_search_request.proto
+++ b/common/proto3/common/auth/tag_search_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/task_data_reply.proto
+++ b/common/proto3/common/auth/task_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/task_data.proto";
 

--- a/common/proto3/common/auth/task_list_request.proto
+++ b/common/proto3/common/auth/task_list_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/task_status.proto";
 

--- a/common/proto3/common/auth/task_view_request.proto
+++ b/common/proto3/common/auth/task_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/topic_data_reply.proto
+++ b/common/proto3/common/auth/topic_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/topic_data.proto";
 

--- a/common/proto3/common/auth/topic_list_topics_request.proto
+++ b/common/proto3/common/auth/topic_list_topics_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/topic_search_request.proto
+++ b/common/proto3/common/auth/topic_search_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/topic_view_request.proto
+++ b/common/proto3/common/auth/topic_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_access_token_reply.proto
+++ b/common/proto3/common/auth/user_access_token_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_create_request.proto
+++ b/common/proto3/common/auth/user_create_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_data_reply.proto
+++ b/common/proto3/common/auth/user_data_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/user_data.proto";
 

--- a/common/proto3/common/auth/user_find_by_name_uid_request.proto
+++ b/common/proto3/common/auth/user_find_by_name_uid_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_find_by_uuids_request.proto
+++ b/common/proto3/common/auth/user_find_by_uuids_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_get_access_token_request.proto
+++ b/common/proto3/common/auth/user_get_access_token_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_get_recent_ep_reply.proto
+++ b/common/proto3/common/auth/user_get_recent_ep_reply.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_get_recent_ep_request.proto
+++ b/common/proto3/common/auth/user_get_recent_ep_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_list_all_request.proto
+++ b/common/proto3/common/auth/user_list_all_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_list_collab_request.proto
+++ b/common/proto3/common/auth/user_list_collab_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_set_access_token_request.proto
+++ b/common/proto3/common/auth/user_set_access_token_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/access_token_type.proto";
 

--- a/common/proto3/common/auth/user_set_recent_ep_request.proto
+++ b/common/proto3/common/auth/user_set_recent_ep_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_update_request.proto
+++ b/common/proto3/common/auth/user_update_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/auth/user_view_request.proto
+++ b/common/proto3/common/auth/user_view_request.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/access_token_type.proto
+++ b/common/proto3/common/enums/access_token_type.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/dependency_dir.proto
+++ b/common/proto3/common/enums/dependency_dir.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/dependency_type.proto
+++ b/common/proto3/common/enums/dependency_type.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/encryption.proto
+++ b/common/proto3/common/enums/encryption.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/error_code.proto
+++ b/common/proto3/common/enums/error_code.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/execution_method.proto
+++ b/common/proto3/common/enums/execution_method.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/note_state.proto
+++ b/common/proto3/common/enums/note_state.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/note_type.proto
+++ b/common/proto3/common/enums/note_type.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/project_role.proto
+++ b/common/proto3/common/enums/project_role.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/search_mode.proto
+++ b/common/proto3/common/enums/search_mode.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/service_status.proto
+++ b/common/proto3/common/enums/service_status.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/sort_option.proto
+++ b/common/proto3/common/enums/sort_option.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/task_command.proto
+++ b/common/proto3/common/enums/task_command.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/task_status.proto
+++ b/common/proto3/common/enums/task_status.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/enums/task_type.proto
+++ b/common/proto3/common/enums/task_type.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/envelope.proto
+++ b/common/proto3/common/envelope.proto
@@ -12,7 +12,7 @@
 
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/acl_rule.proto
+++ b/common/proto3/common/messages/acl_rule.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/alloc_data.proto
+++ b/common/proto3/common/messages/alloc_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_stats_data.proto";
 

--- a/common/proto3/common/messages/alloc_stats_data.proto
+++ b/common/proto3/common/messages/alloc_stats_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/coll_data.proto
+++ b/common/proto3/common/messages/coll_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/dependency_data.proto
+++ b/common/proto3/common/messages/dependency_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/dependency_type.proto";
 import "enums/dependency_dir.proto";

--- a/common/proto3/common/messages/dependency_spec_data.proto
+++ b/common/proto3/common/messages/dependency_spec_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/dependency_type.proto";
 

--- a/common/proto3/common/messages/group_data.proto
+++ b/common/proto3/common/messages/group_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/listing_data.proto
+++ b/common/proto3/common/messages/listing_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/dependency_data.proto";
 

--- a/common/proto3/common/messages/note_comment.proto
+++ b/common/proto3/common/messages/note_comment.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/note_type.proto";
 import "enums/note_state.proto";

--- a/common/proto3/common/messages/note_data.proto
+++ b/common/proto3/common/messages/note_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/note_type.proto";
 import "enums/note_state.proto";

--- a/common/proto3/common/messages/path_data.proto
+++ b/common/proto3/common/messages/path_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/listing_data.proto";
 

--- a/common/proto3/common/messages/project_data.proto
+++ b/common/proto3/common/messages/project_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_data.proto";
 

--- a/common/proto3/common/messages/record_data.proto
+++ b/common/proto3/common/messages/record_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/dependency_data.proto";
 

--- a/common/proto3/common/messages/record_data_location.proto
+++ b/common/proto3/common/messages/record_data_location.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/record_data_size.proto
+++ b/common/proto3/common/messages/record_data_size.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/repo_data.proto
+++ b/common/proto3/common/messages/repo_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/repo_record_data_locations.proto
+++ b/common/proto3/common/messages/repo_record_data_locations.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/record_data_location.proto";
 

--- a/common/proto3/common/messages/schema_data.proto
+++ b/common/proto3/common/messages/schema_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/tag_data.proto
+++ b/common/proto3/common/messages/tag_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/task_data.proto
+++ b/common/proto3/common/messages/task_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "enums/task_type.proto";
 import "enums/task_status.proto";

--- a/common/proto3/common/messages/topic_data.proto
+++ b/common/proto3/common/messages/topic_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 option cc_enable_arenas = true;
 

--- a/common/proto3/common/messages/user_data.proto
+++ b/common/proto3/common/messages/user_data.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package sdms;
+package SDMS;
 
 import "messages/alloc_data.proto";
 


### PR DESCRIPTION
## Ticket  

#1835  

## Description 

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Introduce a new proto3-based common protocol module and library for DataFed.

New Features:
- Add a proto3 common protocol directory structure with enums, messages, auth, anon, and envelope definition files.
- Add a CMake target to generate C++ code from proto3 files and build the datafed-protobuf library.