### PR TITLE
[DAPS-1914] - bug web schema id name version mismatch

### DIFF
--- a/web/static/dlg_schema.js
+++ b/web/static/dlg_schema.js
@@ -13,13 +13,13 @@ const btn_title = ["Close", "Save", "Create", "Create"];
 
 /** Strip version suffix from a composite schema ID (e.g. "foo:0" -> "foo") */
 function schemaName(id) {
-    var idx = id.indexOf(':');
+    var idx = id.indexOf(":");
     return idx !== -1 ? id.substring(0, idx) : id;
 }
 
 /** Ensure a schema ID has the :version suffix */
 function schemaId(id, ver) {
-    return id.indexOf(':') !== -1 ? id : id + ":" + ver;
+    return id.indexOf(":") !== -1 ? id : id + ":" + ver;
 }
 
 export function show(a_mode, a_schema, a_cb) {

--- a/web/static/dlg_schema_list.js
+++ b/web/static/dlg_schema_list.js
@@ -10,13 +10,13 @@ var tree, dlg_inst, frame;
 
 /** Strip version suffix from a composite schema ID (e.g. "foo:0" -> "foo") */
 function schemaName(id) {
-    var idx = id.indexOf(':');
+    var idx = id.indexOf(":");
     return idx !== -1 ? id.substring(0, idx) : id;
 }
 
 /** Ensure a schema ID has the :version suffix */
 function schemaId(id, ver) {
-    return id.indexOf(':') !== -1 ? id : id + ":" + ver;
+    return id.indexOf(":") !== -1 ? id : id + ":" + ver;
 }
 
 window.schemaPageLoad = function (key, offset) {


### PR DESCRIPTION
## Summary by Sourcery

Normalize handling of schema IDs and versions in the web UI to avoid mismatches between schema names and versioned IDs.

Bug Fixes:
- Fix schema view, edit, revision, and delete actions using inconsistent schema IDs when the ID already contains a version suffix.
- Prevent dialog IDs and tree keys from including duplicated version components when schema IDs are composite (id:version).

Enhancements:
- Introduce helper functions to consistently derive schema names and normalized versioned IDs across schema list and dialog components.
- Display schema IDs in the UI using the base name plus version while keeping internal IDs normalized.