### PR TITLE
fix: mock_core server build

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,11 @@ if( ENABLE_INTEGRATION_TESTS )
     ${CMAKE_CURRENT_BINARY_DIR}/mock/mock_stop.sh
     COPYONLY)
 
+    configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/mock_core/Version.hpp.in"
+      "${CMAKE_CURRENT_SOURCE_DIR}/mock_core/Version.hpp"
+      @ONLY)
+
     add_test(NAME start_mock
       COMMAND ${CMAKE_CURRENT_BINARY_DIR}/mock/mock_start.sh
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/tests/mock_core

--- a/tests/mock_core/ClientWorker.cpp
+++ b/tests/mock_core/ClientWorker.cpp
@@ -326,9 +326,9 @@ ClientWorker::procVersionRequest(const std::string &a_uid,
   reply.set_api_minor(protocol::version::MINOR);
   reply.set_api_patch(protocol::version::PATCH);
 
-  reply.set_component_major(core::version::MAJOR);
-  reply.set_component_minor(core::version::MINOR);
-  reply.set_component_patch(core::version::PATCH);
+  reply.set_component_major(version::MAJOR);
+  reply.set_component_minor(version::MINOR);
+  reply.set_component_patch(version::PATCH);
 
   PROC_MSG_END(log_context);
 }

--- a/tests/mock_core/Version.hpp.in
+++ b/tests/mock_core/Version.hpp.in
@@ -1,0 +1,40 @@
+#ifndef MOCK_CORE_VERSION_HPP
+#define MOCK_CORE_VERSION_HPP
+#pragma once
+
+namespace SDMS {
+  namespace MockCore {
+    namespace version {
+      constexpr int MAJOR = @DATAFED_CORE_MAJOR@;
+      constexpr int MINOR = @DATAFED_CORE_MINOR@;
+      constexpr int PATCH = @DATAFED_CORE_PATCH@;
+    }
+  }
+
+  namespace foxx_api {
+    namespace version {
+      constexpr int MAJOR = @DATAFED_FOXX_API_MAJOR@;
+      constexpr int MINOR = @DATAFED_FOXX_API_MINOR@;
+      constexpr int PATCH = @DATAFED_FOXX_API_PATCH@;
+    }
+  }
+
+  namespace protocol {
+    namespace version {
+      constexpr int MAJOR = @DATAFED_COMMON_PROTOCOL_API_MAJOR@;
+      constexpr int MINOR = @DATAFED_COMMON_PROTOCOL_API_MINOR@;
+      constexpr int PATCH = @DATAFED_COMMON_PROTOCOL_API_PATCH@;
+    }
+  }
+
+  namespace release {
+    constexpr int YEAR = @DATAFED_RELEASE_YEAR@;
+    constexpr int MONTH = @DATAFED_RELEASE_MONTH@;
+    constexpr int DAY = @DATAFED_RELEASE_DAY@;
+    constexpr int HOUR = @DATAFED_RELEASE_HOUR@;
+    constexpr int MINUTE = @DATAFED_RELEASE_MINUTE@;
+  }
+}
+
+#endif // MOCK_CORE_VERSION_HPP
+


### PR DESCRIPTION
## Ticket  

<!--- Put ticket # if JIRA or name if Gitlab and link -->    

## Description 

<!--- Describe your changes in detail -->  

## How Has This Been Tested?  

<!--- Please describe in detail how you tested your changes. -->  

<!--- Include details of your testing environment, and the tests you ran to -->  

<!--- see how your change affects other areas of the code, etc. -->  

## Artifacts (if appropriate):  

<!--- Include videos and pictures that validate your work -->  

## Tasks

* [ ] - A description of the PR has been provided, and a diagram included if it is a new feature.
* [ ] - Formatter has been run
* [ ] - CHANGELOG comment has been added
* [ ] - Labels have been assigned to the pr
* [ ] - A reviwer has been added
* [ ] - A user has been assigned to work on the pr
* [ ] - If new feature a unit test has been added

## Summary by Sourcery

Fix mock_core test server version reporting and ensure its version header is generated during test builds.

Bug Fixes:
- Correct version namespace used for mock_core component version in the test client worker so the server reports the intended version values.

Build:
- Generate tests/mock_core/Version.hpp from Version.hpp.in via CMake during test configuration so the mock_core server can be built with the expected version header.

Tests:
- Adjust mock_core client worker in tests to use the mock_core version constants rather than the core library versions.