### PR TITLE
[DAPS-1896] feature foxx schema format

### DIFF
--- a/core/database/foxx/api/schema_router.js
+++ b/core/database/foxx/api/schema_router.js
@@ -160,8 +160,8 @@ router
                         format: req.body.format,
                         type: req.body.type,
                     };
-                    
-                    if (req.body.type === 'json-schema') {
+
+                    if (req.body.type === "json-schema") {
                         // Schema validator has already been run at this point; however, DataFed further restricts
                         // the allowed character set for keys and this must be applied at this point.
                         validateProperties(req.body.def.properties);
@@ -259,8 +259,8 @@ router
                 def: joi.object().required(),
                 pub: joi.boolean().optional().default(true),
                 sys: joi.boolean().optional().default(false),
-                format: joi.string().default("json").valid('json','xml','yaml'),
-                type: joi.string().default("json-schema").valid('json-schema','linkml'),
+                format: joi.string().default("json").valid("json", "xml", "yaml"),
+                type: joi.string().default("json-schema").valid("json-schema", "linkml"),
             })
             .required(),
         "Schema fields",
@@ -365,7 +365,7 @@ router
                     g_lib.procInputParam(req.body, "desc", true, obj);
 
                     if (req.body.def) {
-                        if (sch_old.type === 'json-schema') {
+                        if (sch_old.type === "json-schema") {
                             validateProperties(req.body.def.properties);
                             obj.def = req.body.def;
                         } else {
@@ -521,7 +521,7 @@ router
                     g_lib.procInputParam(req.body, "desc", true, sch);
 
                     if (req.body.def != undefined) {
-                        if (sch.type === 'json-schema') {
+                        if (sch.type === "json-schema") {
                             validateProperties(req.body.def.properties);
                             sch.def = req.body.def;
                         } else {
@@ -771,10 +771,10 @@ router
             sch.id = parsed.id + ":" + parsed.ver;
 
             // If schema is missing sch_format and sch_type default to json
-            if (!Object.hasOwn(sch, 'format')) {
+            if (!Object.hasOwn(sch, "format")) {
                 sch.format = "json";
             }
-            if (!Object.hasOwn(sch, 'type')) {
+            if (!Object.hasOwn(sch, "type")) {
                 sch.type = "json-schema";
             }
 
@@ -886,7 +886,6 @@ router
             } else {
                 if (req.queryParams.sort_rev) qry += " sort i.id desc, i.ver";
                 else qry += " sort i.id,i.ver";
-
             }
 
             qry +=
@@ -1050,7 +1049,7 @@ function updateSchemaRefs(a_sch) {
         r,
         refs = new Set();
 
-    if (a_sch.def && typeof a_sch.def === 'object') {
+    if (a_sch.def && typeof a_sch.def === "object") {
         gatherRefs(a_sch.def.properties, refs);
     }
 

--- a/core/database/foxx/tests/schema_router.test.js
+++ b/core/database/foxx/tests/schema_router.test.js
@@ -325,9 +325,7 @@ describe("schema router - type and format support", () => {
     });
 
     it("view: new schema with explicit type/format returns stored values", () => {
-        const response = request.get(
-            `${schema_base_url}/view?client=u/fakeUser&id=typed_linkml:0`,
-        );
+        const response = request.get(`${schema_base_url}/view?client=u/fakeUser&id=typed_linkml:0`);
 
         expect(response.status).to.equal(200);
         const schema = JSON.parse(response.body)[0];
@@ -415,7 +413,9 @@ describe("schema router - type and format support", () => {
     });
 
     it("update: legacy schema without type treats as json-schema", () => {
-        const newDef = { properties: { old_field: { type: "string" }, new_field: { type: "boolean" } } };
+        const newDef = {
+            properties: { old_field: { type: "string" }, new_field: { type: "boolean" } },
+        };
 
         const response = request.post(
             `${schema_base_url}/update?client=u/fakeUser&id=legacy_schema_1:0`,


### PR DESCRIPTION
## Description

## Summary by Sourcery

Add support for schema type/format metadata and legacy defaults across schema CRUD and search APIs.

New Features:
- Support specifying and persisting schema type (json-schema or linkml) and format (json, xml, yaml) on schema creation, update, revision, view, and search responses.

Bug Fixes:
- Default missing type/format fields for legacy schemas when viewing or searching schemas to ensure consistent API responses.
- Prevent schema reference gathering from failing when schema definitions are absent or non-object for non-json-schema types.

Enhancements:
- Ensure non-json-schema types ignore and clear stored schema definitions while still persisting type/format metadata.
- Extend logging context to include schema type and format in relevant API operations.

Tests:
- Add comprehensive tests covering type/format behavior for create, view, search, update, and revise operations, including legacy and invalid input scenarios.