### PR TITLE
fix: version numbers from proto3 messages follow camel case.

### DIFF
--- a/web/datafed-ws.js
+++ b/web/datafed-ws.js
@@ -146,11 +146,15 @@ class Logger {
 
 const logger = new Logger(LogLevel.INFO);
 
-g_ver_release_year = version.DATAFED_RELEASE_YEAR;
-g_ver_release_month = version.DATAFED_RELEASE_MONTH;
-g_ver_release_day = version.DATAFED_RELEASE_DAY;
-g_ver_release_hour = version.DATAFED_RELEASE_HOUR;
-g_ver_release_minute = version.DATAFED_RELEASE_MINUTE;
+g_ver_release_year = version.RELEASE_YEAR;
+g_ver_release_month = version.RELEASE_MONTH;
+g_ver_release_day = version.RELEASE_DAY;
+g_ver_release_hour = version.RELEASE_HOUR;
+g_ver_release_minute = version.RELEASE_MINUTE;
+
+g_ver_api_major = version.MAJOR;
+g_ver_api_minor = version.MINOR;
+g_ver_api_patch = version.PATCH;
 
 g_version =
     g_ver_release_year +
@@ -212,46 +216,46 @@ function startServer() {
                 "ERROR: No reply from core server",
             );
         } else if (
-            reply.api_major != g_ver_api_major ||
-            reply.api_minor < g_ver_api_minor ||
-            reply.api_minor > g_ver_api_minor + 9
+            reply.apiMajor != g_ver_api_major ||
+            reply.apiMinor < g_ver_api_minor ||
+            reply.apiMinor > g_ver_api_minor + 9
         ) {
             logger.error(
                 startServer.name,
                 getCurrentLineNumber(),
                 "ERROR: Incompatible api version detected (" +
-                    reply.api_major +
+                    reply.apiMajor +
                     "." +
-                    reply.api_minor +
+                    reply.apiMinor +
                     "." +
-                    reply.api_patch +
+                    reply.apiPatch +
                     ")",
             );
         } else {
             var warning_msg =
                 "WARNING: A newer web server may be available the latest release version is: (" +
-                reply.release_year +
+                reply.releaseYear +
                 "." +
-                reply.release_month +
+                reply.releaseMonth +
                 "." +
-                reply.release_day +
+                reply.releaseDay +
                 "." +
-                reply.release_hour +
+                reply.releaseHour +
                 "." +
-                reply.release_minute;
-            if (reply.release_year > g_ver_release_year) {
+                reply.releaseMinute;
+            if (reply.releaseYear > g_ver_release_year) {
                 logger.warning(startServer.name, getCurrentLineNumber(), warning_msg);
-            } else if (reply.release_year == g_ver_release_year) {
-                if (reply.release_month > g_ver_release_month) {
+            } else if (reply.releaseYear == g_ver_release_year) {
+                if (reply.releaseMonth > g_ver_release_month) {
                     logger.warning(startServer.name, getCurrentLineNumber(), warning_msg);
-                } else if (reply.release_month == g_ver_release_month) {
-                    if (reply.release_day > g_ver_release_day) {
+                } else if (reply.releaseMonth == g_ver_release_month) {
+                    if (reply.releaseDay > g_ver_release_day) {
                         logger.warning(startServer.name, getCurrentLineNumber(), warning_msg);
-                    } else if (reply.release_day == g_ver_release_day) {
-                        if (reply.release_hour > g_ver_release_hour) {
+                    } else if (reply.releaseDay == g_ver_release_day) {
+                        if (reply.releaseHour > g_ver_release_hour) {
                             logger.warning(startServer.name, getCurrentLineNumber(), warning_msg);
-                        } else if (reply.release_hour == g_ver_release_hour) {
-                            if (reply.release_minute > g_ver_release_minute) {
+                        } else if (reply.releaseHour == g_ver_release_hour) {
+                            if (reply.releaseMinute > g_ver_release_minute) {
                                 logger.warning(
                                     startServer.name,
                                     getCurrentLineNumber(),


### PR DESCRIPTION
## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Align web server version handling with updated proto3-generated field names for API and release version checks.

Bug Fixes:
- Fix API version compatibility checks to use camelCase proto3 reply fields instead of legacy snake_case names.
- Update release version comparison logic to use new proto3-generated field names and generic version constants.