### PR TITLE
[DAPS-1910] - upgrade: tests playwright 1.51.1 version.

### DIFF
--- a/tests/end-to-end/web-UI/package-lock.json
+++ b/tests/end-to-end/web-UI/package-lock.json
@@ -10,20 +10,20 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "playwright": "^1.45.1"
+        "playwright": "^1.51.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.45.1",
+        "@playwright/test": "^1.51.1",
         "@types/node": "^20.14.10"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
       "integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.45.1"
+        "playwright": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -66,11 +66,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
       "integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
       "dependencies": {
-        "playwright-core": "1.45.1"
+        "playwright-core": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -83,8 +83,8 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
       "integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
       "bin": {
         "playwright-core": "cli.js"

--- a/tests/end-to-end/web-UI/package.json
+++ b/tests/end-to-end/web-UI/package.json
@@ -8,11 +8,11 @@
   "license": "ISC",
   "description": "",
   "devDependencies": {
-    "@playwright/test": "^1.45.1",
+    "@playwright/test": "^1.51.1",
     "@types/node": "^20.14.10"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "playwright": "^1.45.1"
+    "playwright": "^1.51.1"
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Upgrade Playwright tooling versions used by the web UI end-to-end test suite.

Build:
- Bump Playwright and @playwright/test versions in the web-UI end-to-end test package configuration.

Tests:
- Align end-to-end web-UI test dependencies with the newer Playwright release via package and lockfile updates.